### PR TITLE
Release: scroll overlay fix, instant SSE nuggets, headline guard

### DIFF
--- a/src/components/DevPanel.tsx
+++ b/src/components/DevPanel.tsx
@@ -12,14 +12,14 @@ interface Props {
   onResetHistory?: () => void;
   onResetAllHistory?: () => void;
   onIncrementListen?: () => void;
-  activePlayer?: "spotify" | "none" | null;
-  spotifyUri?: string | null;
+  activePlayer?: "spotify" | "apple-music" | "none" | null;
+  trackUri?: string | null;
   currentTier?: "casual" | "curious" | "nerd";
   onTierChange?: (tier: "casual" | "curious" | "nerd") => void;
   onClose?: () => void;
 }
 
-export default function DevPanel({ animStyle, setAnimStyle, onJumpToNugget, nuggetCount, listenCount, trackKey, onResetHistory, onResetAllHistory, onIncrementListen, activePlayer, spotifyUri, currentTier, onTierChange, onClose }: Props) {
+export default function DevPanel({ animStyle, setAnimStyle, onJumpToNugget, nuggetCount, listenCount, trackKey, onResetHistory, onResetAllHistory, onIncrementListen, activePlayer, trackUri, currentTier, onTierChange, onClose }: Props) {
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -140,8 +140,8 @@ export default function DevPanel({ animStyle, setAnimStyle, onJumpToNugget, nugg
       {/* Playback source info */}
       <div>
         <p className="text-xs text-muted-foreground mb-1">Player: <span className="font-semibold text-foreground">{activePlayer || "None"}</span></p>
-        {spotifyUri && (
-          <p className="text-[10px] text-muted-foreground truncate" title={spotifyUri}>SP: {spotifyUri}</p>
+        {trackUri && (
+          <p className="text-[10px] text-muted-foreground truncate" title={trackUri}>URI: {trackUri}</p>
         )}
       </div>
     </motion.div>

--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -176,7 +176,7 @@ export default function MusicNerdLoadingOrchestrator({
 
   // ── Research failed → show error state, auto-dismiss after 4s ──
   useEffect(() => {
-    if (aiError && (phase === "pill" || phase === "pulsating" || phase === "hidden")) {
+    if (aiError && phase !== "ready" && phase !== "failed") {
       clearTimers();
       setPhaseAndRef("failed");
     }
@@ -293,7 +293,9 @@ export default function MusicNerdLoadingOrchestrator({
         )}
       </div>
 
-      {/* ── Glass pill (centered below album art) ── */}
+      {/* ── Glass pill (centered below album art) ──
+          TODO: 216px offset is relative to the centered album art layout.
+          May need adjustment for smaller phones or when keyboard is open. */}
       <AnimatePresence>
         {phase === "pill" && (
           <motion.div

--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -175,12 +175,15 @@ export default function MusicNerdLoadingOrchestrator({
   }, [aiLoading, phase, setPhaseAndRef]);
 
   // ── Research failed → show error state, auto-dismiss after 4s ──
+  // Guard: only fail if aiLoading was true (research actively running).
+  // Prevents a stale aiError from a previous track immediately failing
+  // the next track's pill before useAINuggets clears the error.
   useEffect(() => {
-    if (aiError && phase !== "ready" && phase !== "failed") {
+    if (aiError && !aiLoading && phase !== "ready" && phase !== "failed") {
       clearTimers();
       setPhaseAndRef("failed");
     }
-  }, [aiError, phase, clearTimers, setPhaseAndRef]);
+  }, [aiError, aiLoading, phase, clearTimers, setPhaseAndRef]);
 
   useEffect(() => {
     if (phase !== "failed") return;

--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -175,9 +175,11 @@ export default function MusicNerdLoadingOrchestrator({
   }, [aiLoading, phase, setPhaseAndRef]);
 
   // ── Research failed → show error state, auto-dismiss after 4s ──
-  // Guard: only fail if aiLoading was true (research actively running).
-  // Prevents a stale aiError from a previous track immediately failing
-  // the next track's pill before useAINuggets clears the error.
+  // Timing: aiError is set when generation fails, and aiLoading goes
+  // false at the same time (in the finally block). On track change,
+  // aiLoading goes true and aiError is cleared to null at the start
+  // of generate(). So !aiLoading && aiError is only true when the
+  // CURRENT track's generation has finished with an error.
   useEffect(() => {
     if (aiError && !aiLoading && phase !== "ready" && phase !== "failed") {
       clearTimers();

--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -6,6 +6,7 @@ type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready";
 
 interface Props {
   aiLoading: boolean;
+  hasNuggets?: boolean;
   shortId: string | null;
   trackId: string;
   tier: string;
@@ -52,6 +53,7 @@ function setPhaseCached(key: string, value: AnimPhase) {
 
 export default function MusicNerdLoadingOrchestrator({
   aiLoading,
+  hasNuggets = false,
   shortId,
   trackId,
   tier,
@@ -152,25 +154,16 @@ export default function MusicNerdLoadingOrchestrator({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiLoading, trackId, phase]);
 
-  // ── Pill timer → morph (only if still loading) ──
+  // ── Pill stays visible until nuggets arrive OR loading finishes ──
+  // No timed morph — the pill persists as long as the user has nothing to see.
   useEffect(() => {
     if (phase !== "pill") return;
-    addTimer(() => {
-      if (trackRef.current !== trackId) return;
-      if (phaseRef.current !== "pill") return;
-      startMorphFly();
-    }, PILL_DISPLAY_MS);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase, trackId]);
-
-  // ── aiLoading goes false during pill → skip ahead ──
-  useEffect(() => {
-    if (!aiLoading && phase === "pill") {
+    if (hasNuggets || !aiLoading) {
       clearTimers();
       startMorphFly();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aiLoading, phase]);
+  }, [phase, hasNuggets, aiLoading]);
 
   // ── aiLoading goes false during pulsating → ready ──
   useEffect(() => {

--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -2,10 +2,11 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
 
-type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready";
+type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready" | "failed";
 
 interface Props {
   aiLoading: boolean;
+  aiError?: string | null;
   hasNuggets?: boolean;
   shortId: string | null;
   trackId: string;
@@ -53,6 +54,7 @@ function setPhaseCached(key: string, value: AnimPhase) {
 
 export default function MusicNerdLoadingOrchestrator({
   aiLoading,
+  aiError,
   hasNuggets = false,
   shortId,
   trackId,
@@ -171,6 +173,20 @@ export default function MusicNerdLoadingOrchestrator({
       setPhaseAndRef("ready");
     }
   }, [aiLoading, phase, setPhaseAndRef]);
+
+  // ── Research failed → show error state, auto-dismiss after 4s ──
+  useEffect(() => {
+    if (aiError && (phase === "pill" || phase === "pulsating" || phase === "hidden")) {
+      clearTimers();
+      setPhaseAndRef("failed");
+    }
+  }, [aiError, phase, clearTimers, setPhaseAndRef]);
+
+  useEffect(() => {
+    if (phase !== "failed") return;
+    const t = setTimeout(() => setPhaseAndRef("hidden"), 4000);
+    return () => clearTimeout(t);
+  }, [phase, setPhaseAndRef]);
 
   // ── Cleanup on unmount ──
   useEffect(() => () => clearTimers(), [clearTimers]);
@@ -296,6 +312,28 @@ export default function MusicNerdLoadingOrchestrator({
             <span className="text-sm font-medium text-foreground/70 whitespace-nowrap select-none">
               MusicNerd is researching
               <AnimatedDots />
+            </span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* ── Failed pill ── */}
+      <AnimatePresence>
+        {phase === "failed" && (
+          <motion.div
+            className="fixed left-1/2 z-50 rounded-full px-4 py-2.5 flex items-center gap-2.5 pointer-events-none will-change-transform bg-black/60 border border-red-500/30"
+            style={{
+              top: "calc(50% + 216px)",
+              translateX: "-50%",
+            }}
+            initial={{ opacity: 0, scale: 0.9, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, transition: { duration: 0.3 } }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+          >
+            <MusicNerdLogo size={18} glow={false} />
+            <span className="text-sm font-medium text-red-400/80 whitespace-nowrap select-none">
+              Research unavailable
             </span>
           </motion.div>
         )}

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -243,7 +243,9 @@ export default function ImmersiveNuggetView({
     const { url: imgUrl, isNuggetImage } = getNuggetImage();
     return (
       <div className="w-full h-full overflow-y-auto glass-scrollbar">
-        <div className="relative w-full bg-black" style={{ minHeight: "100%" }}>
+        {/* Sticky image hero — stays pinned while body text scrolls over it.
+            Prevents the gap/overlay break when scrolling up. */}
+        <div className="sticky top-0 w-full h-full">
           {imgUrl && (
             <img
               src={imgUrl}
@@ -283,8 +285,10 @@ export default function ImmersiveNuggetView({
           </div>
         </div>
 
-        <div className="px-5 pb-5 -mt-32 relative z-10 pt-36" style={{
-          background: "linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 20%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 60%, rgb(0,0,0) 100%)",
+        {/* Body scrolls over the sticky image. Solid black bg-black ensures
+            no gap is visible when scrolling past the gradient overlap zone. */}
+        <div className="px-5 pb-5 -mt-32 relative z-10 pt-36 bg-black" style={{
+          backgroundImage: "linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 20%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 60%, rgb(0,0,0) 100%)",
         }}>
           <p className="text-sm leading-relaxed text-white/60 mb-4">
             {activeNugget?.text}

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -1,7 +1,12 @@
 import { createContext, useContext, useRef, useState, useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { useSpotifyToken } from "@/hooks/useSpotifyToken";
 import { useCurrentlyPlaying, type ExternalTrack } from "@/hooks/useCurrentlyPlaying";
+import { SpotifyPlaybackEngine, type SpotifyStateTrack } from "@/lib/engines/SpotifyPlaybackEngine";
+import type { ServiceType } from "@/lib/engines/types";
 import type { Nugget, Source } from "@/mock/types";
+
+// Re-export for consumers that import from PlayerContext
+export type { SpotifyStateTrack } from "@/lib/engines/SpotifyPlaybackEngine";
 
 // ── In-memory nugget cache (survives navigation, not page refresh) ──
 export interface CachedNuggets {
@@ -24,32 +29,9 @@ export interface CompanionNugget {
   imageCaption?: string;
 }
 
-// ── Spotify SDK singleton loader ──────────────────────────────────────
-
-let sdkLoading = false;
-let sdkReady = false;
-const sdkReadyCallbacks: (() => void)[] = [];
-
-function loadSpotifySDK(): Promise<void> {
-  if (sdkReady) return Promise.resolve();
-  return new Promise((resolve) => {
-    sdkReadyCallbacks.push(resolve);
-    if (sdkLoading) return;
-    sdkLoading = true;
-    window.onSpotifyWebPlaybackSDKReady = () => {
-      sdkReady = true;
-      sdkReadyCallbacks.forEach((cb) => cb());
-      sdkReadyCallbacks.length = 0;
-    };
-    const script = document.createElement("script");
-    script.src = "https://sdk.scdn.co/spotify-player.js";
-    document.head.appendChild(script);
-  });
-}
-
 // ── Types ─────────────────────────────────────────────────────────────
 
-export type ActivePlayer = "spotify" | "none";
+export type ActivePlayer = ServiceType;
 
 export interface TrackMeta {
   trackId: string;
@@ -57,17 +39,7 @@ export interface TrackMeta {
   artist: string;
   coverArtUrl: string;
   album?: string;
-  spotifyUri?: string;
-}
-
-/** Track info reported by the Spotify Web Playback SDK (from player_state_changed). */
-export interface SpotifyStateTrack {
-  title: string;
-  artist: string;
-  album: string;
-  albumArtUrl: string;
-  spotifyUri: string;
-  spotifyAlbumUri: string;
+  trackUri?: string;
 }
 
 interface PlayerState {
@@ -76,7 +48,7 @@ interface PlayerState {
   duration: number;
   activePlayer: ActivePlayer;
   spotifyReady: boolean;
-  currentSpotifyUri: string | null;
+  currentTrackUri: string | null;
   currentTrack: TrackMeta | null;
   /** Previous track route (for "go back" button). Null if no history. */
   prevTrackRoute: string | null;
@@ -93,9 +65,9 @@ interface PlayerState {
 }
 
 interface PlayerActions {
-  loadTrack: (opts: { spotifyUri?: string }) => void;
+  loadTrack: (opts: { trackUri?: string }) => void;
   /** Sync state to match an externally-changed track (no pause/restart). */
-  syncExternalTrack: (spotifyUri: string) => void;
+  syncExternalTrack: (trackUri: string) => void;
   setCurrentTrack: (meta: TrackMeta | null) => void;
   setOnEnded: (cb: (() => void) | null) => void;
   /** Push current route to history so prev button works across navigations. */
@@ -150,28 +122,26 @@ export function usePlayer(): PlayerContextType {
 export function PlayerProvider({ children }: { children: ReactNode }) {
   const { hasSpotifyToken, getValidToken } = useSpotifyToken();
 
-  // Spotify state
-  const spPlayerRef = useRef<Spotify.Player | null>(null);
+  // Playback engine ref
+  const engineRef = useRef<SpotifyPlaybackEngine | null>(null);
+
+  // Playback state (driven by engine callbacks)
   const [spReady, setSpReady] = useState(false);
   const [spPlaying, setSpPlaying] = useState(false);
   const [spTime, setSpTime] = useState(0);
   const [spDuration, setSpDuration] = useState(0);
   const [spDeviceId, setSpDeviceId] = useState<string | null>(null);
-  const spPollRef = useRef<number | null>(null);
-  const lastSpUriRef = useRef<string | null>(null);
-  const spHasPlayedRef = useRef(false); // true once track has been unpaused at least once
-  const maxPositionRef = useRef(0); // highest position (ms) reached — prevents false onEnded
-  const deviceLostRef = useRef(false); // true when another Spotify device takes over playback
-  const spTimeRef = useRef(0); // last known position in ms — used to resume after device loss
-  const spDeviceIdRef = useRef<string | null>(null); // stable ref for device ID (avoids deps churn)
-  const reTransferringRef = useRef(false); // prevents duplicate re-transfer API calls
 
   // Active player tracking
   const [activePlayer, setActivePlayer] = useState<ActivePlayer>("none");
-  const [currentSpotifyUri, setCurrentSpotifyUri] = useState<string | null>(null);
+  const [currentTrackUri, setCurrentTrackUri] = useState<string | null>(null);
   const [currentTrack, setCurrentTrack] = useState<TrackMeta | null>(null);
   const [spotifyStateTrack, setSpotifyStateTrack] = useState<SpotifyStateTrack | null>(null);
   const onEndedRef = useRef<(() => void) | null>(null);
+
+  // Stable ref for track URI (avoids stale closures)
+  const currentTrackUriRef = useRef<string | null>(null);
+  currentTrackUriRef.current = currentTrackUri;
 
   // External playback detection
   const [isExternalListenMode, setIsExternalListenMode] = useState(false);
@@ -250,214 +220,118 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     return prev;
   }, []);
 
-  // ── Spotify init (once, on mount if token available) ───────────────
+  // ── Engine init (once, on mount if token available) ────────────────
 
   useEffect(() => {
     if (!hasSpotifyToken) return;
-    let cancelled = false;
 
-    async function init() {
-      await loadSpotifySDK();
-      if (cancelled) return;
+    const engine = new SpotifyPlaybackEngine({
+      getOAuthToken: getValidToken,
+      onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
+      onDeviceLost: () => setSpPlaying(false),
+    });
 
-      const player = new Spotify.Player({
-        name: "MusicNerd TV",
-        getOAuthToken: async (cb) => { const t = await getValidToken(); if (t) cb(t); },
-        volume: 0.8,
-      });
-
-      player.addListener("ready", ({ device_id }) => {
-        if (cancelled) return;
-        spDeviceIdRef.current = device_id;
-        setSpDeviceId(device_id);
+    // Poll for ready state until engine reports ready
+    const readyPoll = window.setInterval(() => {
+      if (engine.ready) {
         setSpReady(true);
-      });
-      player.addListener("not_ready", () => { if (!cancelled) setSpReady(false); });
-      player.addListener("player_state_changed", (state) => {
-        if (cancelled) return;
-        if (!state) {
-          // Another Spotify device took over playback — our device is no longer active.
-          // Update UI to reflect stopped state and flag for re-transfer on next play().
-          deviceLostRef.current = true;
-          setSpPlaying(false);
-          if (spPollRef.current) {
-            clearInterval(spPollRef.current);
-            spPollRef.current = null;
-          }
-          console.log("[Player] Device lost — playback transferred to another device");
-          return;
-        }
-        deviceLostRef.current = false;
-        setSpPlaying(!state.paused);
-        setSpTime(state.position / 1000);
-        spTimeRef.current = state.position;
-        setSpDuration(state.duration / 1000);
-        if (!state.paused) {
-          spHasPlayedRef.current = true;
-          maxPositionRef.current = Math.max(maxPositionRef.current, state.position);
-          if (!spPollRef.current) {
-            spPollRef.current = window.setInterval(async () => {
-              const s = await spPlayerRef.current?.getCurrentState();
-              if (!s) return;
-              setSpTime(s.position / 1000);
-              spTimeRef.current = s.position;
-              setSpDuration(s.duration / 1000);
-              setSpPlaying(!s.paused);
-            }, 250);
-          }
-        } else if (spPollRef.current) {
-          clearInterval(spPollRef.current);
-          spPollRef.current = null;
-        }
-        const ct = state.track_window.current_track;
-        if (ct?.uri) {
-          setSpotifyStateTrack({
-            title: ct.name || "",
-            artist: ct.artists?.map((a: { name: string }) => a.name).join(", ") || "",
-            album: ct.album?.name || "",
-            albumArtUrl: ct.album?.images?.[0]?.url || "",
-            spotifyUri: ct.uri,
-            spotifyAlbumUri: ct.album?.uri || "",
-          });
-        }
-        if (state.paused && state.position === 0 && ct.uri === lastSpUriRef.current && spHasPlayedRef.current && maxPositionRef.current > 5000) {
-          lastSpUriRef.current = null;
-          spHasPlayedRef.current = false;
-          onEndedRef.current?.();
-        }
-      });
-      player.addListener("initialization_error", ({ message }) => console.error("[Spotify] Init error:", message));
-      player.addListener("authentication_error", ({ message }) => console.error("[Spotify] Auth error:", message));
-      player.addListener("account_error", ({ message }) => console.error("[Spotify] Account error:", message));
+        setSpDeviceId(engine.deviceId);
+        clearInterval(readyPoll);
+      }
+    }, 100);
 
-      await player.connect();
-      spPlayerRef.current = player;
-    }
+    const unsubState = engine.onStateChange((state) => {
+      setSpPlaying(state.isPlaying);
+      setSpTime(state.currentTime);
+      if (state.duration >= 0) setSpDuration(state.duration);
+    });
 
-    init();
+    const unsubEnd = engine.onTrackEnd(() => {
+      onEndedRef.current?.();
+    });
+
+    engine.init();
+    engineRef.current = engine;
+
     return () => {
-      cancelled = true;
-      if (spPollRef.current) clearInterval(spPollRef.current);
-      if (spPlayerRef.current) { spPlayerRef.current.disconnect(); spPlayerRef.current = null; }
+      clearInterval(readyPoll);
+      unsubState();
+      unsubEnd();
+      engine.cleanup();
+      engineRef.current = null;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasSpotifyToken]);
 
   // ── loadTrack ─────────────────────────────────────────────────────
 
-  const loadTrack = useCallback(({ spotifyUri }: { spotifyUri?: string }) => {
-    // Don't reload if already playing this exact URI
-    if (spotifyUri && lastSpUriRef.current === spotifyUri) return;
+  const hasAutoPlayedRef = useRef(false);
 
-    // Reset playback state
-    lastSpUriRef.current = null;
-    spHasPlayedRef.current = false;
+  const loadTrack = useCallback(({ trackUri }: { trackUri?: string }) => {
+    if (trackUri && currentTrackUriRef.current === trackUri) return;
+
     hasAutoPlayedRef.current = false;
-    maxPositionRef.current = 0;
-    spPlayerRef.current?.pause();
-    if (spPollRef.current) { clearInterval(spPollRef.current); spPollRef.current = null; }
+
+    // Reset UI state
     setSpTime(0);
     setSpDuration(0);
     setSpPlaying(false);
 
-    setCurrentSpotifyUri(spotifyUri || null);
-    setActivePlayer(spReady && spotifyUri ? "spotify" : "none");
+    setCurrentTrackUri(trackUri || null);
+    setActivePlayer(spReady && trackUri ? "spotify" : "none");
   }, [spReady]);
 
-  /** Sync tracking state to match an externally-changed Spotify track.
+  /** Sync tracking state to match an externally-changed track.
    *  Unlike loadTrack, this does NOT pause or restart playback — the SDK
    *  is already playing the right track. */
-  const syncExternalTrack = useCallback((spotifyUri: string) => {
-    setCurrentSpotifyUri(spotifyUri);
-    lastSpUriRef.current = spotifyUri;
-    spHasPlayedRef.current = true;
+  const syncExternalTrack = useCallback((trackUri: string) => {
+    setCurrentTrackUri(trackUri);
+    currentTrackUriRef.current = trackUri;
     hasAutoPlayedRef.current = true;
     setActivePlayer("spotify");
   }, []);
 
   // ── Upgrade to Spotify when SDK becomes ready after loadTrack ─────
   useEffect(() => {
-    if (spReady && currentSpotifyUri && activePlayer !== "spotify") {
+    if (spReady && currentTrackUri && activePlayer !== "spotify") {
       console.log("[Player] Spotify SDK ready — switching to Spotify");
       setActivePlayer("spotify");
       hasAutoPlayedRef.current = false;
     }
-  }, [spReady, currentSpotifyUri, activePlayer]);
+  }, [spReady, currentTrackUri, activePlayer]);
 
   // ── Auto-play when Spotify is active and ready ────────────────────
 
-  const hasAutoPlayedRef = useRef(false);
-
   useEffect(() => {
-    if (activePlayer === "spotify" && spReady && currentSpotifyUri && !hasAutoPlayedRef.current) {
+    if (activePlayer === "spotify" && spReady && currentTrackUri && !hasAutoPlayedRef.current) {
       hasAutoPlayedRef.current = true;
-      const uriToPlay = currentSpotifyUri; // capture before async gap
-      (async () => {
-        const token = await getValidToken();
-        if (!token || !spDeviceId) return;
-        lastSpUriRef.current = uriToPlay;
-        const res = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${spDeviceId}`, {
-          method: "PUT",
-          headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-          body: JSON.stringify({ uris: [uriToPlay] }),
-        });
-        if (!res.ok) {
-          console.error(`[Player] Spotify play failed (${res.status}):`, await res.text().catch(() => ""), "URI:", uriToPlay);
-        }
-      })();
+      engineRef.current?.loadTrack(currentTrackUri);
     }
-  }, [activePlayer, spReady, currentSpotifyUri, spDeviceId, getValidToken]);
+  }, [activePlayer, spReady, currentTrackUri]);
 
   // ── Controls ──────────────────────────────────────────────────────
 
   const play = useCallback(async () => {
-    // If another Spotify device stole playback, re-transfer it back to our SDK device
-    if (deviceLostRef.current && spDeviceIdRef.current && lastSpUriRef.current) {
-      if (reTransferringRef.current) return; // already in progress
-      reTransferringRef.current = true;
-      try {
-        const token = await getValidToken();
-        if (token) {
-          console.log("[Player] Re-transferring playback back to MusicNerd TV device");
-          const res = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${spDeviceIdRef.current}`, {
-            method: "PUT",
-            headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-            body: JSON.stringify({
-              uris: [lastSpUriRef.current],
-              position_ms: Math.max(0, spTimeRef.current),
-            }),
-          });
-          if (res.ok) {
-            deviceLostRef.current = false;
-          } else {
-            console.error(`[Player] Re-transfer playback failed (${res.status}):`, await res.text().catch(() => ""));
-          }
-        }
-      } finally {
-        reTransferringRef.current = false;
-      }
-      return;
-    }
-    spPlayerRef.current?.resume();
-  }, [getValidToken]);
+    await engineRef.current?.play();
+  }, []);
 
   const pause = useCallback(() => {
-    spPlayerRef.current?.pause();
+    engineRef.current?.pause();
   }, []);
 
   const toggle = useCallback(() => {
     if (activePlayer === "none") {
-      if (currentSpotifyUri && spReady) {
+      if (currentTrackUri && spReady) {
         setActivePlayer("spotify");
         hasAutoPlayedRef.current = false;
       }
       return;
     }
     if (spPlaying) pause(); else play();
-  }, [activePlayer, spPlaying, pause, play, currentSpotifyUri, spReady]);
+  }, [activePlayer, spPlaying, pause, play, currentTrackUri, spReady]);
 
   const seek = useCallback((seconds: number) => {
-    spPlayerRef.current?.seek(seconds * 1000);
+    engineRef.current?.seek(seconds);
     setSpTime(seconds);
   }, []);
 
@@ -466,10 +340,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const stop = useCallback(() => {
-    spPlayerRef.current?.pause();
-    if (spPollRef.current) { clearInterval(spPollRef.current); spPollRef.current = null; }
+    engineRef.current?.stop();
     setActivePlayer("none");
-    setCurrentSpotifyUri(null);
+    setCurrentTrackUri(null);
   }, []);
 
   // ── Unified state ─────────────────────────────────────────────────
@@ -480,7 +353,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     duration: spDuration || 0,
     activePlayer,
     spotifyReady: spReady,
-    currentSpotifyUri,
+    currentTrackUri,
     currentTrack,
     prevTrackRoute,
     externalPlayback: externalTrack,
@@ -518,7 +391,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setNowPlayingFocused,
     setNowPlayingFocusIndex,
   }), [
-    spPlaying, spTime, spDuration, activePlayer, spReady, currentSpotifyUri,
+    spPlaying, spTime, spDuration, activePlayer, spReady, currentTrackUri,
     currentTrack, prevTrackRoute, externalTrack, isExternalListenMode, spotifyStateTrack, nowPlayingFocused, nowPlayingFocusIndex,
     setCurrentTrack, setOnEnded, pushTrackHistory, popTrackHistory, loadTrack,
     syncExternalTrack, play, pause, toggle, seek, stop, setExternalListenMode,

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -238,7 +238,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     const unsubState = engine.onStateChange((state) => {
       setSpPlaying(state.isPlaying);
       setSpTime(state.currentTime);
-      if (state.duration !== undefined) setSpDuration(state.duration);
+      // duration is optional on PlaybackState (omitted = "keep current").
+      // Use != null to safely handle both undefined and null.
+      if (state.duration != null) setSpDuration(state.duration);
     });
 
     const unsubEnd = engine.onTrackEnd(() => {
@@ -283,6 +285,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     currentTrackUriRef.current = trackUri;
     hasAutoPlayedRef.current = true;
     setActivePlayer("spotify");
+    // Update engine's lastUri so end-of-track detection works for
+    // externally-synced tracks (e.g. user skipped on Spotify app).
+    engineRef.current?.syncUri(trackUri);
   }, []);
 
   // ── Upgrade to Spotify when SDK becomes ready after loadTrack ─────

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -227,18 +227,13 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
     const engine = new SpotifyPlaybackEngine({
       getOAuthToken: getValidToken,
+      onReady: (deviceId) => {
+        setSpReady(true);
+        setSpDeviceId(deviceId);
+      },
       onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
       onDeviceLost: () => setSpPlaying(false),
     });
-
-    // Poll for ready state until engine reports ready
-    const readyPoll = window.setInterval(() => {
-      if (engine.ready) {
-        setSpReady(true);
-        setSpDeviceId(engine.deviceId);
-        clearInterval(readyPoll);
-      }
-    }, 100);
 
     const unsubState = engine.onStateChange((state) => {
       setSpPlaying(state.isPlaying);
@@ -254,7 +249,6 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     engineRef.current = engine;
 
     return () => {
-      clearInterval(readyPoll);
       unsubState();
       unsubEnd();
       engine.cleanup();

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -238,7 +238,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     const unsubState = engine.onStateChange((state) => {
       setSpPlaying(state.isPlaying);
       setSpTime(state.currentTime);
-      if (state.duration != null) setSpDuration(state.duration);
+      if (state.duration !== undefined) setSpDuration(state.duration);
     });
 
     const unsubEnd = engine.onTrackEnd(() => {

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -238,7 +238,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     const unsubState = engine.onStateChange((state) => {
       setSpPlaying(state.isPlaying);
       setSpTime(state.currentTime);
-      if (state.duration >= 0) setSpDuration(state.duration);
+      if (state.duration != null) setSpDuration(state.duration);
     });
 
     const unsubEnd = engine.onTrackEnd(() => {

--- a/src/data/seedNuggets.ts
+++ b/src/data/seedNuggets.ts
@@ -59,7 +59,7 @@ export interface DemoTrackMeta {
   artist: string;
   title: string;
   album: string;
-  spotifyUri: string;
+  trackUri: string;
   coverArtUrl: string;
   /** File-name slug used in src/data/seed/ */
   slug: string;
@@ -67,12 +67,12 @@ export interface DemoTrackMeta {
 
 /** All demo tracks — single source of truth for Browse tiles + Listen playback. */
 export const DEMO_TRACKS: DemoTrackMeta[] = [
-  { id: "demo-around-the-world", artist: "Daft Punk", title: "Around the World", album: "Homework", spotifyUri: "spotify:track:1pKYYY0dkg23sQQXi0Q5zN", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738ac778cc7d88779f74d33311", slug: "daftpunk" },
-  { id: "demo-weird-fishes", artist: "Radiohead", title: "Weird Fishes/Arpeggi", album: "In Rainbows", spotifyUri: "spotify:track:4wajJ1o7jWIg62YqpkHC7S", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273de3c04b5fc750b68899b20a9", slug: "radiohead" },
-  { id: "demo-oms-at-play", artist: "Pete Rango", title: "Oms at Play", album: "Savage Planet", spotifyUri: "spotify:track:7mYphBaMfblb6iu1saj3MC", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27305b43e15352510b1b9c9a5a5", slug: "peterango" },
-  { id: "demo-slack", artist: "Jamee Cornelia", title: "SLACK", album: "HARVEST", spotifyUri: "spotify:track:5bU8cB57AfhTtO0qj9zy3X", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273e9c4a69ecd5c43229cfd03f3", slug: "jameecornelia" },
-  { id: "demo-humble", artist: "Kendrick Lamar", title: "HUMBLE.", album: "DAMN.", spotifyUri: "spotify:track:7KXjTSCq5nL1LoYtL7XAwS", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738b52c6b9bc4e43d873869699", slug: "kendrick" },
-  { id: "demo-bad-guy", artist: "Billie Eilish", title: "bad guy", album: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?", spotifyUri: "spotify:track:2Fxmhks0bxGSBdJ92vM42m", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27350a3147b4edd7701a876c6ce", slug: "billie" },
+  { id: "demo-around-the-world", artist: "Daft Punk", title: "Around the World", album: "Homework", trackUri: "spotify:track:1pKYYY0dkg23sQQXi0Q5zN", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738ac778cc7d88779f74d33311", slug: "daftpunk" },
+  { id: "demo-weird-fishes", artist: "Radiohead", title: "Weird Fishes/Arpeggi", album: "In Rainbows", trackUri: "spotify:track:4wajJ1o7jWIg62YqpkHC7S", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273de3c04b5fc750b68899b20a9", slug: "radiohead" },
+  { id: "demo-oms-at-play", artist: "Pete Rango", title: "Oms at Play", album: "Savage Planet", trackUri: "spotify:track:7mYphBaMfblb6iu1saj3MC", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27305b43e15352510b1b9c9a5a5", slug: "peterango" },
+  { id: "demo-slack", artist: "Jamee Cornelia", title: "SLACK", album: "HARVEST", trackUri: "spotify:track:5bU8cB57AfhTtO0qj9zy3X", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273e9c4a69ecd5c43229cfd03f3", slug: "jameecornelia" },
+  { id: "demo-humble", artist: "Kendrick Lamar", title: "HUMBLE.", album: "DAMN.", trackUri: "spotify:track:7KXjTSCq5nL1LoYtL7XAwS", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738b52c6b9bc4e43d873869699", slug: "kendrick" },
+  { id: "demo-bad-guy", artist: "Billie Eilish", title: "bad guy", album: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?", trackUri: "spotify:track:2Fxmhks0bxGSBdJ92vM42m", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27350a3147b4edd7701a876c6ce", slug: "billie" },
 ];
 
 /** Look up a demo track by its simple ID (e.g. "demo-weird-fishes"). */

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -382,7 +382,9 @@ export function useAINuggets(
       // 60s timeout: if the edge function stalls mid-stream (never sends
       // done, never closes), the fetch aborts cleanly. User track-skips
       // also abort via abortRef.current.abort() in the effect cleanup.
-      const timeoutId = setTimeout(() => abortRef.current?.abort(), 60_000);
+      // 120s timeout — matches Supabase edge function limit (150s) with
+      // margin. Lesser-known artists need longer for Exa research + Gemini.
+      const timeoutId = setTimeout(() => abortRef.current?.abort(), 120_000);
 
       const response = await fetch(`${SUPABASE_URL}/functions/v1/generate-nuggets`, {
         method: "POST",

--- a/src/hooks/usePersonalizedCatalog.ts
+++ b/src/hooks/usePersonalizedCatalog.ts
@@ -64,8 +64,8 @@ function trackCoverUrl(
   return `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(artistName + trackName)}&backgroundColor=111827&textColor=ffffff&fontSize=30`;
 }
 
-function realTrackHref(artist: string, title: string, album?: string, spotifyUri?: string): string {
-  const parts = ["real", artist, title, album || "", spotifyUri || ""].map(encodeURIComponent);
+function realTrackHref(artist: string, title: string, album?: string, trackUri?: string): string {
+  const parts = ["real", artist, title, album || "", trackUri || ""].map(encodeURIComponent);
   return `/listen/${parts.join("::")}`;
 }
 

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -209,6 +209,16 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.player?.pause();
   }
 
+  /** Sync internal tracking to match an externally-changed track.
+   *  Unlike loadTrack, this does NOT pause or restart playback. */
+  syncUri(trackUri: string): void {
+    this.lastUri = trackUri;
+    this.hasPlayed = true;
+    this.hasAutoPlayed = true;
+    this._isPlaying = true;
+    this.maxPosition = 0;
+  }
+
   async seek(seconds: number): Promise<void> {
     this.player?.seek(seconds * 1000);
     // Optimistically update time — omit duration so subscribers keep current value
@@ -251,7 +261,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.lastUri = uri;
 
     const token = await this.getOAuthToken();
-    if (!token || !this._deviceId) return;
+    if (this.cancelled || !token || !this._deviceId) return;
 
     const res = await fetch(
       `https://api.spotify.com/v1/me/player/play?device_id=${this._deviceId}`,

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -9,6 +9,15 @@ let sdkLoading = false;
 let sdkReady = false;
 const sdkReadyCallbacks: (() => void)[] = [];
 
+/** Reset module-level SDK state — only for tests. Without this, sdkReady
+ *  stays true after the first test and subsequent init() calls skip the
+ *  SDK load entirely. */
+export function _resetSdkStateForTests(): void {
+  sdkLoading = false;
+  sdkReady = false;
+  sdkReadyCallbacks.length = 0;
+}
+
 function loadSpotifySDK(): Promise<void> {
   if (sdkReady) return Promise.resolve();
   return new Promise((resolve) => {
@@ -216,7 +225,9 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.hasPlayed = true;
     this.hasAutoPlayed = true;
     this._isPlaying = true;
-    this.maxPosition = 0;
+    // Inherit the last known position so end-of-track detection
+    // (maxPosition > 5000) isn't blind for the first few seconds.
+    this.maxPosition = this.lastPosition;
   }
 
   async seek(seconds: number): Promise<void> {

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -295,7 +295,9 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
       // Another device took over
       this.deviceLost = true;
       this.stopPolling();
-      this.emitState({ isPlaying: false, currentTime: 0, duration: 0 });
+      // Preserve last known position so the progress bar doesn't snap to 0.
+      // Omit duration so subscribers keep the current value.
+      this.emitState({ isPlaying: false, currentTime: this.lastPosition / 1000 });
       this.onDeviceLostCb?.();
       console.log("[Player] Device lost — playback transferred to another device");
       return;

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -28,6 +28,10 @@ function loadSpotifySDK(): Promise<void> {
 
 // ── Track info reported by the Spotify SDK ───────────────────────────
 
+// Intentionally uses spotifyUri (not trackUri) — this is the SDK's native
+// Spotify URI format (spotify:track:xxxxx). It equals the service-agnostic
+// trackUri for Spotify tracks but is named distinctly because this type is
+// only populated from the Spotify SDK's player_state_changed event.
 export interface SpotifyStateTrack {
   title: string;
   artist: string;
@@ -41,6 +45,8 @@ export interface SpotifyStateTrack {
 
 export interface SpotifyPlaybackEngineOptions {
   getOAuthToken: () => Promise<string | null>;
+  /** Called when the SDK is ready with the device ID. */
+  onReady?: (deviceId: string) => void;
   /** Called when the SDK reports a new current track (player_state_changed). */
   onSpotifyStateTrack?: (track: SpotifyStateTrack) => void;
   /** Called when another Spotify device takes over playback. */
@@ -60,6 +66,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
   private lastUri: string | null = null;
   private hasPlayed = false;
   private hasAutoPlayed = false;
+  private _isPlaying = false;  // current playing state (not "has ever played")
   private maxPosition = 0;        // ms — highest position reached
   private lastPosition = 0;       // ms — for resume after device loss
   private deviceLost = false;
@@ -71,10 +78,12 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   private getOAuthToken: () => Promise<string | null>;
   private onSpotifyStateTrackCb?: (track: SpotifyStateTrack) => void;
+  private onReadyCb?: (deviceId: string) => void;
   private onDeviceLostCb?: () => void;
 
   constructor(opts: SpotifyPlaybackEngineOptions) {
     this.getOAuthToken = opts.getOAuthToken;
+    this.onReadyCb = opts.onReady;
     this.onSpotifyStateTrackCb = opts.onSpotifyStateTrack;
     this.onDeviceLostCb = opts.onDeviceLost;
   }
@@ -101,6 +110,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
       if (this.cancelled) return;
       this._deviceId = device_id;
       this._ready = true;
+      this.onReadyCb?.(device_id);
     });
 
     player.addListener("not_ready", () => {
@@ -139,6 +149,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.lastUri = null;
     this.hasPlayed = false;
     this.hasAutoPlayed = false;
+    this._isPlaying = false;
     this.maxPosition = 0;
     this.player?.pause();
     this.stopPolling();
@@ -196,8 +207,8 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   async seek(seconds: number): Promise<void> {
     this.player?.seek(seconds * 1000);
-    // Optimistically update time (preserve current playing state)
-    this.emitState({ isPlaying: this.hasPlayed && !this.deviceLost, currentTime: seconds, duration: -1 });
+    // Optimistically update time — use actual playing state, not "has ever played"
+    this.emitState({ isPlaying: this._isPlaying, currentTime: seconds, duration: -1 });
   }
 
   stop(): void {
@@ -268,6 +279,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     const currentTime = state.position / 1000;
     const duration = state.duration / 1000;
     const isPlaying = !state.paused;
+    this._isPlaying = isPlaying;
     this.lastPosition = state.position;
 
     this.emitState({ isPlaying, currentTime, duration });

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -216,6 +216,8 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
   }
 
   async pause(): Promise<void> {
+    // Fire-and-forget: actual state update comes via player_state_changed.
+    // Awaiting the SDK promise adds latency without meaningful benefit.
     this.player?.pause();
   }
 

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -1,0 +1,325 @@
+// Spotify Web Playback SDK engine — extracted from PlayerContext.tsx.
+// Implements PlaybackEngine so PlayerContext can swap between providers.
+
+import type { PlaybackEngine, PlaybackState } from "./types";
+
+// ── SDK singleton loader ─────────────────────────────────────────────
+
+let sdkLoading = false;
+let sdkReady = false;
+const sdkReadyCallbacks: (() => void)[] = [];
+
+function loadSpotifySDK(): Promise<void> {
+  if (sdkReady) return Promise.resolve();
+  return new Promise((resolve) => {
+    sdkReadyCallbacks.push(resolve);
+    if (sdkLoading) return;
+    sdkLoading = true;
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      sdkReady = true;
+      sdkReadyCallbacks.forEach((cb) => cb());
+      sdkReadyCallbacks.length = 0;
+    };
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  });
+}
+
+// ── Track info reported by the Spotify SDK ───────────────────────────
+
+export interface SpotifyStateTrack {
+  title: string;
+  artist: string;
+  album: string;
+  albumArtUrl: string;
+  spotifyUri: string;
+  spotifyAlbumUri: string;
+}
+
+// ── Engine ────────────────────────────────────────────────────────────
+
+export interface SpotifyPlaybackEngineOptions {
+  getOAuthToken: () => Promise<string | null>;
+  /** Called when the SDK reports a new current track (player_state_changed). */
+  onSpotifyStateTrack?: (track: SpotifyStateTrack) => void;
+  /** Called when another Spotify device takes over playback. */
+  onDeviceLost?: () => void;
+}
+
+export class SpotifyPlaybackEngine implements PlaybackEngine {
+  readonly service = "spotify" as const;
+
+  private player: Spotify.Player | null = null;
+  private _ready = false;
+  private _deviceId: string | null = null;
+  private cancelled = false;
+
+  // Internal tracking refs
+  private pollInterval: number | null = null;
+  private lastUri: string | null = null;
+  private hasPlayed = false;
+  private hasAutoPlayed = false;
+  private maxPosition = 0;        // ms — highest position reached
+  private lastPosition = 0;       // ms — for resume after device loss
+  private deviceLost = false;
+  private reTransferring = false;
+
+  // Subscribers
+  private stateListeners: Set<(s: PlaybackState) => void> = new Set();
+  private endListeners: Set<() => void> = new Set();
+
+  private getOAuthToken: () => Promise<string | null>;
+  private onSpotifyStateTrackCb?: (track: SpotifyStateTrack) => void;
+  private onDeviceLostCb?: () => void;
+
+  constructor(opts: SpotifyPlaybackEngineOptions) {
+    this.getOAuthToken = opts.getOAuthToken;
+    this.onSpotifyStateTrackCb = opts.onSpotifyStateTrack;
+    this.onDeviceLostCb = opts.onDeviceLost;
+  }
+
+  get ready() { return this._ready; }
+  get deviceId() { return this._deviceId; }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────
+
+  async init(): Promise<void> {
+    await loadSpotifySDK();
+    if (this.cancelled) return;
+
+    const player = new Spotify.Player({
+      name: "MusicNerd TV",
+      getOAuthToken: async (cb) => {
+        const t = await this.getOAuthToken();
+        if (t) cb(t);
+      },
+      volume: 0.8,
+    });
+
+    player.addListener("ready", ({ device_id }) => {
+      if (this.cancelled) return;
+      this._deviceId = device_id;
+      this._ready = true;
+    });
+
+    player.addListener("not_ready", () => {
+      if (!this.cancelled) this._ready = false;
+    });
+
+    player.addListener("player_state_changed", (state) => this.handleStateChange(state));
+
+    player.addListener("initialization_error", ({ message }) =>
+      console.error("[Spotify] Init error:", message));
+    player.addListener("authentication_error", ({ message }) =>
+      console.error("[Spotify] Auth error:", message));
+    player.addListener("account_error", ({ message }) =>
+      console.error("[Spotify] Account error:", message));
+
+    await player.connect();
+    this.player = player;
+  }
+
+  cleanup(): void {
+    this.cancelled = true;
+    this.stopPolling();
+    if (this.player) {
+      this.player.disconnect();
+      this.player = null;
+    }
+  }
+
+  // ── Playback control ────────────────────────────────────────────────
+
+  async loadTrack(trackUri: string): Promise<void> {
+    // Don't reload if already playing this exact URI
+    if (trackUri && this.lastUri === trackUri) return;
+
+    // Reset state
+    this.lastUri = null;
+    this.hasPlayed = false;
+    this.hasAutoPlayed = false;
+    this.maxPosition = 0;
+    this.player?.pause();
+    this.stopPolling();
+
+    this.emitState({ isPlaying: false, currentTime: 0, duration: 0 });
+
+    if (!trackUri) return;
+
+    // If ready, auto-play immediately; otherwise it will play when ready
+    if (this._ready && this._deviceId) {
+      await this.autoPlay(trackUri);
+    } else {
+      // Store URI — will auto-play when init completes
+      this.lastUri = trackUri;
+    }
+  }
+
+  async play(): Promise<void> {
+    // Re-transfer if another device stole playback
+    if (this.deviceLost && this._deviceId && this.lastUri) {
+      if (this.reTransferring) return;
+      this.reTransferring = true;
+      try {
+        const token = await this.getOAuthToken();
+        if (token) {
+          console.log("[Player] Re-transferring playback back to MusicNerd TV device");
+          const res = await fetch(
+            `https://api.spotify.com/v1/me/player/play?device_id=${this._deviceId}`,
+            {
+              method: "PUT",
+              headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+              body: JSON.stringify({
+                uris: [this.lastUri],
+                position_ms: Math.max(0, this.lastPosition),
+              }),
+            }
+          );
+          if (res.ok) {
+            this.deviceLost = false;
+          } else {
+            console.error(`[Player] Re-transfer failed (${res.status}):`, await res.text().catch(() => ""));
+          }
+        }
+      } finally {
+        this.reTransferring = false;
+      }
+      return;
+    }
+    this.player?.resume();
+  }
+
+  async pause(): Promise<void> {
+    this.player?.pause();
+  }
+
+  async seek(seconds: number): Promise<void> {
+    this.player?.seek(seconds * 1000);
+    // Optimistically update time (preserve current playing state)
+    this.emitState({ isPlaying: this.hasPlayed && !this.deviceLost, currentTime: seconds, duration: -1 });
+  }
+
+  stop(): void {
+    this.player?.pause();
+    this.stopPolling();
+    this.lastUri = null;
+  }
+
+  // ── Subscriptions ───────────────────────────────────────────────────
+
+  onStateChange(cb: (s: PlaybackState) => void): () => void {
+    this.stateListeners.add(cb);
+    return () => { this.stateListeners.delete(cb); };
+  }
+
+  onTrackEnd(cb: () => void): () => void {
+    this.endListeners.add(cb);
+    return () => { this.endListeners.delete(cb); };
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private emitState(partial: Partial<PlaybackState> & { isPlaying: boolean }) {
+    // duration of -1 means "keep current" — caller only knows time changed
+    const state: PlaybackState = {
+      isPlaying: partial.isPlaying,
+      currentTime: partial.currentTime ?? 0,
+      duration: partial.duration === -1 ? -1 : (partial.duration ?? 0),
+    };
+    for (const cb of this.stateListeners) cb(state);
+  }
+
+  private async autoPlay(uri: string): Promise<void> {
+    if (this.hasAutoPlayed) return;
+    this.hasAutoPlayed = true;
+    this.lastUri = uri;
+
+    const token = await this.getOAuthToken();
+    if (!token || !this._deviceId) return;
+
+    const res = await fetch(
+      `https://api.spotify.com/v1/me/player/play?device_id=${this._deviceId}`,
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ uris: [uri] }),
+      }
+    );
+    if (!res.ok) {
+      console.error(`[Player] Spotify play failed (${res.status}):`, await res.text().catch(() => ""), "URI:", uri);
+    }
+  }
+
+  private handleStateChange(state: Spotify.PlaybackState | null): void {
+    if (this.cancelled) return;
+
+    if (!state) {
+      // Another device took over
+      this.deviceLost = true;
+      this.stopPolling();
+      this.emitState({ isPlaying: false, currentTime: 0, duration: 0 });
+      this.onDeviceLostCb?.();
+      console.log("[Player] Device lost — playback transferred to another device");
+      return;
+    }
+
+    this.deviceLost = false;
+    const currentTime = state.position / 1000;
+    const duration = state.duration / 1000;
+    const isPlaying = !state.paused;
+    this.lastPosition = state.position;
+
+    this.emitState({ isPlaying, currentTime, duration });
+
+    if (isPlaying) {
+      this.hasPlayed = true;
+      this.maxPosition = Math.max(this.maxPosition, state.position);
+      this.startPolling();
+    } else {
+      this.stopPolling();
+    }
+
+    // Report SDK track info
+    const ct = state.track_window.current_track;
+    if (ct?.uri) {
+      this.onSpotifyStateTrackCb?.({
+        title: ct.name || "",
+        artist: ct.artists?.map((a: { name: string }) => a.name).join(", ") || "",
+        album: ct.album?.name || "",
+        albumArtUrl: ct.album?.images?.[0]?.url || "",
+        spotifyUri: ct.uri,
+        spotifyAlbumUri: ct.album?.uri || "",
+      });
+    }
+
+    // End-of-track detection
+    if (state.paused && state.position === 0 && ct?.uri === this.lastUri
+        && this.hasPlayed && this.maxPosition > 5000) {
+      this.lastUri = null;
+      this.hasPlayed = false;
+      for (const cb of this.endListeners) cb();
+    }
+  }
+
+  private startPolling(): void {
+    if (this.pollInterval) return;
+    this.pollInterval = window.setInterval(async () => {
+      const s = await this.player?.getCurrentState();
+      if (!s) return;
+      this.lastPosition = s.position;
+      this.emitState({
+        isPlaying: !s.paused,
+        currentTime: s.position / 1000,
+        duration: s.duration / 1000,
+      });
+    }, 250);
+  }
+
+  private stopPolling(): void {
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    }
+  }
+}

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -111,6 +111,10 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
       this._deviceId = device_id;
       this._ready = true;
       this.onReadyCb?.(device_id);
+      // Auto-play pending URI that was stored before the SDK was ready
+      if (this.lastUri && !this.hasAutoPlayed) {
+        this.autoPlay(this.lastUri);
+      }
     });
 
     player.addListener("not_ready", () => {
@@ -143,7 +147,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   async loadTrack(trackUri: string): Promise<void> {
     // Don't reload if already playing this exact URI
-    if (trackUri && this.lastUri === trackUri) return;
+    if (this.lastUri === trackUri) return;
 
     // Reset state
     this.lastUri = null;
@@ -158,11 +162,11 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
     if (!trackUri) return;
 
-    // If ready, auto-play immediately; otherwise it will play when ready
+    // If ready, auto-play immediately; otherwise store the URI and
+    // auto-play when onReady fires (see the "ready" listener in init()).
     if (this._ready && this._deviceId) {
       await this.autoPlay(trackUri);
     } else {
-      // Store URI — will auto-play when init completes
       this.lastUri = trackUri;
     }
   }
@@ -207,8 +211,8 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   async seek(seconds: number): Promise<void> {
     this.player?.seek(seconds * 1000);
-    // Optimistically update time — use actual playing state, not "has ever played"
-    this.emitState({ isPlaying: this._isPlaying, currentTime: seconds, duration: -1 });
+    // Optimistically update time — omit duration so subscribers keep current value
+    this.emitState({ isPlaying: this._isPlaying, currentTime: seconds });
   }
 
   stop(): void {
@@ -231,12 +235,12 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   // ── Internals ───────────────────────────────────────────────────────
 
-  private emitState(partial: Partial<PlaybackState> & { isPlaying: boolean }) {
-    // duration of -1 means "keep current" — caller only knows time changed
+  private emitState(partial: { isPlaying: boolean; currentTime: number; duration?: number }) {
+    // When duration is omitted, subscribers should keep their current value.
     const state: PlaybackState = {
       isPlaying: partial.isPlaying,
-      currentTime: partial.currentTime ?? 0,
-      duration: partial.duration === -1 ? -1 : (partial.duration ?? 0),
+      currentTime: partial.currentTime,
+      duration: partial.duration,
     };
     for (const cb of this.stateListeners) cb(state);
   }

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -164,6 +164,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.hasAutoPlayed = false;
     this._isPlaying = false;
     this.maxPosition = 0;
+    this.lastPosition = 0;
     this.player?.pause();
     this.stopPolling();
 

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -7,7 +7,7 @@ export type ServiceType = "spotify" | "apple-music" | "none";
 export interface PlaybackState {
   isPlaying: boolean;
   currentTime: number;   // seconds
-  duration: number;       // seconds
+  duration?: number;      // seconds — omitted means "keep current value"
 }
 
 export interface PlaybackEngine {

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -1,0 +1,31 @@
+// Service abstraction layer for multi-provider playback (Spotify, Apple Music).
+// PlaybackEngine is a plain class interface — not a hook — so implementations
+// can be instantiated conditionally without violating React's rules of hooks.
+
+export type ServiceType = "spotify" | "apple-music" | "none";
+
+export interface PlaybackState {
+  isPlaying: boolean;
+  currentTime: number;   // seconds
+  duration: number;       // seconds
+}
+
+export interface PlaybackEngine {
+  readonly service: ServiceType;
+  readonly ready: boolean;
+  readonly deviceId: string | null;
+
+  init(): Promise<void>;
+  cleanup(): void;
+
+  loadTrack(trackUri: string): Promise<void>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  seek(seconds: number): Promise<void>;
+  stop(): void;
+
+  /** Subscribe to playback state changes. Returns unsubscribe function. */
+  onStateChange(cb: (state: PlaybackState) => void): () => void;
+  /** Subscribe to track-end events. Returns unsubscribe function. */
+  onTrackEnd(cb: () => void): () => void;
+}

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -13,7 +13,8 @@ export interface PlaybackState {
 export interface PlaybackEngine {
   readonly service: ServiceType;
   readonly ready: boolean;
-  readonly deviceId: string | null;
+  /** Spotify-only: the Web Playback SDK device ID. Other engines return null. */
+  readonly deviceId?: string | null;
 
   init(): Promise<void>;
   cleanup(): void;

--- a/src/lib/routeParsing.ts
+++ b/src/lib/routeParsing.ts
@@ -1,12 +1,14 @@
-// Route URL parsing utilities for spotify:: and real:: prefixed routes.
+// Route URL parsing utilities for spotify::, apple::, and real:: prefixed routes.
 // CONSTRAINT: "::" is the delimiter — names containing "::" would break parsing.
-// Safe for Spotify data (IDs/names don't contain "::"), but not arbitrary user input.
+// Safe for Spotify/Apple Music data (IDs/names don't contain "::"), but not arbitrary user input.
 //
 // Segment formats:
 //   Artist: spotify::{spotifyId}::{artistName}
+//           apple::{appleId}::{artistName}
 //   Album:  spotify::{albumId}::{artistName}::{artistSpotifyId}
+//           apple::{albumId}::{artistName}::{artistAppleId}
 //   Real:   real::{artistName}
-//   Listen: real::{artist}::{title}::{album}::{spotifyUri}
+//   Listen: real::{artist}::{title}::{album}::{trackUri}
 
 /** Detect if a raw route param has a spotify:: prefix (URL-encoded or raw) */
 export function isSpotifyPrefix(raw: string | undefined): boolean {
@@ -52,5 +54,37 @@ export function parseSpotifyAlbum(raw: string): { spotifyAlbumId: string; artist
     spotifyAlbumId,
     artistName: parts[2] || "",
     artistSpotifyId: parts[3] || "",
+  };
+}
+
+// ── Apple Music route parsing ────────────────────────────────────────
+
+/** Detect if a raw route param has an apple:: prefix (URL-encoded or raw) */
+export function isApplePrefix(raw: string | undefined): boolean {
+  if (!raw) return false;
+  return raw.startsWith("apple%3A%3A") || raw.startsWith("apple::");
+}
+
+/** Parse apple::{id}::{name} from an artist route param */
+export function parseAppleArtist(raw: string): { appleId: string; artistName: string } | null {
+  if (!isApplePrefix(raw)) return null;
+  const decoded = decodeURIComponent(raw);
+  const parts = decoded.split("::");
+  const appleId = parts[1] || "";
+  if (!appleId) return null;
+  return { appleId, artistName: parts[2] || "" };
+}
+
+/** Parse apple::{albumId}::{artistName}::{artistAppleId} from an album route param */
+export function parseAppleAlbum(raw: string): { appleAlbumId: string; artistName: string; artistAppleId: string } | null {
+  if (!isApplePrefix(raw)) return null;
+  const decoded = decodeURIComponent(raw);
+  const parts = decoded.split("::");
+  const appleAlbumId = parts[1] || "";
+  if (!appleAlbumId) return null;
+  return {
+    appleAlbumId,
+    artistName: parts[2] || "",
+    artistAppleId: parts[3] || "",
   };
 }

--- a/src/lib/trackUri.ts
+++ b/src/lib/trackUri.ts
@@ -1,0 +1,20 @@
+// Utilities for working with service-prefixed track URIs.
+// Spotify: "spotify:track:7KXjTSCq5nL1LoYtL7XAwS"
+// Apple Music: "apple:song:1440833060"
+
+import type { ServiceType } from "./engines/types";
+
+/** Determine the streaming service from a track URI. */
+export function getServiceFromUri(uri: string): ServiceType {
+  if (uri.startsWith("spotify:")) return "spotify";
+  if (uri.startsWith("apple:")) return "apple-music";
+  return "none";
+}
+
+/** Extract the service-specific ID from a track URI. */
+export function getIdFromUri(uri: string): string {
+  // spotify:track:7KXjTSCq5nL1LoYtL7XAwS → 7KXjTSCq5nL1LoYtL7XAwS
+  // apple:song:1440833060 → 1440833060
+  const parts = uri.split(":");
+  return parts[parts.length - 1] || "";
+}

--- a/src/mock/types.ts
+++ b/src/mock/types.ts
@@ -92,6 +92,8 @@ export interface DeepDiveResponse {
 export interface UserProfile {
   streamingService: "Spotify" | "YouTube Music" | "Apple Music" | "";
   lastFmUsername?: string;
+  /** Service-agnostic display name (populated from Spotify or user input for Apple Music) */
+  displayName?: string;
   spotifyDisplayName?: string;    // e.g. "Peter Rango" — from Spotify OAuth
   // Spotify taste profile — populated after OAuth, stored as serialised top artists/tracks
   spotifyTopArtists?: string[];   // e.g. ["Radiohead", "Björk", "Portishead"]

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -28,7 +28,7 @@ export default function Browse() {
   useTierAccent(tier);
 
   const { rows: allRows } = usePersonalizedCatalog(profile);
-  const userName = profile?.spotifyDisplayName || "";
+  const userName = profile?.displayName || profile?.spotifyDisplayName || "";
 
   const demoItems = [
     {
@@ -281,11 +281,9 @@ export default function Browse() {
             )}
           </div>
           <p className="mt-1 text-muted-foreground text-lg">
-            {profile?.spotifyTopArtists?.length
-              ? "Listening via Spotify"
-              : profile?.streamingService
-                ? `Listening via ${profile.streamingService}`
-                : "What do you want to listen to?"}
+            {profile?.streamingService
+              ? `Listening via ${profile.streamingService}`
+              : "What do you want to listen to?"}
           </p>
         </div>
 

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1095,7 +1095,10 @@ export default function Listen() {
     const shouldTrigger = (n: typeof trackNuggets[0]) =>
       !aiFromCache || currentTime >= n.timestampSec;
 
-    if (!isPlaying && aiFromCache) return; // cached: wait for playback
+    // Cached tracks: wait for playback to reach each timestamp.
+    // Fresh SSE: show immediately even if paused — the user is waiting
+    // for content and should see nuggets the moment they arrive.
+    if (!isPlaying && aiFromCache) return;
 
     for (const n of trackNuggets) {
       if (shownNuggetIds.has(n.id)) continue;

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1262,6 +1262,7 @@ export default function Listen() {
           {!isMobile && <div className="flex flex-col items-center gap-1.5">
             <MusicNerdLoadingOrchestrator
               aiLoading={aiLoading}
+              aiError={aiError}
               hasNuggets={trackNuggets.length > 0}
               shortId={shortId}
               trackId={trackId}
@@ -1647,6 +1648,7 @@ export default function Listen() {
         <div className="fixed top-3 right-3 z-[60]" style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}>
           <MusicNerdLoadingOrchestrator
             aiLoading={aiLoading}
+            aiError={aiError}
             hasNuggets={trackNuggets.length > 0}
             shortId={shortId}
             trackId={trackId}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -49,7 +49,7 @@ export default function Listen() {
   const realTrackMeta = useMemo(() => {
     // Demo track lookup (e.g. "demo-weird-fishes")
     const demo = rawTrackId ? getDemoTrackById(rawTrackId) : null;
-    if (demo) return { artist: demo.artist, title: demo.title, album: demo.album, spotifyUri: demo.spotifyUri };
+    if (demo) return { artist: demo.artist, title: demo.title, album: demo.album, trackUri: demo.trackUri };
 
     if (!rawTrackId?.startsWith("real%3A%3A") && !rawTrackId?.startsWith("real::")) return null;
     const decoded = decodeURIComponent(rawTrackId);
@@ -58,7 +58,7 @@ export default function Listen() {
       artist: decodeURIComponent(parts[1] || ""),
       title: decodeURIComponent(parts[2] || ""),
       album: decodeURIComponent(parts[3] || "") || undefined,
-      spotifyUri: decodeURIComponent(parts[4] || "") || undefined,
+      trackUri: decodeURIComponent(parts[4] || "") || undefined,
     };
   }, [rawTrackId]);
 
@@ -103,15 +103,15 @@ export default function Listen() {
 
   // ── Playback source resolution ───────────────────────────────────────
   const { hasSpotifyToken } = useSpotifyToken();
-  const [spotifyUri, setSpotifyUri] = useState<string | null>(null);
+  const [trackUri, setTrackUri] = useState<string | null>(null);
 
   // Resolve Spotify URI — from route (real tracks) or by searching Spotify
   useEffect(() => {
-    setSpotifyUri(null);
+    setTrackUri(null);
 
     // Real track with URI baked into the route
-    if (realTrackMeta?.spotifyUri) {
-      setSpotifyUri(realTrackMeta.spotifyUri);
+    if (realTrackMeta?.trackUri) {
+      setTrackUri(realTrackMeta.trackUri);
       return;
     }
 
@@ -161,7 +161,7 @@ export default function Listen() {
 
         if (match?.uri) {
           console.log(`[Listen] Spotify match: "${match.artist} - ${match.title}" for "${track!.artist} - ${track!.title}"`);
-          setSpotifyUri(match.uri);
+          setTrackUri(match.uri);
         } else {
           console.warn(`[Listen] No Spotify match for "${track!.artist} - ${track!.title}"`);
         }
@@ -171,7 +171,7 @@ export default function Listen() {
     }
     findSpotifyUri();
     return () => { cancelled = true; };
-  }, [hasSpotifyToken, realTrackMeta?.spotifyUri, track?.artist, track?.title]);
+  }, [hasSpotifyToken, realTrackMeta?.trackUri, track?.artist, track?.title]);
 
   const [shuffleOn, setShuffleOn] = useState(false); // kept for PlaybackBar UI only
   const isMobile = useIsMobile();
@@ -286,7 +286,7 @@ export default function Listen() {
           });
           if (albumData?.tracks?.length) {
             const currentIdx = albumData.tracks.findIndex(
-              (t: any) => t.uri === spotifyUri
+              (t: any) => t.uri === trackUri
             );
             if (currentIdx >= 0 && currentIdx < albumData.tracks.length - 1) {
               const next = albumData.tracks[currentIdx + 1];
@@ -300,9 +300,9 @@ export default function Listen() {
       }
 
       // P2: Spotify Recommendations (taste-weighted — prefer user's top artists)
-      if (spotifyUri) {
+      if (trackUri) {
         const { data: recData } = await supabase.functions.invoke("spotify-search", {
-          body: { recommend: spotifyUri },
+          body: { recommend: trackUri },
         });
         const recs = ((recData?.tracks || []) as SpotifyTrackResult[]).filter(
           (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
@@ -346,7 +346,7 @@ export default function Listen() {
       const demos = DEMO_TRACKS.filter((d) => notPlayed(d.artist, d.title));
       if (demos.length > 0) {
         const pick = demos[Math.floor(Math.random() * demos.length)];
-        navigateTo({ artist: pick.artist, title: pick.title, album: pick.album, uri: pick.spotifyUri });
+        navigateTo({ artist: pick.artist, title: pick.title, album: pick.album, uri: pick.trackUri });
         return;
       }
 
@@ -358,7 +358,7 @@ export default function Listen() {
       isNavigatingRef.current = false;
       setSkipLoading(false);
     }
-  }, [track, spotifyUri, navigate, player, profile]);
+  }, [track, trackUri, navigate, player, profile]);
 
   const handlePrev = useCallback(() => {
     isNavigatingRef.current = true;
@@ -473,8 +473,8 @@ export default function Listen() {
   }, [setExternalListenMode]);
 
   // Navigate when Spotify plays a different track (e.g. user changed song on phone).
-  // IMPORTANT: Only depend on spotifyStateTrack changes, NOT player.currentSpotifyUri.
-  // Otherwise loadTrack (which sets currentSpotifyUri) causes the effect to fire while
+  // IMPORTANT: Only depend on spotifyStateTrack changes, NOT player.currentTrackUri.
+  // Otherwise loadTrack (which sets currentTrackUri) causes the effect to fire while
   // the SDK still reports the OLD track, creating a false "external skip" → bounce loop.
   // Also require isPlaying — when loadTrack pauses the old track, the SDK fires a state
   // change for the OLD track (paused). Without the isPlaying guard, this is misinterpreted
@@ -483,13 +483,13 @@ export default function Listen() {
     if (!spotifyStateTrack) return;
     if (isNavigatingRef.current) return;
     if (!isPlaying) return;
-    if (!player.currentSpotifyUri) return;
+    if (!player.currentTrackUri) return;
     // Suppress during the brief window after a track load where the SDK still
     // reports the OLD track — prevents false redirect back to the previous track.
     if (Date.now() - trackLoadTimestampRef.current < 2000) return;
-    if (spotifyStateTrack.spotifyUri === player.currentSpotifyUri) return;
+    if (spotifyStateTrack.spotifyUri === player.currentTrackUri) return;
     // Also skip if the SDK is reporting what we're about to load (route resolved but loadTrack pending)
-    if (spotifyUri && spotifyStateTrack.spotifyUri === spotifyUri) return;
+    if (trackUri && spotifyStateTrack.spotifyUri === trackUri) return;
     console.log(`[Listen] Spotify track changed externally: "${spotifyStateTrack.artist} - ${spotifyStateTrack.title}"`);
     isNavigatingRef.current = true;
     const newRoute = `/listen/real::${encodeURIComponent(spotifyStateTrack.artist)}::${encodeURIComponent(spotifyStateTrack.title)}::${encodeURIComponent(spotifyStateTrack.album)}::${encodeURIComponent(spotifyStateTrack.spotifyUri)}`;
@@ -508,28 +508,28 @@ export default function Listen() {
       artist: track.artist,
       coverArtUrl: effectiveCoverArt,
       album: track.album,
-      spotifyUri: spotifyUri || undefined,
+      trackUri: trackUri || undefined,
     });
-  }, [track?.title, track?.artist, trackId, spotifyUri, effectiveCoverArt]);
+  }, [track?.title, track?.artist, trackId, trackUri, effectiveCoverArt]);
 
   // Load track into global player when sources resolve
   // Skip if the same track is already playing (e.g. returning from Browse via mini-player)
   useEffect(() => {
     if (isExternalListenMode) return;
-    if (!spotifyUri) return;
-    if (player.currentSpotifyUri === spotifyUri) return;
-    if (lastLoadedTrackRef.current === spotifyUri) return;
-    lastLoadedTrackRef.current = spotifyUri;
+    if (!trackUri) return;
+    if (player.currentTrackUri === trackUri) return;
+    if (lastLoadedTrackRef.current === trackUri) return;
+    lastLoadedTrackRef.current = trackUri;
 
     // If the SDK is already playing this track (external skip on Spotify),
     // just sync state — don't pause and restart playback.
-    if (spotifyStateTrack?.spotifyUri === spotifyUri) {
-      player.syncExternalTrack(spotifyUri);
+    if (spotifyStateTrack?.spotifyUri === trackUri) {
+      player.syncExternalTrack(trackUri);
       return;
     }
 
-    player.loadTrack({ spotifyUri });
-  }, [spotifyUri, isExternalListenMode]);
+    player.loadTrack({ trackUri });
+  }, [trackUri, isExternalListenMode]);
 
   const play = player.play;
   const seek = player.seek;
@@ -989,12 +989,12 @@ export default function Listen() {
   }, [activeNugget, clearDwell]);
 
   // Auto-resume only after the correct track has been loaded into the SDK.
-  // Without the spotifyUri guard, this fires on mount and resumes the PREVIOUS
+  // Without the trackUri guard, this fires on mount and resumes the PREVIOUS
   // track (still in the SDK) before loadTrack has a chance to swap it out.
   // Skip during the brief window after a track load — let PlayerContext's
   // autoplay effect handle it via the Spotify API to avoid resuming the old track.
   useEffect(() => {
-    if (!isExternalListenMode && spotifyUri && player.currentSpotifyUri === spotifyUri) {
+    if (!isExternalListenMode && trackUri && player.currentTrackUri === trackUri) {
       // 2s guard: after a fresh track load, let PlayerContext's autoplay
       // handle playback via the Spotify API. Calling resume() too early
       // would briefly play the OLD track. On very slow SDK loads (>2s)
@@ -1004,7 +1004,7 @@ export default function Listen() {
       if (Date.now() - trackLoadTimestampRef.current < 2000) return;
       play();
     }
-  }, [play, isExternalListenMode, spotifyUri, player.currentSpotifyUri]);
+  }, [play, isExternalListenMode, trackUri, player.currentTrackUri]);
 
   useEffect(() => {
     if (trackNuggets.length === 0) return;
@@ -1304,7 +1304,7 @@ export default function Listen() {
         </motion.div>
 
         {/* Spotify URI resolving indicator */}
-        {hasSpotifyToken && !spotifyUri && !isExternalListenMode && (
+        {hasSpotifyToken && !trackUri && !isExternalListenMode && (
           <motion.p
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -1315,7 +1315,7 @@ export default function Listen() {
         )}
 
         {/* Spotify session expired — reconnect prompt */}
-        {!hasSpotifyToken && spotifyUri && (
+        {!hasSpotifyToken && trackUri && (
           <motion.div
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -1557,7 +1557,7 @@ export default function Listen() {
                 setRegenerateKey(0);
               }}
               activePlayer={activePlayer}
-              spotifyUri={spotifyUri}
+              trackUri={trackUri}
               onIncrementListen={async () => {
                 if (!track) return;
                 const trackKey = `${track.artist}::${track.title}`;

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1085,15 +1085,23 @@ export default function Listen() {
     });
   }, [seek, trackNuggets]);
 
-  // Nugget trigger logic — fires on playback tick
+  // Nugget trigger logic — fires on playback tick or when new nuggets arrive.
+  // For fresh SSE generation (!aiFromCache), nuggets show immediately as they
+  // stream in. For cached tracks, they show at their timestamp markers.
   useEffect(() => {
-    if (!isPlaying || !nerdActive) return;
+    if (!nerdActive) return;
+    // Cached tracks: require playback to reach the timestamp
+    // Fresh generation: show as soon as the nugget arrives from SSE
+    const shouldTrigger = (n: typeof trackNuggets[0]) =>
+      !aiFromCache || currentTime >= n.timestampSec;
+
+    if (!isPlaying && aiFromCache) return; // cached: wait for playback
+
     for (const n of trackNuggets) {
       if (shownNuggetIds.has(n.id)) continue;
-      if (currentTime >= n.timestampSec) {
+      if (shouldTrigger(n)) {
         if (activeNugget) {
           if (reopenedNuggetId) {
-            // Immediately swap: dismiss reopened nugget, show new one
             setDismissedNuggets((prev) => new Map(prev).set(activeNugget.id, activeNugget));
             setActiveNugget(n);
             setReopenedNuggetId(null);
@@ -1108,7 +1116,7 @@ export default function Listen() {
         }
       }
     }
-  }, [currentTime, isPlaying, nerdActive, trackNuggets, activeNugget, shownNuggetIds, reopenedNuggetId]);
+  }, [currentTime, isPlaying, nerdActive, trackNuggets, activeNugget, shownNuggetIds, reopenedNuggetId, aiFromCache]);
 
   // Auto-dismiss nugget: quick swap if queued, otherwise fade after 8s
   useEffect(() => {
@@ -1254,6 +1262,7 @@ export default function Listen() {
           {!isMobile && <div className="flex flex-col items-center gap-1.5">
             <MusicNerdLoadingOrchestrator
               aiLoading={aiLoading}
+              hasNuggets={trackNuggets.length > 0}
               shortId={shortId}
               trackId={trackId}
               tier={tier}
@@ -1638,6 +1647,7 @@ export default function Listen() {
         <div className="fixed top-3 right-3 z-[60]" style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}>
           <MusicNerdLoadingOrchestrator
             aiLoading={aiLoading}
+            hasNuggets={trackNuggets.length > 0}
             shortId={shortId}
             trackId={trackId}
             tier={tier}

--- a/src/test/SpotifyPlaybackEngine.test.ts
+++ b/src/test/SpotifyPlaybackEngine.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture listeners registered by the Spotify Player
+const listeners = new Map<string, Function>();
+const mockPlayer = {
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  seek: vi.fn(),
+  getCurrentState: vi.fn().mockResolvedValue(null),
+  addListener: vi.fn((event: string, cb: Function) => {
+    listeners.set(event, cb);
+  }),
+};
+
+// Mock Spotify global + SDK script load
+vi.stubGlobal("Spotify", {
+  Player: vi.fn().mockImplementation(() => mockPlayer),
+});
+
+// The SDK loader appends a script tag and waits for onSpotifyWebPlaybackSDKReady.
+// Fire it synchronously so init() resolves immediately in tests.
+const originalCreateElement = document.createElement.bind(document);
+vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+  const el = originalCreateElement(tag);
+  if (tag === "script") {
+    // When the script is appended, immediately fire the SDK ready callback
+    const origAppend = document.head.appendChild.bind(document.head);
+    vi.spyOn(document.head, "appendChild").mockImplementationOnce((node) => {
+      const result = origAppend(node);
+      // Fire the global callback that the SDK loader is waiting for
+      (window as any).onSpotifyWebPlaybackSDKReady?.();
+      return result;
+    });
+  }
+  return el;
+});
+
+import { SpotifyPlaybackEngine } from "@/lib/engines/SpotifyPlaybackEngine";
+
+describe("SpotifyPlaybackEngine", () => {
+  let engine: SpotifyPlaybackEngine;
+  const onReady = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listeners.clear();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+
+    engine = new SpotifyPlaybackEngine({
+      getOAuthToken: vi.fn().mockResolvedValue("fake-token"),
+      onReady,
+    });
+  });
+
+  it("auto-plays a pending URI when onReady fires after loadTrack", async () => {
+    await engine.init();
+
+    // SDK is connected but "ready" event hasn't fired yet
+    expect(engine.ready).toBe(false);
+
+    // loadTrack before ready — stores URI but doesn't call autoPlay
+    await engine.loadTrack("spotify:track:abc123");
+    expect(fetch).not.toHaveBeenCalled();
+
+    // Simulate the SDK "ready" event
+    const readyCb = listeners.get("ready");
+    expect(readyCb).toBeDefined();
+    readyCb!({ device_id: "device-1" });
+
+    // Give the async autoPlay a tick to resolve
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(engine.ready).toBe(true);
+    expect(onReady).toHaveBeenCalledWith("device-1");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("api.spotify.com/v1/me/player/play"),
+      expect.objectContaining({
+        body: expect.stringContaining("spotify:track:abc123"),
+      })
+    );
+  });
+});

--- a/src/test/SpotifyPlaybackEngine.test.ts
+++ b/src/test/SpotifyPlaybackEngine.test.ts
@@ -37,7 +37,7 @@ vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
   return el;
 });
 
-import { SpotifyPlaybackEngine } from "@/lib/engines/SpotifyPlaybackEngine";
+import { SpotifyPlaybackEngine, _resetSdkStateForTests } from "@/lib/engines/SpotifyPlaybackEngine";
 
 describe("SpotifyPlaybackEngine", () => {
   let engine: SpotifyPlaybackEngine;
@@ -46,6 +46,7 @@ describe("SpotifyPlaybackEngine", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listeners.clear();
+    _resetSdkStateForTests();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
 
     engine = new SpotifyPlaybackEngine({

--- a/supabase/functions/_shared/spotify-token.ts
+++ b/supabase/functions/_shared/spotify-token.ts
@@ -1,0 +1,37 @@
+// Shared Spotify Client Credentials token management.
+// Import as: import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+/** Get a Spotify app token via Client Credentials flow. Cached in-memory with 5-min early expiry. */
+export async function getSpotifyAppToken(): Promise<string> {
+  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
+
+  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
+  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
+  if (!clientId || !clientSecret) throw new Error("Missing Spotify credentials");
+
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+    },
+    body: "grant_type=client_credentials",
+  });
+
+  if (!res.ok) throw new Error(`Spotify token request failed: ${res.status}`);
+
+  const data = await res.json();
+  cachedToken = data.access_token;
+  // Expire 5 minutes early to avoid edge cases
+  tokenExpiresAt = Date.now() + (data.expires_in - 300) * 1000;
+  return cachedToken!;
+}
+
+/** Clear the cached token (e.g. on 401 to force re-auth). */
+export function clearSpotifyAppToken(): void {
+  cachedToken = null;
+  tokenExpiresAt = 0;
+}

--- a/supabase/functions/_shared/spotify-token.ts
+++ b/supabase/functions/_shared/spotify-token.ts
@@ -1,5 +1,11 @@
 // Shared Spotify Client Credentials token management.
 // Import as: import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+//
+// The token is cached at module level. Each Supabase edge function runs in its
+// own Deno V8 isolate, so the cache only persists for warm requests within the
+// same isolate — it won't be shared across cold starts or parallel instances.
+// Concurrent cold-start requests may both fetch a token; the second write
+// clobbers the first harmlessly.
 
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1308,6 +1308,19 @@ function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { vali
   let hallucinatedSourceCount = 0;
   for (let i = 0; i < nuggets.length; i++) {
     const n = nuggets[i];
+    // Empty headline — generate one from the first sentence of text
+    if (!n.headline?.trim() && n.text?.trim()) {
+      const firstSentence = n.text.split(/[.!?]/)[0]?.trim();
+      if (firstSentence && firstSentence.length > 10) {
+        n.headline = firstSentence.length > 80
+          ? firstSentence.slice(0, 77) + "..."
+          : firstSentence;
+        console.log(`[Validator] Generated headline for nugget ${i} from text: "${n.headline}"`);
+      }
+    }
+    if (!n.headline?.trim()) {
+      issues.push(`Nugget ${i} (${n.kind}): empty headline`);
+    }
     const allText = `${n.headline} ${n.text}`.toLowerCase();
     for (const banned of BANNED_PHRASES) {
       if (allText.includes(banned.toLowerCase())) {
@@ -2714,9 +2727,18 @@ Return ONLY valid JSON:
 
     function assembleNugget(n: any, i: number) {
       const source = n.source || {};
+      let headline = stripCitMarkers(n.headline || "");
+      const text = stripCitMarkers(n.text || "");
+      // Last-resort headline: first sentence of the body text
+      if (!headline && text) {
+        const first = text.split(/[.!?]/)[0]?.trim();
+        headline = first && first.length > 10
+          ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
+          : text.slice(0, 80);
+      }
       const result: any = {
-        headline: stripCitMarkers(n.headline || ""),
-        text: stripCitMarkers(n.text || ""),
+        headline,
+        text,
         kind: n.kind,
         listenFor: n.listenFor,
         source: {

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1283,6 +1283,16 @@ Return ONLY valid JSON:
 }
 
 // ── Nugget Quality Validator ───────────────────────────────────────────
+// ── Shared headline generator — used by both validator and assembler ──
+function generateHeadlineFromText(text: string): string {
+  if (!text) return "";
+  const first = text.split(/[.!?]/)[0]?.trim();
+  if (first && first.length > 10) {
+    return first.length > 80 ? first.slice(0, 77) + "..." : first;
+  }
+  return text.slice(0, 80);
+}
+
 // Agent 3: Code-level check for banned words, vague headlines, structure.
 const BANNED_PHRASES = [
   "likely", "suggests", "implies", "might conjure", "could be", "possibly", "perhaps",
@@ -1310,13 +1320,8 @@ function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { vali
     const n = nuggets[i];
     // Empty headline — generate one from the first sentence of text
     if (!n.headline?.trim() && n.text?.trim()) {
-      const firstSentence = n.text.split(/[.!?]/)[0]?.trim();
-      if (firstSentence && firstSentence.length > 10) {
-        n.headline = firstSentence.length > 80
-          ? firstSentence.slice(0, 77) + "..."
-          : firstSentence;
-        console.log(`[Validator] Generated headline for nugget ${i} from text: "${n.headline}"`);
-      }
+      n.headline = generateHeadlineFromText(n.text);
+      if (n.headline) console.log(`[Validator] Generated headline for nugget ${i} from text: "${n.headline}"`);
     }
     if (!n.headline?.trim()) {
       issues.push(`Nugget ${i} (${n.kind}): empty headline`);
@@ -2729,12 +2734,9 @@ Return ONLY valid JSON:
       const source = n.source || {};
       let headline = stripCitMarkers(n.headline || "");
       const text = stripCitMarkers(n.text || "");
-      // Last-resort headline: first sentence of the body text
+      // Last-resort headline from body text (same logic as validator)
       if (!headline && text) {
-        const first = text.split(/[.!?]/)[0]?.trim();
-        headline = first && first.length > 10
-          ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
-          : text.slice(0, 80);
+        headline = generateHeadlineFromText(text);
       }
       const result: any = {
         headline,

--- a/supabase/functions/spotify-album/index.ts
+++ b/supabase/functions/spotify-album/index.ts
@@ -1,39 +1,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
-
-// In-memory token cache. Concurrent cold-start requests may both fetch a token;
-// the second write clobbers the first harmlessly (both tokens are valid).
-let cachedToken: string | null = null;
-let tokenExpiresAt = 0;
-
-async function getAppToken(): Promise<string> {
-  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
-
-  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
-  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
-  if (!clientId || !clientSecret) throw new Error("Missing Spotify credentials");
-
-  const res = await fetch("https://accounts.spotify.com/api/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-    },
-    body: "grant_type=client_credentials",
-  });
-
-  if (!res.ok) throw new Error(`Spotify token request failed: ${res.status}`);
-
-  const data = await res.json();
-  cachedToken = data.access_token;
-  tokenExpiresAt = Date.now() + (data.expires_in - 300) * 1000;
-  return cachedToken!;
-}
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -59,7 +31,7 @@ serve(async (req) => {
     }
     const safeMarket = (typeof market === "string" && /^[A-Z]{2}$/.test(market)) ? market : "US";
 
-    const token = await getAppToken();
+    const token = await getSpotifyAppToken();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
     const res = await fetch(`https://api.spotify.com/v1/albums/${albumId}?market=${safeMarket}`, {

--- a/supabase/functions/spotify-album/index.ts
+++ b/supabase/functions/spotify-album/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+import { getSpotifyAppToken, clearSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -31,14 +31,23 @@ serve(async (req) => {
     }
     const safeMarket = (typeof market === "string" && /^[A-Z]{2}$/.test(market)) ? market : "US";
 
-    const token = await getSpotifyAppToken();
+    let token = await getSpotifyAppToken();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
-    const res = await fetch(`https://api.spotify.com/v1/albums/${albumId}?market=${safeMarket}`, {
+    let res = await fetch(`https://api.spotify.com/v1/albums/${albumId}?market=${safeMarket}`, {
       headers: { Authorization: `Bearer ${token}` },
       signal: controller.signal,
     });
     clearTimeout(timeout);
+
+    // Retry once on 401 (stale token in shared cache)
+    if (res.status === 401) {
+      clearSpotifyAppToken();
+      token = await getSpotifyAppToken();
+      res = await fetch(`https://api.spotify.com/v1/albums/${albumId}?market=${safeMarket}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    }
 
     if (!res.ok) {
       console.error(`[spotify-album] Spotify API error: ${res.status} for albumId=${albumId}`);

--- a/supabase/functions/spotify-artist/index.ts
+++ b/supabase/functions/spotify-artist/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { CACHE_TTL_MS } from "../_shared/config.ts";
-import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+import { getSpotifyAppToken, clearSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -87,9 +87,17 @@ Be factual and vivid. No hedging ("is known for", "is considered"). No markdown.
 }
 
 async function spotifyGet(path: string, token: string) {
-  const res = await fetch(`https://api.spotify.com/v1${path}`, {
+  let res = await fetch(`https://api.spotify.com/v1${path}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
+  // Retry once on 401 (stale token in shared cache)
+  if (res.status === 401) {
+    clearSpotifyAppToken();
+    const freshToken = await getSpotifyAppToken();
+    res = await fetch(`https://api.spotify.com/v1${path}`, {
+      headers: { Authorization: `Bearer ${freshToken}` },
+    });
+  }
   if (!res.ok) return null;
   return res.json();
 }

--- a/supabase/functions/spotify-artist/index.ts
+++ b/supabase/functions/spotify-artist/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { CACHE_TTL_MS } from "../_shared/config.ts";
+import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -12,34 +13,6 @@ function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
   const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   return createClient(url, key);
-}
-
-// Reuse the same Client Credentials flow as spotify-search
-let cachedToken: string | null = null;
-let tokenExpiresAt = 0;
-
-async function getAppToken(): Promise<string> {
-  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
-
-  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
-  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
-  if (!clientId || !clientSecret) throw new Error("Missing Spotify credentials");
-
-  const res = await fetch("https://accounts.spotify.com/api/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-    },
-    body: "grant_type=client_credentials",
-  });
-
-  if (!res.ok) throw new Error(`Spotify token request failed: ${res.status}`);
-
-  const data = await res.json();
-  cachedToken = data.access_token;
-  tokenExpiresAt = Date.now() + (data.expires_in - 300) * 1000;
-  return cachedToken!;
 }
 
 async function generateArtistBio(
@@ -158,7 +131,7 @@ serve(async (req) => {
       }
     }
 
-    const token = await getAppToken();
+    const token = await getSpotifyAppToken();
 
     let artist: any;
     let artistId: string;

--- a/supabase/functions/spotify-resolve/index.ts
+++ b/supabase/functions/spotify-resolve/index.ts
@@ -21,7 +21,7 @@ serve(async (req) => {
       );
     }
 
-    let token = await getSpotifyAppToken();
+    const token = await getSpotifyAppToken();
     const batch = artists.slice(0, 20);
 
     const results = await Promise.allSettled(
@@ -31,13 +31,14 @@ serve(async (req) => {
           `https://api.spotify.com/v1/search?type=artist&limit=5&q=${q}`,
           { headers: { Authorization: `Bearer ${token}` } }
         );
-        // Retry once on 401 (stale shared token cache)
+        // Retry once on 401 — read fresh token locally to avoid racing
+        // with other concurrent requests that may also be retrying.
         if (res.status === 401) {
           clearSpotifyAppToken();
-          token = await getSpotifyAppToken();
+          const freshToken = await getSpotifyAppToken();
           res = await fetch(
             `https://api.spotify.com/v1/search?type=artist&limit=5&q=${q}`,
-            { headers: { Authorization: `Bearer ${token}` } }
+            { headers: { Authorization: `Bearer ${freshToken}` } }
           );
         }
         if (!res.ok) return { name, id: null, imageUrl: null };

--- a/supabase/functions/spotify-resolve/index.ts
+++ b/supabase/functions/spotify-resolve/index.ts
@@ -1,37 +1,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
-
-let cachedToken: string | null = null;
-let tokenExpiresAt = 0;
-
-async function getAppToken(): Promise<string> {
-  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
-
-  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
-  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
-  if (!clientId || !clientSecret) throw new Error("Missing Spotify credentials");
-
-  const res = await fetch("https://accounts.spotify.com/api/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-    },
-    body: "grant_type=client_credentials",
-  });
-
-  if (!res.ok) throw new Error(`Spotify token request failed: ${res.status}`);
-
-  const data = await res.json();
-  cachedToken = data.access_token;
-  tokenExpiresAt = Date.now() + (data.expires_in - 300) * 1000;
-  return cachedToken!;
-}
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -47,7 +21,7 @@ serve(async (req) => {
       );
     }
 
-    const token = await getAppToken();
+    const token = await getSpotifyAppToken();
     const batch = artists.slice(0, 20);
 
     const results = await Promise.allSettled(

--- a/supabase/functions/spotify-resolve/index.ts
+++ b/supabase/functions/spotify-resolve/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+import { getSpotifyAppToken, clearSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -21,16 +21,25 @@ serve(async (req) => {
       );
     }
 
-    const token = await getSpotifyAppToken();
+    let token = await getSpotifyAppToken();
     const batch = artists.slice(0, 20);
 
     const results = await Promise.allSettled(
       batch.map(async (name: string) => {
         const q = encodeURIComponent(name.trim());
-        const res = await fetch(
+        let res = await fetch(
           `https://api.spotify.com/v1/search?type=artist&limit=5&q=${q}`,
           { headers: { Authorization: `Bearer ${token}` } }
         );
+        // Retry once on 401 (stale shared token cache)
+        if (res.status === 401) {
+          clearSpotifyAppToken();
+          token = await getSpotifyAppToken();
+          res = await fetch(
+            `https://api.spotify.com/v1/search?type=artist&limit=5&q=${q}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+        }
         if (!res.ok) return { name, id: null, imageUrl: null };
         const data = await res.json();
         const candidates = data.artists?.items || [];

--- a/supabase/functions/spotify-search/index.ts
+++ b/supabase/functions/spotify-search/index.ts
@@ -1,43 +1,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { getSpotifyAppToken, clearSpotifyAppToken } from "../_shared/spotify-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
-
-// In-memory cache for the Client Credentials app token
-let cachedToken: string | null = null;
-let tokenExpiresAt = 0;
-
-async function getAppToken(): Promise<string> {
-  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
-
-  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
-  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
-  if (!clientId || !clientSecret) {
-    throw new Error("Missing Spotify credentials");
-  }
-
-  const res = await fetch("https://accounts.spotify.com/api/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-    },
-    body: "grant_type=client_credentials",
-  });
-
-  if (!res.ok) {
-    throw new Error(`Spotify token request failed: ${res.status}`);
-  }
-
-  const data = await res.json();
-  cachedToken = data.access_token;
-  // Expire 5 minutes early to avoid edge cases
-  tokenExpiresAt = Date.now() + (data.expires_in - 300) * 1000;
-  return cachedToken!;
-}
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -47,7 +15,7 @@ serve(async (req) => {
   try {
     const { query, artist, title, recommend } = await req.json();
 
-    const token = await getAppToken();
+    const token = await getSpotifyAppToken();
 
     // ── Recommendations mode: seed by track ID ──────────────────────
     if (recommend) {
@@ -59,9 +27,8 @@ serve(async (req) => {
       });
       if (!res.ok) {
         if (res.status === 401) {
-          cachedToken = null;
-          tokenExpiresAt = 0;
-          const retryToken = await getAppToken();
+          clearSpotifyAppToken();
+          const retryToken = await getSpotifyAppToken();
           const retryRes = await fetch(url, { headers: { Authorization: `Bearer ${retryToken}` } });
           if (!retryRes.ok) throw new Error(`Spotify recommendations failed: ${retryRes.status}`);
           const retryData = await retryRes.json();
@@ -100,9 +67,8 @@ serve(async (req) => {
 
     if (!res.ok) {
       if (res.status === 401) {
-        cachedToken = null;
-        tokenExpiresAt = 0;
-        const retryToken = await getAppToken();
+        clearSpotifyAppToken();
+        const retryToken = await getSpotifyAppToken();
         const retryRes = await fetch(url, {
           headers: { Authorization: `Bearer ${retryToken}` },
         });


### PR DESCRIPTION
## Summary
Merges staging to main with two PRs since last release:

**PR #27 — Immersive scroll fix + instant nuggets**
- Sticky image hero prevents scroll overlay gap on mobile
- Research pill stays visible until first nugget arrives
- SSE nuggets show immediately as they stream in
- Edge function generates headline from text if Gemini returns empty
- SSE timeout increased to 120s for lesser-known artists

**PR #28 — PlaybackEngine abstraction**
- Extract PlaybackEngine for Apple Music support

## Test plan
- [x] Build passes, 41 tests pass
- [x] Staging backup: `backup/staging-2026-04-05`