### PR TITLE
fix: seek updates lastPosition + loadTrack stops engine

### DIFF
--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -266,6 +266,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const loadTrack = useCallback(({ trackUri }: { trackUri?: string }) => {
     if (trackUri && currentTrackUriRef.current === trackUri) return;
 
+    // Stop the engine immediately so the old track doesn't keep polling
+    // or emitting state while the new track's load effect fires later.
+    engineRef.current?.stop();
     hasAutoPlayedRef.current = false;
 
     // Reset UI state

--- a/src/lib/engines/SpotifyPlaybackEngine.ts
+++ b/src/lib/engines/SpotifyPlaybackEngine.ts
@@ -235,6 +235,9 @@ export class SpotifyPlaybackEngine implements PlaybackEngine {
 
   async seek(seconds: number): Promise<void> {
     this.player?.seek(seconds * 1000);
+    // Update lastPosition so play() re-transfer after device loss
+    // resumes at the new seek position, not the pre-seek one.
+    this.lastPosition = seconds * 1000;
     // Optimistically update time — omit duration so subscribers keep current value
     this.emitState({ isPlaying: this._isPlaying, currentTime: seconds });
   }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "htfhnwhtauvflothadlw"
+project_id = "ofuayztvadxtacmsevxk"
 
 [functions.generate-nuggets]
 verify_jwt = false


### PR DESCRIPTION
Fixes from post-merge review of PR #29:

## Bug fixes

1. **`seek()` lastPosition** — `seek()` now updates `this.lastPosition` so that a device-lost re-transfer after a seek resumes at the new position instead of the pre-seek one.

2. **`loadTrack` engine stop** — `PlayerContext.loadTrack` calls `engineRef.current?.stop()` immediately to stop polling and pause the old track, preventing state updates from contradicting the UI reset while the auto-play effect is pending.

## Config change

3. **`supabase/config.toml` project_id** — Updated from `htfhnwhtauvflothadlw` (stale leftover ID, doesn't match the old personal project or the current xdjs project) to `ofuayztvadxtacmsevxk`, which is the new xdjs-org Supabase project we migrated to earlier this week.

   **Why it's intentional:** The database migration from the personal Supabase project to the xdjs-org project was completed separately — all 17 migrations applied, edge functions deployed, secrets set, Spotify OAuth enabled. The `config.toml` file was left pointing to an old project ID that nobody had touched. This change aligns local CLI commands (`supabase functions deploy`, etc.) with the current production project.

   **Runtime impact:** None. `config.toml` only affects local CLI defaults — it's not read by the deployed app or edge functions at runtime. But leaving it wrong would confuse anyone running CLI commands locally without `--project-ref`.