### PR TITLE
fix: scroll overlay, instant SSE nuggets, empty headline guard

### DIFF
--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -6,6 +6,7 @@ type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready";
 
 interface Props {
   aiLoading: boolean;
+  hasNuggets?: boolean;
   shortId: string | null;
   trackId: string;
   tier: string;
@@ -52,6 +53,7 @@ function setPhaseCached(key: string, value: AnimPhase) {
 
 export default function MusicNerdLoadingOrchestrator({
   aiLoading,
+  hasNuggets = false,
   shortId,
   trackId,
   tier,
@@ -152,25 +154,16 @@ export default function MusicNerdLoadingOrchestrator({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiLoading, trackId, phase]);
 
-  // ── Pill timer → morph (only if still loading) ──
+  // ── Pill stays visible until nuggets arrive OR loading finishes ──
+  // No timed morph — the pill persists as long as the user has nothing to see.
   useEffect(() => {
     if (phase !== "pill") return;
-    addTimer(() => {
-      if (trackRef.current !== trackId) return;
-      if (phaseRef.current !== "pill") return;
-      startMorphFly();
-    }, PILL_DISPLAY_MS);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase, trackId]);
-
-  // ── aiLoading goes false during pill → skip ahead ──
-  useEffect(() => {
-    if (!aiLoading && phase === "pill") {
+    if (hasNuggets || !aiLoading) {
       clearTimers();
       startMorphFly();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aiLoading, phase]);
+  }, [phase, hasNuggets, aiLoading]);
 
   // ── aiLoading goes false during pulsating → ready ──
   useEffect(() => {

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -265,14 +265,15 @@ export default function ImmersiveNuggetView({
             <span className="text-[10px] uppercase tracking-[0.2em] text-white/60 mb-2 block" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.8)" }}>
               {activeNugget ? (KIND_LABELS[activeNugget.kind] || activeNugget.kind) : ""}
             </span>
-            {activeNugget && (
-              isTypewriterDone ? (
+            {activeNugget && (() => {
+              const headlineText = activeNugget.headline || activeNugget.text || "Did you know?";
+              return isTypewriterDone ? (
                 <h2 className="text-xl font-bold leading-tight text-white" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}>
-                  {activeNugget.headline || activeNugget.text}
+                  {headlineText}
                 </h2>
               ) : (
                 <TypewriterText
-                  text={activeNugget.headline || activeNugget.text}
+                  text={headlineText}
                   speed={35}
                   paused={false}
                   onComplete={handleTypewriterComplete}
@@ -280,8 +281,8 @@ export default function ImmersiveNuggetView({
                   className="text-xl font-bold leading-tight text-white"
                   style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}
                 />
-              )
-            )}
+              );
+            })()}
           </div>
         </div>
 

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -265,15 +265,14 @@ export default function ImmersiveNuggetView({
             <span className="text-[10px] uppercase tracking-[0.2em] text-white/60 mb-2 block" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.8)" }}>
               {activeNugget ? (KIND_LABELS[activeNugget.kind] || activeNugget.kind) : ""}
             </span>
-            {activeNugget && (() => {
-              const headlineText = activeNugget.headline || activeNugget.text || "Did you know?";
-              return isTypewriterDone ? (
+            {activeNugget && (
+              isTypewriterDone ? (
                 <h2 className="text-xl font-bold leading-tight text-white" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}>
-                  {headlineText}
+                  {activeNugget.headline || activeNugget.text}
                 </h2>
               ) : (
                 <TypewriterText
-                  text={headlineText}
+                  text={activeNugget.headline || activeNugget.text}
                   speed={35}
                   paused={false}
                   onComplete={handleTypewriterComplete}
@@ -281,8 +280,8 @@ export default function ImmersiveNuggetView({
                   className="text-xl font-bold leading-tight text-white"
                   style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}
                 />
-              );
-            })()}
+              )
+            )}
           </div>
         </div>
 

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -243,7 +243,9 @@ export default function ImmersiveNuggetView({
     const { url: imgUrl, isNuggetImage } = getNuggetImage();
     return (
       <div className="w-full h-full overflow-y-auto glass-scrollbar">
-        <div className="relative w-full bg-black" style={{ minHeight: "100%" }}>
+        {/* Sticky image hero — stays pinned while body text scrolls over it.
+            Prevents the gap/overlay break when scrolling up. */}
+        <div className="sticky top-0 w-full h-full">
           {imgUrl && (
             <img
               src={imgUrl}
@@ -283,8 +285,10 @@ export default function ImmersiveNuggetView({
           </div>
         </div>
 
-        <div className="px-5 pb-5 -mt-32 relative z-10 pt-36" style={{
-          background: "linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 20%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 60%, rgb(0,0,0) 100%)",
+        {/* Body scrolls over the sticky image. Solid black bg-black ensures
+            no gap is visible when scrolling past the gradient overlap zone. */}
+        <div className="px-5 pb-5 -mt-32 relative z-10 pt-36 bg-black" style={{
+          backgroundImage: "linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 20%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 60%, rgb(0,0,0) 100%)",
         }}>
           <p className="text-sm leading-relaxed text-white/60 mb-4">
             {activeNugget?.text}

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -382,7 +382,9 @@ export function useAINuggets(
       // 60s timeout: if the edge function stalls mid-stream (never sends
       // done, never closes), the fetch aborts cleanly. User track-skips
       // also abort via abortRef.current.abort() in the effect cleanup.
-      const timeoutId = setTimeout(() => abortRef.current?.abort(), 60_000);
+      // 120s timeout — matches Supabase edge function limit (150s) with
+      // margin. Lesser-known artists need longer for Exa research + Gemini.
+      const timeoutId = setTimeout(() => abortRef.current?.abort(), 120_000);
 
       const response = await fetch(`${SUPABASE_URL}/functions/v1/generate-nuggets`, {
         method: "POST",

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1085,15 +1085,23 @@ export default function Listen() {
     });
   }, [seek, trackNuggets]);
 
-  // Nugget trigger logic — fires on playback tick
+  // Nugget trigger logic — fires on playback tick or when new nuggets arrive.
+  // For fresh SSE generation (!aiFromCache), nuggets show immediately as they
+  // stream in. For cached tracks, they show at their timestamp markers.
   useEffect(() => {
-    if (!isPlaying || !nerdActive) return;
+    if (!nerdActive) return;
+    // Cached tracks: require playback to reach the timestamp
+    // Fresh generation: show as soon as the nugget arrives from SSE
+    const shouldTrigger = (n: typeof trackNuggets[0]) =>
+      !aiFromCache || currentTime >= n.timestampSec;
+
+    if (!isPlaying && aiFromCache) return; // cached: wait for playback
+
     for (const n of trackNuggets) {
       if (shownNuggetIds.has(n.id)) continue;
-      if (currentTime >= n.timestampSec) {
+      if (shouldTrigger(n)) {
         if (activeNugget) {
           if (reopenedNuggetId) {
-            // Immediately swap: dismiss reopened nugget, show new one
             setDismissedNuggets((prev) => new Map(prev).set(activeNugget.id, activeNugget));
             setActiveNugget(n);
             setReopenedNuggetId(null);
@@ -1108,7 +1116,7 @@ export default function Listen() {
         }
       }
     }
-  }, [currentTime, isPlaying, nerdActive, trackNuggets, activeNugget, shownNuggetIds, reopenedNuggetId]);
+  }, [currentTime, isPlaying, nerdActive, trackNuggets, activeNugget, shownNuggetIds, reopenedNuggetId, aiFromCache]);
 
   // Auto-dismiss nugget: quick swap if queued, otherwise fade after 8s
   useEffect(() => {
@@ -1254,6 +1262,7 @@ export default function Listen() {
           {!isMobile && <div className="flex flex-col items-center gap-1.5">
             <MusicNerdLoadingOrchestrator
               aiLoading={aiLoading}
+              hasNuggets={trackNuggets.length > 0}
               shortId={shortId}
               trackId={trackId}
               tier={tier}
@@ -1638,6 +1647,7 @@ export default function Listen() {
         <div className="fixed top-3 right-3 z-[60]" style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}>
           <MusicNerdLoadingOrchestrator
             aiLoading={aiLoading}
+            hasNuggets={trackNuggets.length > 0}
             shortId={shortId}
             trackId={trackId}
             tier={tier}

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1308,6 +1308,19 @@ function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { vali
   let hallucinatedSourceCount = 0;
   for (let i = 0; i < nuggets.length; i++) {
     const n = nuggets[i];
+    // Empty headline — generate one from the first sentence of text
+    if (!n.headline?.trim() && n.text?.trim()) {
+      const firstSentence = n.text.split(/[.!?]/)[0]?.trim();
+      if (firstSentence && firstSentence.length > 10) {
+        n.headline = firstSentence.length > 80
+          ? firstSentence.slice(0, 77) + "..."
+          : firstSentence;
+        console.log(`[Validator] Generated headline for nugget ${i} from text: "${n.headline}"`);
+      }
+    }
+    if (!n.headline?.trim()) {
+      issues.push(`Nugget ${i} (${n.kind}): empty headline`);
+    }
     const allText = `${n.headline} ${n.text}`.toLowerCase();
     for (const banned of BANNED_PHRASES) {
       if (allText.includes(banned.toLowerCase())) {
@@ -2714,9 +2727,18 @@ Return ONLY valid JSON:
 
     function assembleNugget(n: any, i: number) {
       const source = n.source || {};
+      let headline = stripCitMarkers(n.headline || "");
+      const text = stripCitMarkers(n.text || "");
+      // Last-resort headline: first sentence of the body text
+      if (!headline && text) {
+        const first = text.split(/[.!?]/)[0]?.trim();
+        headline = first && first.length > 10
+          ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
+          : text.slice(0, 80);
+      }
       const result: any = {
-        headline: stripCitMarkers(n.headline || ""),
-        text: stripCitMarkers(n.text || ""),
+        headline,
+        text,
         kind: n.kind,
         listenFor: n.listenFor,
         source: {


### PR DESCRIPTION
## Summary
- Sticky image hero prevents scroll overlay gap on mobile
- Research pill stays visible until first nugget arrives
- SSE nuggets show immediately as they stream in (not at timestamp markers)
- Edge function: generate headline from text if Gemini returns empty
- SSE timeout increased to 120s for lesser-known artists

## Test plan
- [x] Build passes, 41 tests pass
- [ ] Scroll up on a nugget — no gap/overlay break
- [ ] Research pill visible until first nugget appears
- [ ] Nuggets appear as soon as they stream in