### PR TITLE
UI updates: loading animation, security fixes, README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ dist-ssr
 scripts/fix-caches.sh
 scripts/seed-demo-resumable.sh
 
+# Claude Code session/memory
+.claude/
+
 # Supabase local CLI state
 supabase/.temp/
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ dist-ssr
 .env
 .env.*
 
+# Scripts with DB credentials
+scripts/fix-caches.sh
+scripts/seed-demo-resumable.sh
+
 # Supabase local CLI state
 supabase/.temp/
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,73 +1,53 @@
-# Welcome to your Lovable project
+# MusicNerd TV
 
-## Project info
+A music discovery app that surfaces AI-generated insights ("nuggets") while you listen. Connect Spotify, play a track, and learn fascinating facts about the artist, song, and album — displayed in a cinematic TV-style interface.
 
-**URL**: https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID
+## Features
 
-## How can I edit this code?
+- **Spotify Playback** — Stream tracks directly via Spotify Web Playback SDK
+- **AI Nuggets** — Real-time AI-generated facts and insights powered by Gemini, enriched with Exa web research
+- **Companion Page** — QR code on screen opens a mobile companion with categorized deep-dive content
+- **Personalized Browse** — Home page rows built from your Spotify listening history
+- **Tiered Experience** — Casual, Curious, and Nerd tiers adjust the depth of insights
+- **Artist Profiles** — Explore artist pages with top tracks and related artists
 
-There are several ways of editing your application.
+## Tech Stack
 
-**Use Lovable**
+- **Frontend**: React + Vite + TypeScript, Tailwind CSS, Framer Motion
+- **Backend**: Supabase (database, edge functions, auth)
+- **AI**: Google Gemini (nugget generation), Exa (web research)
+- **Playback**: Spotify Web Playback SDK, YouTube IFrame API (backdrop)
+- **Deploy**: Vercel (frontend), Supabase (edge functions)
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID) and start prompting.
+## Local Development
 
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
+Requires Node.js & npm — [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
 ```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
+git clone https://github.com/xdjs/MNTv.git
+cd MNTv
+npm install
 npm run dev
 ```
 
-**Edit a file directly in GitHub**
+Create a `.env` file with:
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+```
+VITE_SUPABASE_PROJECT_ID=your_project_id
+VITE_SUPABASE_PUBLISHABLE_KEY=your_anon_key
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SPOTIFY_CLIENT_ID=your_spotify_client_id
+```
 
-**Use GitHub Codespaces**
+## Architecture
 
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
-
-## What technologies are used for this project?
-
-This project is built with:
-
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/features/custom-domain#custom-domain)
+```
+src/
+  pages/         — Route pages (Browse, Listen, Connect, Companion)
+  components/    — Reusable UI components
+  hooks/         — Custom React hooks (AI nuggets, Spotify auth, etc.)
+  contexts/      — Global state (PlayerContext)
+  data/          — Seed data for demo tracks
+supabase/
+  functions/     — Edge functions (generate-nuggets, generate-companion, etc.)
+```

--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -1,0 +1,352 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import MusicNerdLogo from "@/components/MusicNerdLogo";
+
+type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready";
+
+interface Props {
+  aiLoading: boolean;
+  shortId: string | null;
+  trackId: string;
+  tier: string;
+  listenCount: number;
+  focusZone: string;
+  topFocusIndex: number;
+  onCompanionClick: () => void;
+}
+
+/** Animated dots for "researching..." text */
+function AnimatedDots() {
+  const [dotCount, setDotCount] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setDotCount((c) => (c + 1) % 4), 500);
+    return () => clearInterval(interval);
+  }, []);
+  return <span className="inline-block w-4 text-left">{".".repeat(dotCount)}</span>;
+}
+
+/** Settle delay before pill appears (ms) */
+const SETTLE_MS = 500;
+/** How long the pill is visible before morphing (ms) */
+const PILL_DISPLAY_MS = 3000;
+/** Duration of the morph-fly animation (s) */
+const MORPH_FLY_S = 0.7;
+
+/**
+ * Module-level cache so that when the user navigates away (Browse) and comes
+ * back to the same track, we restore the phase instead of restarting the
+ * animation from scratch.
+ */
+const phaseCache = new Map<string, AnimPhase>();
+
+export default function MusicNerdLoadingOrchestrator({
+  aiLoading,
+  shortId,
+  trackId,
+  tier,
+  listenCount,
+  focusZone,
+  topFocusIndex,
+  onCompanionClick,
+}: Props) {
+  // Restore cached phase for this track, or start hidden
+  const initialPhase = (): AnimPhase => {
+    const cached = phaseCache.get(trackId);
+    // If we already reached pulsating/ready/morphFly for this track, restore
+    // (morphFly → skip to pulsating/ready since we can't resume mid-flight)
+    if (cached === "ready") return "ready";
+    if (cached === "pulsating") return aiLoading ? "pulsating" : "ready";
+    if (cached === "morphFly") return aiLoading ? "pulsating" : "ready";
+    if (cached === "pill") return aiLoading ? "pill" : "ready";
+    return "hidden";
+  };
+
+  const [phase, setPhase] = useState<AnimPhase>(initialPhase);
+  const phaseRef = useRef(phase);
+  const trackRef = useRef(trackId);
+  const aiLoadingRef = useRef(aiLoading);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const pillRef = useRef<HTMLDivElement>(null);
+  const [flyCoords, setFlyCoords] = useState<{ x: number; y: number; startX: number; startY: number } | null>(null);
+  // Track whether this is the initial mount (skip burst animation on remount)
+  const isRestoredRef = useRef(initialPhase() !== "hidden");
+
+  // Keep refs in sync
+  aiLoadingRef.current = aiLoading;
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  }, []);
+
+  const addTimer = useCallback((fn: () => void, ms: number) => {
+    const id = setTimeout(fn, ms);
+    timersRef.current.push(id);
+    return id;
+  }, []);
+
+  const setPhaseAndRef = useCallback((p: AnimPhase) => {
+    phaseRef.current = p;
+    setPhase(p);
+  }, []);
+
+  // Persist phase to module cache on every change
+  useEffect(() => {
+    phaseCache.set(trackId, phase);
+    phaseRef.current = phase;
+  }, [phase, trackId]);
+
+  // ── Track change → reset ──
+  useEffect(() => {
+    if (trackRef.current !== trackId) {
+      trackRef.current = trackId;
+      clearTimers();
+      setFlyCoords(null);
+      isRestoredRef.current = false;
+      // Check cache for new track
+      const cached = phaseCache.get(trackId);
+      if (cached && cached !== "hidden") {
+        const restored = cached === "ready" ? "ready"
+          : cached === "pulsating" ? (aiLoadingRef.current ? "pulsating" : "ready")
+          : cached === "morphFly" ? (aiLoadingRef.current ? "pulsating" : "ready")
+          : cached === "pill" ? (aiLoadingRef.current ? "pill" : "ready")
+          : "hidden";
+        isRestoredRef.current = restored !== "hidden";
+        setPhaseAndRef(restored);
+      } else {
+        setPhaseAndRef("hidden");
+      }
+    }
+  }, [trackId, clearTimers, setPhaseAndRef]);
+
+  // ── State machine driver ──
+  useEffect(() => {
+    // Only drive from hidden — skip if restored to a later phase
+    if (phase !== "hidden") return;
+
+    // Cache hit: aiLoading is already false → go straight to ready
+    if (!aiLoading) {
+      setPhaseAndRef("ready");
+      return;
+    }
+
+    // Start settle timer
+    addTimer(() => {
+      if (trackRef.current !== trackId) return;
+      // Guard: only advance if still hidden (could have been changed by cache-hit path)
+      if (phaseRef.current !== "hidden") return;
+      setPhaseAndRef("pill");
+    }, SETTLE_MS);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiLoading, trackId, phase]);
+
+  // ── Pill timer → morph (only if still loading) ──
+  useEffect(() => {
+    if (phase !== "pill") return;
+    addTimer(() => {
+      if (trackRef.current !== trackId) return;
+      if (phaseRef.current !== "pill") return;
+      startMorphFly();
+    }, PILL_DISPLAY_MS);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, trackId]);
+
+  // ── aiLoading goes false during pill → skip ahead ──
+  useEffect(() => {
+    if (!aiLoading && phase === "pill") {
+      clearTimers();
+      startMorphFly();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiLoading, phase]);
+
+  // ── aiLoading goes false during pulsating → ready ──
+  useEffect(() => {
+    if (!aiLoading && phase === "pulsating") {
+      setPhaseAndRef("ready");
+    }
+  }, [aiLoading, phase, setPhaseAndRef]);
+
+  // ── Cleanup on unmount ──
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  function startMorphFly() {
+    const pillEl = pillRef.current;
+    const anchorEl = anchorRef.current;
+    if (pillEl && anchorEl) {
+      const pillRect = pillEl.getBoundingClientRect();
+      const anchorRect = anchorEl.getBoundingClientRect();
+      setFlyCoords({
+        startX: pillRect.left + pillRect.width / 2,
+        startY: pillRect.top + pillRect.height / 2,
+        x: anchorRect.left + anchorRect.width / 2,
+        y: anchorRect.top + anchorRect.height / 2,
+      });
+    }
+    setPhaseAndRef("morphFly");
+  }
+
+  function onMorphComplete() {
+    setFlyCoords(null);
+    // Use ref for latest aiLoading value (closure may be stale)
+    if (aiLoadingRef.current) {
+      setPhaseAndRef("pulsating");
+    } else {
+      setPhaseAndRef("ready");
+    }
+  }
+
+  const isFocused = focusZone === "top" && topFocusIndex === 1;
+  // Don't play burst/spin on restored remount (navigating back to same song)
+  const skipEntrance = isRestoredRef.current;
+
+  return (
+    <>
+      {/* Anchor div in top-right for morph target + final logo */}
+      <div ref={anchorRef} className="flex flex-col items-center gap-1.5">
+        {/* Final logo button — visible in pulsating + ready phases */}
+        {(phase === "pulsating" || phase === "ready") && (
+          <motion.button
+            onClick={onCompanionClick}
+            disabled={phase !== "ready" || !shortId}
+            className={`relative transition-all duration-300 outline-none rounded-full ${
+              isFocused ? "tv-focus-glow scale-110" : ""
+            }`}
+            aria-label="Open companion page"
+            initial={skipEntrance ? { opacity: 1, scale: 1 } : { opacity: 0.8, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: skipEntrance ? 0 : 0.3, ease: "easeOut" }}
+          >
+            {/* Burst ring on ready (skip on restored remount) */}
+            {phase === "ready" && !skipEntrance && (
+              <motion.div
+                className="absolute inset-0 rounded-full pointer-events-none"
+                style={{
+                  border: "2px solid hsl(var(--neon-glow) / 0.6)",
+                }}
+                initial={{ scale: 1, opacity: 0.8 }}
+                animate={{ scale: 3, opacity: 0 }}
+                transition={{ duration: 0.6, ease: "easeOut" }}
+              />
+            )}
+            <motion.div
+              animate={
+                phase === "pulsating"
+                  ? { scale: [1, 1.08, 1], opacity: [0.6, 0.8, 0.6] }
+                  : { scale: 1, opacity: 1 }
+              }
+              transition={
+                phase === "pulsating"
+                  ? { duration: 1.8, repeat: Infinity, ease: "easeInOut" }
+                  : { duration: 0.3 }
+              }
+              style={{
+                filter:
+                  phase === "pulsating"
+                    ? "grayscale(0.4) opacity(0.7)"
+                    : "drop-shadow(0 0 8px hsl(var(--neon-glow) / 0.7)) drop-shadow(0 0 24px hsl(var(--neon-glow) / 0.35))",
+                transition: "filter 0.4s ease",
+              }}
+            >
+              {phase === "ready" && !skipEntrance ? (
+                <motion.div
+                  initial={{ rotate: 0 }}
+                  animate={{ rotate: 360 }}
+                  transition={{ duration: 0.6, ease: "easeOut" }}
+                >
+                  <MusicNerdLogo size={40} glow={false} />
+                </motion.div>
+              ) : (
+                <MusicNerdLogo size={40} glow={false} />
+              )}
+            </motion.div>
+          </motion.button>
+        )}
+
+        {/* Invisible placeholder to keep layout when logo not yet shown */}
+        {phase !== "pulsating" && phase !== "ready" && (
+          <div className="w-10 h-10 opacity-0 pointer-events-none" aria-hidden />
+        )}
+      </div>
+
+      {/* ── Glass pill (centered below album art) ── */}
+      <AnimatePresence>
+        {phase === "pill" && (
+          <motion.div
+            ref={pillRef}
+            className="fixed left-1/2 z-50 apple-glass rounded-full px-4 py-2.5 flex items-center gap-2.5 pointer-events-none"
+            style={{
+              top: "calc(50% + 216px)",
+              translateX: "-50%",
+            }}
+            initial={{ opacity: 0, scale: 0.8, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.85, transition: { duration: 0.15 } }}
+            transition={{ duration: 0.5, ease: [0.4, 0, 0.2, 1] }}
+          >
+            <MusicNerdLogo size={18} glow={false} />
+            <span className="text-sm font-medium text-foreground/70 whitespace-nowrap select-none">
+              MusicNerd is researching
+              <AnimatedDots />
+            </span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* ── Morph fly element ── */}
+      <AnimatePresence>
+        {phase === "morphFly" && flyCoords && (
+          <motion.div
+            className="fixed z-50 pointer-events-none flex items-center justify-center apple-glass"
+            style={{
+              left: flyCoords.startX,
+              top: flyCoords.startY,
+              translateX: "-50%",
+              translateY: "-50%",
+            }}
+            initial={{
+              width: 260,
+              height: 44,
+              borderRadius: 22,
+              x: 0,
+              y: 0,
+              opacity: 1,
+            }}
+            animate={{
+              width: 48,
+              height: 48,
+              borderRadius: 24,
+              x: flyCoords.x - flyCoords.startX,
+              y: flyCoords.y - flyCoords.startY,
+              opacity: 1,
+            }}
+            transition={{
+              duration: MORPH_FLY_S,
+              ease: [0.4, 0, 0.2, 1],
+            }}
+            onAnimationComplete={onMorphComplete}
+          >
+            {/* Text fades quickly */}
+            <motion.span
+              className="absolute text-sm font-medium text-foreground/70 whitespace-nowrap ml-7"
+              initial={{ opacity: 1 }}
+              animate={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+            >
+              MusicNerd is researching...
+            </motion.span>
+            {/* Logo scales up */}
+            <motion.div
+              initial={{ scale: 0.45 }}
+              animate={{ scale: 1 }}
+              transition={{ duration: MORPH_FLY_S, ease: "easeInOut" }}
+            >
+              <MusicNerdLogo size={32} glow={false} />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -7,6 +7,7 @@ import { QRCode } from "react-qrcode-logo";
 import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
+import MusicNerdLoadingOrchestrator from "@/components/MusicNerdLoadingOrchestrator";
 import NuggetCard from "@/components/NuggetCard";
 const MediaOverlay = lazy(() => import("@/components/overlays/MediaOverlay"));
 const ReadingOverlay = lazy(() => import("@/components/overlays/ReadingOverlay"));
@@ -1034,26 +1035,20 @@ export default function Listen() {
             </motion.p>
           )}
           <div className="flex flex-col items-center gap-1.5">
-            <button
-              onClick={() => {
+            <MusicNerdLoadingOrchestrator
+              aiLoading={aiLoading}
+              shortId={shortId}
+              trackId={trackId}
+              tier={tier}
+              listenCount={listenCount}
+              focusZone={focusZone}
+              topFocusIndex={topFocusIndex}
+              onCompanionClick={() => {
                 if (shortId) {
                   window.open(`${window.location.origin}/c/${shortId}?tier=${tier}&listen=${listenCount}`, "_blank");
                 }
               }}
-              disabled={!shortId}
-              className={`transition-all duration-300 outline-none rounded-full ${
-                focusZone === 'top' && topFocusIndex === 1 ? "tv-focus-glow scale-110" : ""
-              }`}
-              aria-label="Open companion page"
-              style={{
-                filter: shortId
-                  ? "drop-shadow(0 0 8px hsl(var(--neon-glow) / 0.7)) drop-shadow(0 0 24px hsl(var(--neon-glow) / 0.35))"
-                  : "grayscale(1) opacity(0.4)",
-                transition: "filter 0.4s ease",
-              }}
-            >
-              <MusicNerdLogo size={40} glow={false} />
-            </button>
+            />
             <button
               onClick={() => setDevOpen((o) => !o)}
               className="rounded-md bg-foreground/5 px-2.5 py-0.5 text-[10px] text-muted-foreground/50 hover:bg-foreground/10 hover:text-muted-foreground transition-colors"


### PR DESCRIPTION
## Summary
- **Cinematic loading animation**: Glass pill appears below album art ("MusicNerd is researching..."), morphs and flies to top-right logo, pulsates while AI loads, bursts with neon glow when ready
- **Security**: Removed exposed secrets from git history, added `.claude/` and DB scripts to `.gitignore`
- **README**: Replaced Lovable boilerplate with MusicNerd TV project documentation

## Test plan
- [ ] Play a non-cached track — verify pill → morph → pulsate → ready sequence
- [ ] Play a cached/seed track — logo appears directly with glow (no pill)
- [ ] Switch tracks mid-animation — resets cleanly
- [ ] Navigate to Browse and back to same track — animation state preserved
- [ ] Mobile viewport — pill centered properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)