### PR TITLE
ci: add Claude Code PR review workflow with @mention trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,49 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
- Adds Claude Code PR review workflow that triggers on PR open/sync and @claude mentions in PR comments
- Includes `issue_comment` trigger with condition to only fire on `@claude` mentions
- Uses `anthropics/claude-code-action@v1` with scoped tool permissions

## Context
The workflow file existed on `staging` but was never on `main`, so it never triggered. This PR adds it directly to `main` via cherry-pick.

## Test plan
- [ ] Verify workflow appears in Actions tab after merge
- [ ] Open a test PR and confirm the workflow triggers
- [ ] Comment `@claude` on a PR and confirm the workflow triggers
- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` secret is configured in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)