### PR TITLE
feat: multi-service DB schema for Apple Music

### DIFF
--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -8,6 +8,14 @@ const PROFILE_KEY = "musicnerd_profile";
 // ── DB profile sync ───────────────────────────────────────────────────────────
 // Accept userId as a param — callers obtain it from AuthContext (no extra getSession() calls).
 
+interface TasteData {
+  topArtists?: string[];
+  topTracks?: string[];
+  artistImages?: Record<string, string>;
+  artistIds?: Record<string, string>;
+  trackImages?: { title: string; artist: string; imageUrl: string }[];
+}
+
 async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   const { data } = await supabase
     .from("profiles")
@@ -17,17 +25,17 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
 
   if (!data) return null;
 
-  // Parse spotify_taste JSONB column into typed arrays.
-  const taste = data.spotify_taste as {
-    topArtists?: string[];
-    topTracks?: string[];
-    artistImages?: Record<string, string>;
-    artistIds?: Record<string, string>;
-    trackImages?: { title: string; artist: string; imageUrl: string }[];
-  } | null;
+  const service = (data.streaming_service as UserProfile["streamingService"]) || "";
+  const serviceKey = service === "Spotify" ? "spotify" : service === "Apple Music" ? "apple" : null;
+
+  // Read taste from music_taste (new, keyed by service) → fall back to spotify_taste (legacy)
+  const musicTaste = data.music_taste as Record<string, TasteData> | null;
+  const taste: TasteData | null =
+    (serviceKey && musicTaste?.[serviceKey]) ||
+    (data.spotify_taste as TasteData | null);
 
   return {
-    streamingService: (data.streaming_service as UserProfile["streamingService"]) || "",
+    streamingService: service,
     lastFmUsername: data.last_fm_username || undefined,
     spotifyTopArtists: taste?.topArtists ?? undefined,
     spotifyTopTracks: taste?.topTracks ?? undefined,
@@ -39,8 +47,8 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
 }
 
 async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
-  // Persist all profile fields including Spotify taste arrays and images.
-  const spotify_taste =
+  // Build taste data from profile fields
+  const tasteData: TasteData | null =
     p.spotifyTopArtists || p.spotifyTopTracks
       ? {
           topArtists: p.spotifyTopArtists ?? [],
@@ -51,13 +59,19 @@ async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
         }
       : null;
 
+  // Determine service key for music_taste JSONB
+  const serviceKey = p.streamingService === "Spotify" ? "spotify"
+    : p.streamingService === "Apple Music" ? "apple" : null;
+
+  // Dual-write: spotify_taste (legacy) + music_taste (new, keyed by service)
   await supabase.from("profiles").upsert(
     {
       user_id: userId,
       tier: p.calculatedTier,
       streaming_service: p.streamingService,
       last_fm_username: p.lastFmUsername || null,
-      spotify_taste,
+      spotify_taste: tasteData,
+      music_taste: serviceKey && tasteData ? { [serviceKey]: tasteData } : null,
     },
     { onConflict: "user_id" }
   );

--- a/supabase/functions/spotify-artist/index.ts
+++ b/supabase/functions/spotify-artist/index.ts
@@ -118,6 +118,7 @@ serve(async (req) => {
         .from("artist_cache")
         .select("data, created_at")
         .eq("artist_id", providedId)
+        .eq("service", "spotify")
         .single();
 
       if (cached && Date.now() - new Date(cached.created_at).getTime() < CACHE_TTL_MS) {
@@ -168,6 +169,7 @@ serve(async (req) => {
         .from("artist_cache")
         .select("data, created_at")
         .eq("artist_id", artistId)
+        .eq("service", "spotify")
         .single();
 
       if (cached && Date.now() - new Date(cached.created_at).getTime() < CACHE_TTL_MS) {
@@ -263,8 +265,15 @@ serve(async (req) => {
     // Write to cache (fire-and-forget — don't block response)
     // Note: concurrent cold-cache requests for the same artist will both generate a bio,
     // but upsert is idempotent so the second write just overwrites with equivalent data.
+    const artistName = result.artist?.name || "";
     db.from("artist_cache")
-      .upsert({ artist_id: artistId, data: result, created_at: new Date().toISOString() })
+      .upsert({
+        artist_id: artistId,
+        service: "spotify",
+        canonical_name: artistName.toLowerCase().trim() || null,
+        data: result,
+        created_at: new Date().toISOString(),
+      })
       .then(({ error }) => { if (error) console.error("[spotify-artist] cache write failed:", error.message); })
       .catch((err) => console.error("[spotify-artist] cache write exception:", err));
 

--- a/supabase/migrations/20260408200000_apple_music_support.sql
+++ b/supabase/migrations/20260408200000_apple_music_support.sql
@@ -1,0 +1,44 @@
+-- Multi-service support: music_taste column + artist_cache composite key
+-- Part of Apple Music integration (Phase 2)
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 1. profiles: add service-agnostic music_taste column
+-- ═══════════════════════════════════════════════════════════════════════
+
+-- New column stores taste data keyed by service:
+--   { "spotify": { topArtists, topTracks, artistImages, artistIds, trackImages } }
+--   { "apple":   { topArtists, topTracks, artistImages, artistIds, trackImages, partial: true } }
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS music_taste JSONB;
+
+-- Backfill existing spotify_taste data into the new structure
+UPDATE public.profiles
+SET music_taste = jsonb_build_object('spotify', spotify_taste)
+WHERE spotify_taste IS NOT NULL
+  AND music_taste IS NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 2. artist_cache: add service column + canonical_name for cross-service bio reuse
+-- ═══════════════════════════════════════════════════════════════════════
+
+-- Service column: same artist can be cached under different IDs per service
+ALTER TABLE public.artist_cache
+  ADD COLUMN IF NOT EXISTS service TEXT NOT NULL DEFAULT 'spotify';
+
+-- Canonical name: lowercase artist name for cross-service lookups
+-- (e.g., reuse Gemini-generated bio from Spotify cache when Apple Music requests same artist)
+ALTER TABLE public.artist_cache
+  ADD COLUMN IF NOT EXISTS canonical_name TEXT;
+
+-- Change primary key from single-column to composite (artist_id, service)
+-- artist_id is only unique within a service
+ALTER TABLE public.artist_cache
+  DROP CONSTRAINT IF EXISTS artist_cache_pkey;
+
+ALTER TABLE public.artist_cache
+  ADD PRIMARY KEY (artist_id, service);
+
+-- Index for cross-service bio lookup by canonical name
+CREATE INDEX IF NOT EXISTS idx_artist_cache_canonical_name
+  ON public.artist_cache (canonical_name)
+  WHERE canonical_name IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds `music_taste` JSONB column to `profiles` table, keyed by service (`{ "spotify": {...} }` or `{ "apple": {...} }`) with backfill from existing `spotify_taste`
- Evolves `artist_cache` to composite PK `(artist_id, service)` with `canonical_name` index for cross-service bio reuse (avoids duplicate Gemini calls)
- Updates `useMusicNerdState` for dual-write (both `spotify_taste` and `music_taste` during migration) and read-from-new-first with fallback
- Updates `spotify-artist` edge function to include `service` and `canonical_name` in cache operations

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 41/41 tests pass
- [ ] Run `supabase db push` to apply migration
- [ ] Manual: Spotify connect + browse still works (taste data loads from new column)
- [ ] Verify backfill: existing profiles have `music_taste = { "spotify": ... }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)