### PR TITLE
feat: research failed state + PR29 review fixes

### DIFF
--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -2,10 +2,11 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
 
-type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready";
+type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready" | "failed";
 
 interface Props {
   aiLoading: boolean;
+  aiError?: string | null;
   hasNuggets?: boolean;
   shortId: string | null;
   trackId: string;
@@ -53,6 +54,7 @@ function setPhaseCached(key: string, value: AnimPhase) {
 
 export default function MusicNerdLoadingOrchestrator({
   aiLoading,
+  aiError,
   hasNuggets = false,
   shortId,
   trackId,
@@ -171,6 +173,20 @@ export default function MusicNerdLoadingOrchestrator({
       setPhaseAndRef("ready");
     }
   }, [aiLoading, phase, setPhaseAndRef]);
+
+  // ── Research failed → show error state, auto-dismiss after 4s ──
+  useEffect(() => {
+    if (aiError && (phase === "pill" || phase === "pulsating" || phase === "hidden")) {
+      clearTimers();
+      setPhaseAndRef("failed");
+    }
+  }, [aiError, phase, clearTimers, setPhaseAndRef]);
+
+  useEffect(() => {
+    if (phase !== "failed") return;
+    const t = setTimeout(() => setPhaseAndRef("hidden"), 4000);
+    return () => clearTimeout(t);
+  }, [phase, setPhaseAndRef]);
 
   // ── Cleanup on unmount ──
   useEffect(() => () => clearTimers(), [clearTimers]);
@@ -296,6 +312,28 @@ export default function MusicNerdLoadingOrchestrator({
             <span className="text-sm font-medium text-foreground/70 whitespace-nowrap select-none">
               MusicNerd is researching
               <AnimatedDots />
+            </span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* ── Failed pill ── */}
+      <AnimatePresence>
+        {phase === "failed" && (
+          <motion.div
+            className="fixed left-1/2 z-50 rounded-full px-4 py-2.5 flex items-center gap-2.5 pointer-events-none will-change-transform bg-black/60 border border-red-500/30"
+            style={{
+              top: "calc(50% + 216px)",
+              translateX: "-50%",
+            }}
+            initial={{ opacity: 0, scale: 0.9, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, transition: { duration: 0.3 } }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+          >
+            <MusicNerdLogo size={18} glow={false} />
+            <span className="text-sm font-medium text-red-400/80 whitespace-nowrap select-none">
+              Research unavailable
             </span>
           </motion.div>
         )}

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -238,7 +238,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     const unsubState = engine.onStateChange((state) => {
       setSpPlaying(state.isPlaying);
       setSpTime(state.currentTime);
-      if (state.duration != null) setSpDuration(state.duration);
+      if (state.duration !== undefined) setSpDuration(state.duration);
     });
 
     const unsubEnd = engine.onTrackEnd(() => {

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1262,6 +1262,7 @@ export default function Listen() {
           {!isMobile && <div className="flex flex-col items-center gap-1.5">
             <MusicNerdLoadingOrchestrator
               aiLoading={aiLoading}
+              aiError={aiError}
               hasNuggets={trackNuggets.length > 0}
               shortId={shortId}
               trackId={trackId}
@@ -1647,6 +1648,7 @@ export default function Listen() {
         <div className="fixed top-3 right-3 z-[60]" style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}>
           <MusicNerdLoadingOrchestrator
             aiLoading={aiLoading}
+            aiError={aiError}
             hasNuggets={trackNuggets.length > 0}
             shortId={shortId}
             trackId={trackId}

--- a/src/test/SpotifyPlaybackEngine.test.ts
+++ b/src/test/SpotifyPlaybackEngine.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture listeners registered by the Spotify Player
+const listeners = new Map<string, Function>();
+const mockPlayer = {
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  seek: vi.fn(),
+  getCurrentState: vi.fn().mockResolvedValue(null),
+  addListener: vi.fn((event: string, cb: Function) => {
+    listeners.set(event, cb);
+  }),
+};
+
+// Mock Spotify global + SDK script load
+vi.stubGlobal("Spotify", {
+  Player: vi.fn().mockImplementation(() => mockPlayer),
+});
+
+// The SDK loader appends a script tag and waits for onSpotifyWebPlaybackSDKReady.
+// Fire it synchronously so init() resolves immediately in tests.
+const originalCreateElement = document.createElement.bind(document);
+vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+  const el = originalCreateElement(tag);
+  if (tag === "script") {
+    // When the script is appended, immediately fire the SDK ready callback
+    const origAppend = document.head.appendChild.bind(document.head);
+    vi.spyOn(document.head, "appendChild").mockImplementationOnce((node) => {
+      const result = origAppend(node);
+      // Fire the global callback that the SDK loader is waiting for
+      (window as any).onSpotifyWebPlaybackSDKReady?.();
+      return result;
+    });
+  }
+  return el;
+});
+
+import { SpotifyPlaybackEngine } from "@/lib/engines/SpotifyPlaybackEngine";
+
+describe("SpotifyPlaybackEngine", () => {
+  let engine: SpotifyPlaybackEngine;
+  const onReady = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listeners.clear();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+
+    engine = new SpotifyPlaybackEngine({
+      getOAuthToken: vi.fn().mockResolvedValue("fake-token"),
+      onReady,
+    });
+  });
+
+  it("auto-plays a pending URI when onReady fires after loadTrack", async () => {
+    await engine.init();
+
+    // SDK is connected but "ready" event hasn't fired yet
+    expect(engine.ready).toBe(false);
+
+    // loadTrack before ready — stores URI but doesn't call autoPlay
+    await engine.loadTrack("spotify:track:abc123");
+    expect(fetch).not.toHaveBeenCalled();
+
+    // Simulate the SDK "ready" event
+    const readyCb = listeners.get("ready");
+    expect(readyCb).toBeDefined();
+    readyCb!({ device_id: "device-1" });
+
+    // Give the async autoPlay a tick to resolve
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(engine.ready).toBe(true);
+    expect(onReady).toHaveBeenCalledWith("device-1");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("api.spotify.com/v1/me/player/play"),
+      expect.objectContaining({
+        body: expect.stringContaining("spotify:track:abc123"),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Research failed pill: red-bordered "Research unavailable" shown when aiError fires, auto-dismisses after 4s
- PR29 review: duration guard consistency (!== undefined), pending-URI autoplay regression test (42 tests passing)

## Test plan
- [ ] Trigger a generation error (e.g. disconnect wifi mid-research) — verify red pill appears and auto-dismisses
- [x] Build passes, 42 tests pass