### PR TITLE
fix: PR29 review — onReady, seek state, headline helper

### DIFF
--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -227,18 +227,13 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
     const engine = new SpotifyPlaybackEngine({
       getOAuthToken: getValidToken,
+      onReady: (deviceId) => {
+        setSpReady(true);
+        setSpDeviceId(deviceId);
+      },
       onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
       onDeviceLost: () => setSpPlaying(false),
     });
-
-    // Poll for ready state until engine reports ready
-    const readyPoll = window.setInterval(() => {
-      if (engine.ready) {
-        setSpReady(true);
-        setSpDeviceId(engine.deviceId);
-        clearInterval(readyPoll);
-      }
-    }, 100);
 
     const unsubState = engine.onStateChange((state) => {
       setSpPlaying(state.isPlaying);
@@ -254,7 +249,6 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     engineRef.current = engine;
 
     return () => {
-      clearInterval(readyPoll);
       unsubState();
       unsubEnd();
       engine.cleanup();

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -28,6 +28,10 @@ function loadSpotifySDK(): Promise<void> {
 
 // ── Track info reported by the Spotify SDK ───────────────────────────
 
+// Intentionally uses spotifyUri (not trackUri) — this is the SDK's native
+// Spotify URI format (spotify:track:xxxxx). It equals the service-agnostic
+// trackUri for Spotify tracks but is named distinctly because this type is
+// only populated from the Spotify SDK's player_state_changed event.
 export interface SpotifyStateTrack {
   title: string;
   artist: string;
@@ -41,6 +45,8 @@ export interface SpotifyStateTrack {
 
 export interface SpotifyPlaybackEngineOptions {
   getOAuthToken: () => Promise<string | null>;
+  /** Called when the SDK is ready with the device ID. */
+  onReady?: (deviceId: string) => void;
   /** Called when the SDK reports a new current track (player_state_changed). */
   onSpotifyStateTrack?: (track: SpotifyStateTrack) => void;
   /** Called when another Spotify device takes over playback. */
@@ -60,6 +66,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
   private lastUri: string | null = null;
   private hasPlayed = false;
   private hasAutoPlayed = false;
+  private _isPlaying = false;  // current playing state (not "has ever played")
   private maxPosition = 0;        // ms — highest position reached
   private lastPosition = 0;       // ms — for resume after device loss
   private deviceLost = false;
@@ -71,10 +78,12 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   private getOAuthToken: () => Promise<string | null>;
   private onSpotifyStateTrackCb?: (track: SpotifyStateTrack) => void;
+  private onReadyCb?: (deviceId: string) => void;
   private onDeviceLostCb?: () => void;
 
   constructor(opts: SpotifyPlaybackEngineOptions) {
     this.getOAuthToken = opts.getOAuthToken;
+    this.onReadyCb = opts.onReady;
     this.onSpotifyStateTrackCb = opts.onSpotifyStateTrack;
     this.onDeviceLostCb = opts.onDeviceLost;
   }
@@ -101,6 +110,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
       if (this.cancelled) return;
       this._deviceId = device_id;
       this._ready = true;
+      this.onReadyCb?.(device_id);
     });
 
     player.addListener("not_ready", () => {
@@ -139,6 +149,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.lastUri = null;
     this.hasPlayed = false;
     this.hasAutoPlayed = false;
+    this._isPlaying = false;
     this.maxPosition = 0;
     this.player?.pause();
     this.stopPolling();
@@ -196,8 +207,8 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   async seek(seconds: number): Promise<void> {
     this.player?.seek(seconds * 1000);
-    // Optimistically update time (preserve current playing state)
-    this.emitState({ isPlaying: this.hasPlayed && !this.deviceLost, currentTime: seconds, duration: -1 });
+    // Optimistically update time — use actual playing state, not "has ever played"
+    this.emitState({ isPlaying: this._isPlaying, currentTime: seconds, duration: -1 });
   }
 
   stop(): void {
@@ -268,6 +279,7 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     const currentTime = state.position / 1000;
     const duration = state.duration / 1000;
     const isPlaying = !state.paused;
+    this._isPlaying = isPlaying;
     this.lastPosition = state.position;
 
     this.emitState({ isPlaying, currentTime, duration });

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -13,7 +13,8 @@ export interface PlaybackState {
 export interface PlaybackEngine {
   readonly service: ServiceType;
   readonly ready: boolean;
-  readonly deviceId: string | null;
+  /** Spotify-only: the Web Playback SDK device ID. Other engines return null. */
+  readonly deviceId?: string | null;
 
   init(): Promise<void>;
   cleanup(): void;

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1283,6 +1283,16 @@ Return ONLY valid JSON:
 }
 
 // ── Nugget Quality Validator ───────────────────────────────────────────
+// ── Shared headline generator — used by both validator and assembler ──
+function generateHeadlineFromText(text: string): string {
+  if (!text) return "";
+  const first = text.split(/[.!?]/)[0]?.trim();
+  if (first && first.length > 10) {
+    return first.length > 80 ? first.slice(0, 77) + "..." : first;
+  }
+  return text.slice(0, 80);
+}
+
 // Agent 3: Code-level check for banned words, vague headlines, structure.
 const BANNED_PHRASES = [
   "likely", "suggests", "implies", "might conjure", "could be", "possibly", "perhaps",
@@ -1310,13 +1320,8 @@ function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { vali
     const n = nuggets[i];
     // Empty headline — generate one from the first sentence of text
     if (!n.headline?.trim() && n.text?.trim()) {
-      const firstSentence = n.text.split(/[.!?]/)[0]?.trim();
-      if (firstSentence && firstSentence.length > 10) {
-        n.headline = firstSentence.length > 80
-          ? firstSentence.slice(0, 77) + "..."
-          : firstSentence;
-        console.log(`[Validator] Generated headline for nugget ${i} from text: "${n.headline}"`);
-      }
+      n.headline = generateHeadlineFromText(n.text);
+      if (n.headline) console.log(`[Validator] Generated headline for nugget ${i} from text: "${n.headline}"`);
     }
     if (!n.headline?.trim()) {
       issues.push(`Nugget ${i} (${n.kind}): empty headline`);
@@ -2729,12 +2734,9 @@ Return ONLY valid JSON:
       const source = n.source || {};
       let headline = stripCitMarkers(n.headline || "");
       const text = stripCitMarkers(n.text || "");
-      // Last-resort headline: first sentence of the body text
+      // Last-resort headline from body text (same logic as validator)
       if (!headline && text) {
-        const first = text.split(/[.!?]/)[0]?.trim();
-        headline = first && first.length > 10
-          ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
-          : text.slice(0, 80);
+        headline = generateHeadlineFromText(text);
       }
       const result: any = {
         headline,


### PR DESCRIPTION
## Fixes from PR #29 review

1. **onReady callback** — replace 100ms polling with direct callback from SDK ready event
2. **seek() isPlaying** — use actual `_isPlaying` state, not `hasPlayed` (has-ever-played)
3. **Headline helper** — consolidate duplicate logic into `generateHeadlineFromText()`
4. **deviceId optional** — make it optional on PlaybackEngine interface for Apple Music
5. **spotifyUri comment** — document why it differs from trackUri naming

Build passes, 41 tests pass.