### PR TITLE
fix: syncUri position, SDK test reset, token cache docs

### DIFF
--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -9,6 +9,15 @@ let sdkLoading = false;
 let sdkReady = false;
 const sdkReadyCallbacks: (() => void)[] = [];
 
+/** Reset module-level SDK state — only for tests. Without this, sdkReady
+ *  stays true after the first test and subsequent init() calls skip the
+ *  SDK load entirely. */
+export function _resetSdkStateForTests(): void {
+  sdkLoading = false;
+  sdkReady = false;
+  sdkReadyCallbacks.length = 0;
+}
+
 function loadSpotifySDK(): Promise<void> {
   if (sdkReady) return Promise.resolve();
   return new Promise((resolve) => {
@@ -216,7 +225,9 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
     this.hasPlayed = true;
     this.hasAutoPlayed = true;
     this._isPlaying = true;
-    this.maxPosition = 0;
+    // Inherit the last known position so end-of-track detection
+    // (maxPosition > 5000) isn't blind for the first few seconds.
+    this.maxPosition = this.lastPosition;
   }
 
   async seek(seconds: number): Promise<void> {

--- a/src/test/SpotifyPlaybackEngine.test.ts
+++ b/src/test/SpotifyPlaybackEngine.test.ts
@@ -37,7 +37,7 @@ vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
   return el;
 });
 
-import { SpotifyPlaybackEngine } from "@/lib/engines/SpotifyPlaybackEngine";
+import { SpotifyPlaybackEngine, _resetSdkStateForTests } from "@/lib/engines/SpotifyPlaybackEngine";
 
 describe("SpotifyPlaybackEngine", () => {
   let engine: SpotifyPlaybackEngine;
@@ -46,6 +46,7 @@ describe("SpotifyPlaybackEngine", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listeners.clear();
+    _resetSdkStateForTests();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
 
     engine = new SpotifyPlaybackEngine({

--- a/supabase/functions/_shared/spotify-token.ts
+++ b/supabase/functions/_shared/spotify-token.ts
@@ -1,5 +1,11 @@
 // Shared Spotify Client Credentials token management.
 // Import as: import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+//
+// The token is cached at module level. Each Supabase edge function runs in its
+// own Deno V8 isolate, so the cache only persists for warm requests within the
+// same isolate — it won't be shared across cold starts or parallel instances.
+// Concurrent cold-start requests may both fetch a token; the second write
+// clobbers the first harmlessly.
 
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;


### PR DESCRIPTION
Fixes #1 and #2 from final review. 42 tests passing.