### PR TITLE
feat: Apple Music auth + playback engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ dist-ssr
 .env
 .env.*
 
+# Apple Music private keys (NEVER commit these)
+*.p8
+AuthKey_*.p8
+
 # Scripts with DB credentials
 scripts/fix-caches.sh
 scripts/seed-demo-resumable.sh

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -226,7 +226,15 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   }, []);
 
   // ── Engine init (on profile service change, if token available) ────
-
+  //
+  // Two string namespaces at play here — don't confuse them:
+  //   • profile.streamingService: display label, "Spotify" | "Apple Music" | ""
+  //     (matches the DB `streaming_service` column and onboarding UI)
+  //   • engine.service (ServiceType): kebab-case id, "spotify" | "apple-music" | "none"
+  //     (used for PlayerContext's activePlayer state and engine dispatch)
+  //
+  // Profile strings are translated to engine strings below; engine.service is
+  // used downstream for setActivePlayer and syncExternalTrack guards.
   const service = profile?.streamingService;
 
   useEffect(() => {

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -317,6 +317,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
     // No engine — user hasn't connected a service yet
     return;
+  // getValidToken and getDeveloperToken are intentionally omitted from deps:
+  // both are useCallback([])-stable and re-including them would churn the
+  // effect on every parent re-render, destroying and recreating engines.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [service, hasSpotifyToken, hasMusicToken]);
 

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -272,7 +272,12 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         // Assign ref BEFORE init so the upgrade-to-engine effect can read
         // engineRef.current?.service when spReady flips later.
         engineRef.current = am;
-        am.init();
+        am.init().catch((err) => {
+          console.error("[Player] Apple Music engine init failed:", err);
+          // Prevent a broken engine from poisoning engineRef — downstream
+          // code guards on spReady but this keeps the invariant clean.
+          if (engineRef.current === am) engineRef.current = null;
+        });
       });
 
       return () => {
@@ -309,7 +314,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       // Assign ref BEFORE init so the upgrade-to-engine effect can read
       // engineRef.current?.service when spReady flips later.
       engineRef.current = sp;
-      sp.init();
+      sp.init().catch((err) => {
+        console.error("[Player] Spotify engine init failed:", err);
+        if (engineRef.current === sp) engineRef.current = null;
+      });
 
       return () => {
         unsubState();

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -325,10 +325,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
     // No engine — user hasn't connected a service yet
     return;
-  // getValidToken and getDeveloperToken are intentionally omitted from deps:
-  // both are useCallback([])-stable and re-including them would churn the
-  // effect on every parent re-render, destroying and recreating engines.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- getValidToken and getDeveloperToken are useCallback([])-stable; re-including them would churn the effect on every parent re-render and destroy/recreate engines
   }, [service, hasSpotifyToken, hasMusicToken]);
 
   // ── loadTrack ─────────────────────────────────────────────────────

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -1,8 +1,11 @@
 import { createContext, useContext, useRef, useState, useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { useSpotifyToken } from "@/hooks/useSpotifyToken";
+import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { useCurrentlyPlaying, type ExternalTrack } from "@/hooks/useCurrentlyPlaying";
 import { SpotifyPlaybackEngine, type SpotifyStateTrack } from "@/lib/engines/SpotifyPlaybackEngine";
-import type { ServiceType } from "@/lib/engines/types";
+import { AppleMusicPlaybackEngine } from "@/lib/engines/AppleMusicPlaybackEngine";
+import type { PlaybackEngine, ServiceType } from "@/lib/engines/types";
 import type { Nugget, Source } from "@/mock/types";
 
 // Re-export for consumers that import from PlayerContext
@@ -121,11 +124,13 @@ export function usePlayer(): PlayerContextType {
 
 export function PlayerProvider({ children }: { children: ReactNode }) {
   const { hasSpotifyToken, getValidToken } = useSpotifyToken();
+  const { hasMusicToken, getDeveloperToken } = useAppleMusicToken();
+  const { profile } = useUserProfile();
 
-  // Playback engine ref
-  const engineRef = useRef<SpotifyPlaybackEngine | null>(null);
+  // Playback engine ref (Spotify or Apple Music — selected by profile service)
+  const engineRef = useRef<PlaybackEngine | null>(null);
 
-  // Playback state (driven by engine callbacks)
+  // Playback state (driven by engine callbacks — generic across services)
   const [spReady, setSpReady] = useState(false);
   const [spPlaying, setSpPlaying] = useState(false);
   const [spTime, setSpTime] = useState(0);
@@ -143,10 +148,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const currentTrackUriRef = useRef<string | null>(null);
   currentTrackUriRef.current = currentTrackUri;
 
-  // External playback detection
+  // External playback detection — Spotify-only (Apple Music has no cross-device API)
   const [isExternalListenMode, setIsExternalListenMode] = useState(false);
   const externalTrack = useCurrentlyPlaying({
-    suppressPolling: activePlayer !== "none",
+    suppressPolling: activePlayer !== "none" || profile?.streamingService !== "Spotify",
     ownDeviceId: spDeviceId,
   });
   const setExternalListenMode = useCallback((mode: boolean) => {
@@ -220,44 +225,100 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     return prev;
   }, []);
 
-  // ── Engine init (once, on mount if token available) ────────────────
+  // ── Engine init (on profile service change, if token available) ────
+
+  const service = profile?.streamingService;
 
   useEffect(() => {
-    if (!hasSpotifyToken) return;
+    // Determine which engine to create based on profile service + token.
+    // Apple Music and Spotify are mutually exclusive — only one engine at a time.
 
-    const engine = new SpotifyPlaybackEngine({
-      getOAuthToken: getValidToken,
-      onReady: (deviceId) => {
-        setSpReady(true);
-        setSpDeviceId(deviceId);
-      },
-      onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
-      onDeviceLost: () => setSpPlaying(false),
-    });
+    if (service === "Apple Music" && hasMusicToken) {
+      let cancelled = false;
+      let currentEngine: AppleMusicPlaybackEngine | null = null;
+      let unsubState: (() => void) | null = null;
+      let unsubEnd: (() => void) | null = null;
 
-    const unsubState = engine.onStateChange((state) => {
-      setSpPlaying(state.isPlaying);
-      setSpTime(state.currentTime);
-      // duration is optional on PlaybackState (omitted = "keep current").
-      // Use != null to safely handle both undefined and null.
-      if (state.duration != null) setSpDuration(state.duration);
-    });
+      getDeveloperToken().then((devToken) => {
+        if (cancelled || !devToken) return;
+        const am = new AppleMusicPlaybackEngine({
+          developerToken: devToken,
+          onReady: () => {
+            // Guard against late onReady firing after the effect was cancelled
+            if (cancelled) return;
+            setSpReady(true);
+            setSpDeviceId(null);  // Apple Music has no device ID
+          },
+        });
+        currentEngine = am;
 
-    const unsubEnd = engine.onTrackEnd(() => {
-      onEndedRef.current?.();
-    });
+        unsubState = am.onStateChange((state) => {
+          setSpPlaying(state.isPlaying);
+          setSpTime(state.currentTime);
+          if (state.duration != null) setSpDuration(state.duration);
+        });
+        unsubEnd = am.onTrackEnd(() => {
+          onEndedRef.current?.();
+        });
 
-    engine.init();
-    engineRef.current = engine;
+        // Assign ref BEFORE init so the upgrade-to-engine effect can read
+        // engineRef.current?.service when spReady flips later.
+        engineRef.current = am;
+        am.init();
+      });
 
-    return () => {
-      unsubState();
-      unsubEnd();
-      engine.cleanup();
-      engineRef.current = null;
-    };
+      return () => {
+        cancelled = true;
+        unsubState?.();
+        unsubEnd?.();
+        currentEngine?.cleanup();
+        if (engineRef.current === currentEngine) engineRef.current = null;
+        setSpReady(false);
+        setSpDeviceId(null);
+      };
+    }
+
+    if (service === "Spotify" && hasSpotifyToken) {
+      const sp = new SpotifyPlaybackEngine({
+        getOAuthToken: getValidToken,
+        onReady: (deviceId) => {
+          setSpReady(true);
+          setSpDeviceId(deviceId);
+        },
+        onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
+        onDeviceLost: () => setSpPlaying(false),
+      });
+
+      const unsubState = sp.onStateChange((state) => {
+        setSpPlaying(state.isPlaying);
+        setSpTime(state.currentTime);
+        if (state.duration != null) setSpDuration(state.duration);
+      });
+      const unsubEnd = sp.onTrackEnd(() => {
+        onEndedRef.current?.();
+      });
+
+      // Assign ref BEFORE init so the upgrade-to-engine effect can read
+      // engineRef.current?.service when spReady flips later.
+      engineRef.current = sp;
+      sp.init();
+
+      return () => {
+        unsubState();
+        unsubEnd();
+        sp.cleanup();
+        // Only null the ref if it still points to THIS engine — prevents
+        // clobbering a newer engine created by a rapid service switch.
+        if (engineRef.current === sp) engineRef.current = null;
+        setSpReady(false);
+        setSpDeviceId(null);
+      };
+    }
+
+    // No engine — user hasn't connected a service yet
+    return;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasSpotifyToken]);
+  }, [service, hasSpotifyToken, hasMusicToken]);
 
   // ── loadTrack ─────────────────────────────────────────────────────
 
@@ -276,14 +337,17 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setSpDuration(0);
     setSpPlaying(false);
 
+    const engineService = engineRef.current?.service;
     setCurrentTrackUri(trackUri || null);
-    setActivePlayer(spReady && trackUri ? "spotify" : "none");
+    setActivePlayer(spReady && trackUri && engineService ? engineService : "none");
   }, [spReady]);
 
   /** Sync tracking state to match an externally-changed track.
+   *  Spotify-only — Apple Music has no cross-device detection.
    *  Unlike loadTrack, this does NOT pause or restart playback — the SDK
    *  is already playing the right track. */
   const syncExternalTrack = useCallback((trackUri: string) => {
+    if (engineRef.current?.service !== "spotify") return;
     setCurrentTrackUri(trackUri);
     currentTrackUriRef.current = trackUri;
     hasAutoPlayedRef.current = true;
@@ -293,19 +357,20 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     engineRef.current?.syncUri(trackUri);
   }, []);
 
-  // ── Upgrade to Spotify when SDK becomes ready after loadTrack ─────
+  // ── Upgrade to active engine when SDK becomes ready after loadTrack ─
   useEffect(() => {
-    if (spReady && currentTrackUri && activePlayer !== "spotify") {
-      console.log("[Player] Spotify SDK ready — switching to Spotify");
-      setActivePlayer("spotify");
+    const engineService = engineRef.current?.service;
+    if (spReady && currentTrackUri && engineService && activePlayer !== engineService) {
+      console.log(`[Player] ${engineService} SDK ready — switching`);
+      setActivePlayer(engineService);
       hasAutoPlayedRef.current = false;
     }
   }, [spReady, currentTrackUri, activePlayer]);
 
-  // ── Auto-play when Spotify is active and ready ────────────────────
+  // ── Auto-play when engine is active and ready ─────────────────────
 
   useEffect(() => {
-    if (activePlayer === "spotify" && spReady && currentTrackUri && !hasAutoPlayedRef.current) {
+    if (activePlayer !== "none" && spReady && currentTrackUri && !hasAutoPlayedRef.current) {
       hasAutoPlayedRef.current = true;
       engineRef.current?.loadTrack(currentTrackUri);
     }
@@ -323,8 +388,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
   const toggle = useCallback(() => {
     if (activePlayer === "none") {
-      if (currentTrackUri && spReady) {
-        setActivePlayer("spotify");
+      const engineService = engineRef.current?.service;
+      if (currentTrackUri && spReady && engineService) {
+        setActivePlayer(engineService);
         hasAutoPlayedRef.current = false;
       }
       return;

--- a/src/hooks/useAppleMusicAuth.ts
+++ b/src/hooks/useAppleMusicAuth.ts
@@ -41,7 +41,7 @@ export async function initiateAppleMusicAuth(): Promise<string | null> {
     // 3. Configure MusicKit with the Developer Token
     await window.MusicKit.configure({
       developerToken,
-      app: { name: "MusicNerd TV" },
+      app: { name: "MusicNerd TV", build: "1.0.0" },
     });
 
     const music = window.MusicKit.getInstance();

--- a/src/hooks/useAppleMusicAuth.ts
+++ b/src/hooks/useAppleMusicAuth.ts
@@ -12,7 +12,6 @@
  * revokes access, the app must prompt them to re-authorize.
  */
 
-import { supabase } from "@/integrations/supabase/client";
 import { loadMusicKitSDK } from "@/lib/musickitLoader";
 import { fetchAppleDeveloperToken, saveAppleMusicToken } from "./useAppleMusicToken";
 
@@ -75,24 +74,37 @@ export interface AppleMusicTaste {
   partial?: boolean;   // true = weaker signal than Spotify's user-top-read
 }
 
-export async function fetchAppleMusicTaste(musicUserToken: string): Promise<AppleMusicTaste | null> {
-  const storefront = window.MusicKit?.getInstance?.()?.storefrontCountryCode || "us";
-  const { data, error } = await supabase.functions.invoke("apple-taste", {
-    body: { musicUserToken, storefront },
-  });
+/**
+ * Fetch a taste profile from the user's Apple Music library.
+ *
+ * **NOT YET IMPLEMENTED** — the `apple-taste` edge function is scheduled for
+ * Phase 5. Apple Music has no `/me/top/artists` equivalent, so Phase 5 will
+ * combine `/me/history/heavy-rotation` + `/me/recent/played/tracks` into a
+ * best-effort taste profile (marked `partial: true` in the response).
+ *
+ * Callers will currently receive `null`. When Phase 5 lands, delete this stub
+ * and uncomment the implementation below.
+ */
+export async function fetchAppleMusicTaste(_musicUserToken: string): Promise<AppleMusicTaste | null> {
+  console.warn("[AppleMusic] fetchAppleMusicTaste: apple-taste edge function not yet deployed (Phase 5)");
+  return null;
 
-  if (error || !data) {
-    console.error("[AppleMusic] Taste fetch error:", error);
-    return null;
-  }
-
-  return {
-    topArtists: data.topArtists || [],
-    topTracks: data.topTracks || [],
-    artistImages: data.artistImages || {},
-    artistIds: data.artistIds || {},
-    trackImages: data.trackImages || [],
-    displayName: data.displayName || null,
-    partial: data.partial === true,
-  };
+  // Phase 5 implementation (keep for reference):
+  // const storefront = window.MusicKit?.getInstance?.()?.storefrontCountryCode || "us";
+  // const { data, error } = await supabase.functions.invoke("apple-taste", {
+  //   body: { musicUserToken: _musicUserToken, storefront },
+  // });
+  // if (error || !data) {
+  //   console.error("[AppleMusic] Taste fetch error:", error);
+  //   return null;
+  // }
+  // return {
+  //   topArtists: data.topArtists || [],
+  //   topTracks: data.topTracks || [],
+  //   artistImages: data.artistImages || {},
+  //   artistIds: data.artistIds || {},
+  //   trackImages: data.trackImages || [],
+  //   displayName: data.displayName || null,
+  //   partial: data.partial === true,
+  // };
 }

--- a/src/hooks/useAppleMusicAuth.ts
+++ b/src/hooks/useAppleMusicAuth.ts
@@ -77,34 +77,11 @@ export interface AppleMusicTaste {
 /**
  * Fetch a taste profile from the user's Apple Music library.
  *
- * **NOT YET IMPLEMENTED** — the `apple-taste` edge function is scheduled for
- * Phase 5. Apple Music has no `/me/top/artists` equivalent, so Phase 5 will
- * combine `/me/history/heavy-rotation` + `/me/recent/played/tracks` into a
- * best-effort taste profile (marked `partial: true` in the response).
- *
- * Callers will currently receive `null`. When Phase 5 lands, delete this stub
- * and uncomment the implementation below.
+ * TODO(Phase 5): implement the `apple-taste` edge function. Apple Music has
+ * no `/me/top/artists` equivalent, so Phase 5 will combine `heavy-rotation`
+ * + `recent/played/tracks` into a best-effort profile marked `partial: true`.
  */
 export async function fetchAppleMusicTaste(_musicUserToken: string): Promise<AppleMusicTaste | null> {
   console.warn("[AppleMusic] fetchAppleMusicTaste: apple-taste edge function not yet deployed (Phase 5)");
   return null;
-
-  // Phase 5 implementation (keep for reference):
-  // const storefront = window.MusicKit?.getInstance?.()?.storefrontCountryCode || "us";
-  // const { data, error } = await supabase.functions.invoke("apple-taste", {
-  //   body: { musicUserToken: _musicUserToken, storefront },
-  // });
-  // if (error || !data) {
-  //   console.error("[AppleMusic] Taste fetch error:", error);
-  //   return null;
-  // }
-  // return {
-  //   topArtists: data.topArtists || [],
-  //   topTracks: data.topTracks || [],
-  //   artistImages: data.artistImages || {},
-  //   artistIds: data.artistIds || {},
-  //   trackImages: data.trackImages || [],
-  //   displayName: data.displayName || null,
-  //   partial: data.partial === true,
-  // };
 }

--- a/src/hooks/useAppleMusicAuth.ts
+++ b/src/hooks/useAppleMusicAuth.ts
@@ -1,0 +1,98 @@
+/**
+ * Apple Music authorization via MusicKit JS v3.
+ *
+ * Unlike Spotify's PKCE redirect flow, Apple Music uses a popup:
+ *   1. Fetch Developer Token from our edge function
+ *   2. Load MusicKit JS SDK (lazy singleton)
+ *   3. Configure MusicKit with the Developer Token
+ *   4. Call MusicKit.getInstance().authorize() — shows Apple popup
+ *   5. Returns a Music User Token directly (no redirect, no callback page)
+ *
+ * The Music User Token has no refresh mechanism — if it expires or the user
+ * revokes access, the app must prompt them to re-authorize.
+ */
+
+import { supabase } from "@/integrations/supabase/client";
+import { loadMusicKitSDK } from "@/lib/musickitLoader";
+import { fetchAppleDeveloperToken, saveAppleMusicToken } from "./useAppleMusicToken";
+
+// ── Auth flow ─────────────────────────────────────────────────────────
+
+/**
+ * Kick off Apple Music authorization.
+ * On success, persists tokens to localStorage and returns the Music User Token.
+ * On cancellation or failure, returns null.
+ */
+export async function initiateAppleMusicAuth(): Promise<string | null> {
+  try {
+    // 1. Fetch Developer Token from edge function
+    const developerToken = await fetchAppleDeveloperToken();
+    if (!developerToken) {
+      console.error("[AppleMusic] No developer token — cannot authorize");
+      return null;
+    }
+
+    // 2. Load MusicKit JS
+    await loadMusicKitSDK();
+    if (!window.MusicKit) {
+      console.error("[AppleMusic] MusicKit failed to load");
+      return null;
+    }
+
+    // 3. Configure MusicKit with the Developer Token
+    await window.MusicKit.configure({
+      developerToken,
+      app: { name: "MusicNerd TV" },
+    });
+
+    const music = window.MusicKit.getInstance();
+
+    // 4. Open authorize popup — resolves with Music User Token
+    const musicUserToken = await music.authorize();
+    if (!musicUserToken) {
+      console.warn("[AppleMusic] Authorization cancelled or denied");
+      return null;
+    }
+
+    // 5. Persist tokens
+    saveAppleMusicToken(musicUserToken, developerToken);
+    return musicUserToken;
+  } catch (err) {
+    console.error("[AppleMusic] initiateAppleMusicAuth failed:", err);
+    return null;
+  }
+}
+
+// ── Taste profile fetch (mirrors useSpotifyAuth.fetchSpotifyTaste) ────
+
+export interface AppleMusicTaste {
+  topArtists: string[];
+  topTracks: string[];
+  artistImages: Record<string, string>;
+  artistIds: Record<string, string>;
+  trackImages: { title: string; artist: string; imageUrl: string; uri?: string }[];
+  displayName: string | null;
+  partial?: boolean;   // true = weaker signal than Spotify's user-top-read
+}
+
+export async function fetchAppleMusicTaste(musicUserToken: string): Promise<AppleMusicTaste | null> {
+  const storefront = window.MusicKit?.getInstance?.()?.storefrontCountryCode || "us";
+  const { data, error } = await supabase.functions.invoke("apple-taste", {
+    body: { musicUserToken, storefront },
+  });
+
+  if (error || !data) {
+    console.error("[AppleMusic] Taste fetch error:", error);
+    return null;
+  }
+
+  return {
+    topArtists: data.topArtists || [],
+    topTracks: data.topTracks || [],
+    artistImages: data.artistImages || {},
+    artistIds: data.artistIds || {},
+    trackImages: data.trackImages || [],
+    displayName: data.displayName || null,
+    partial: data.partial === true,
+  };
+}

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -72,26 +72,28 @@ export function saveAppleMusicToken(musicUserToken: string, developerToken: stri
 export function useAppleMusicToken() {
   const [hasMusicToken, setHasMusicToken] = useState(() => !!readToken());
 
-  // Update hasMusicToken when a token is written externally — after the
-  // authorize popup saves via saveAppleMusicToken (same-tab custom event)
-  // or when another tab writes to localStorage (cross-tab storage event).
+  // Sync hasMusicToken with localStorage writes from outside this hook —
+  //  • same tab: saveAppleMusicToken dispatches TOKEN_SAVED_EVENT
+  //  • cross-tab: the native `storage` event fires when localStorage changes
+  //    in another tab (add, update, or remove the key)
   // Event-driven instead of polling so we don't burn CPU forever after
-  // clearToken() if the user never re-authorizes.
+  // clearToken() if the user never re-authorizes, and we correctly reflect
+  // cross-tab clears (tab B logs out → tab A flips to hasMusicToken=false).
   useEffect(() => {
-    if (hasMusicToken) return;
-    const check = () => {
-      if (readToken()) setHasMusicToken(true);
+    const syncFromStorage = () => {
+      const present = !!readToken();
+      setHasMusicToken((prev) => (prev === present ? prev : present));
     };
     const onStorage = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY) check();
+      if (e.key === STORAGE_KEY) syncFromStorage();
     };
     window.addEventListener("storage", onStorage);
-    window.addEventListener(TOKEN_SAVED_EVENT, check);
+    window.addEventListener(TOKEN_SAVED_EVENT, syncFromStorage);
     return () => {
       window.removeEventListener("storage", onStorage);
-      window.removeEventListener(TOKEN_SAVED_EVENT, check);
+      window.removeEventListener(TOKEN_SAVED_EVENT, syncFromStorage);
     };
-  }, [hasMusicToken]);
+  }, []);
 
   /** Return the stored Music User Token, or null if missing. No refresh — MUT is session-scoped. */
   const getMusicUserToken = useCallback((): string | null => {

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -29,19 +29,31 @@ function writeToken(token: StoredToken) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(token));
 }
 
+// In-flight promise dedup — concurrent callers share a single edge function
+// invocation rather than firing N parallel requests.
+let inFlightFetch: Promise<string | null> | null = null;
+
 /** Fetch a fresh Developer Token from the edge function. */
 export async function fetchAppleDeveloperToken(): Promise<string | null> {
-  try {
-    const { data, error } = await supabase.functions.invoke("apple-dev-token", { body: {} });
-    if (error || !data?.token) {
-      console.error("[AppleMusic] Failed to fetch developer token:", error);
+  if (inFlightFetch) return inFlightFetch;
+
+  inFlightFetch = (async () => {
+    try {
+      const { data, error } = await supabase.functions.invoke("apple-dev-token", { body: {} });
+      if (error || !data?.token) {
+        console.error("[AppleMusic] Failed to fetch developer token:", error);
+        return null;
+      }
+      return data.token as string;
+    } catch (err) {
+      console.error("[AppleMusic] Developer token fetch exception:", err);
       return null;
+    } finally {
+      inFlightFetch = null;
     }
-    return data.token as string;
-  } catch (err) {
-    console.error("[AppleMusic] Developer token fetch exception:", err);
-    return null;
-  }
+  })();
+
+  return inFlightFetch;
 }
 
 /** Persist a newly obtained token pair to localStorage. */

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -8,6 +8,7 @@ import { supabase } from "@/integrations/supabase/client";
 //     No refresh mechanism — if expired/revoked, user must re-authorize.
 
 const STORAGE_KEY = "apple_music_token";
+const TOKEN_SAVED_EVENT = "apple-music-token-saved";
 
 interface StoredToken {
   musicUserToken: string;
@@ -62,21 +63,34 @@ export function saveAppleMusicToken(musicUserToken: string, developerToken: stri
   // from the client to reduce staleness risk from key rotations.
   const devTokenExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
   writeToken({ musicUserToken, developerToken, devTokenExpiresAt });
+  // Notify same-tab listeners — the `storage` event only fires cross-tab.
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(TOKEN_SAVED_EVENT));
+  }
 }
 
 export function useAppleMusicToken() {
   const [hasMusicToken, setHasMusicToken] = useState(() => !!readToken());
 
-  // Keep checking until the token appears (covers popup auth storing token after mount).
+  // Update hasMusicToken when a token is written externally — after the
+  // authorize popup saves via saveAppleMusicToken (same-tab custom event)
+  // or when another tab writes to localStorage (cross-tab storage event).
+  // Event-driven instead of polling so we don't burn CPU forever after
+  // clearToken() if the user never re-authorizes.
   useEffect(() => {
     if (hasMusicToken) return;
-    const id = setInterval(() => {
-      if (readToken()) {
-        setHasMusicToken(true);
-        clearInterval(id);
-      }
-    }, 500);
-    return () => clearInterval(id);
+    const check = () => {
+      if (readToken()) setHasMusicToken(true);
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) check();
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(TOKEN_SAVED_EVENT, check);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(TOKEN_SAVED_EVENT, check);
+    };
   }, [hasMusicToken]);
 
   /** Return the stored Music User Token, or null if missing. No refresh — MUT is session-scoped. */

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -40,7 +40,7 @@ export async function fetchAppleDeveloperToken(): Promise<string | null> {
 
   inFlightFetch = (async () => {
     try {
-      const { data, error } = await supabase.functions.invoke("apple-dev-token", { body: {} });
+      const { data, error } = await supabase.functions.invoke("apple-dev-token");
       if (error || !data?.token) {
         console.error("[AppleMusic] Failed to fetch developer token:", error);
         return null;
@@ -112,8 +112,13 @@ export function useAppleMusicToken() {
     const fresh = await fetchAppleDeveloperToken();
     if (!fresh) return null;
 
+    // Only persist when we have a Music User Token to pair it with. In
+    // practice this always runs from PlayerContext after hasMusicToken
+    // flipped true, so `stored` is non-null; this guard is defensive.
+    // If called pre-auth (no stored token yet), the fresh token is
+    // returned unpersisted — the caller gets a working token and the
+    // next authorize() flow will persist the pair via saveAppleMusicToken.
     if (stored) {
-      // Keep existing MUT, refresh the developer token
       writeToken({
         ...stored,
         developerToken: fresh,

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -1,0 +1,104 @@
+import { useCallback, useState, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+// Apple Music uses a two-token system:
+//   - Developer Token: ES256 JWT, generated server-side, 180-day lifetime.
+//     Fetched from our apple-dev-token edge function.
+//   - Music User Token: obtained via MusicKit.authorize() popup.
+//     No refresh mechanism — if expired/revoked, user must re-authorize.
+
+const STORAGE_KEY = "apple_music_token";
+
+interface StoredToken {
+  musicUserToken: string;
+  developerToken: string;
+  devTokenExpiresAt: number;  // ms epoch
+}
+
+function readToken(): StoredToken | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as StoredToken;
+  } catch {
+    return null;
+  }
+}
+
+function writeToken(token: StoredToken) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(token));
+}
+
+/** Fetch a fresh Developer Token from the edge function. */
+export async function fetchAppleDeveloperToken(): Promise<string | null> {
+  try {
+    const { data, error } = await supabase.functions.invoke("apple-dev-token", { body: {} });
+    if (error || !data?.token) {
+      console.error("[AppleMusic] Failed to fetch developer token:", error);
+      return null;
+    }
+    return data.token as string;
+  } catch (err) {
+    console.error("[AppleMusic] Developer token fetch exception:", err);
+    return null;
+  }
+}
+
+/** Persist a newly obtained token pair to localStorage. */
+export function saveAppleMusicToken(musicUserToken: string, developerToken: string): void {
+  // Developer token lifetime is 180 days server-side, but we refetch every 30 days
+  // from the client to reduce staleness risk from key rotations.
+  const devTokenExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
+  writeToken({ musicUserToken, developerToken, devTokenExpiresAt });
+}
+
+export function useAppleMusicToken() {
+  const [hasMusicToken, setHasMusicToken] = useState(() => !!readToken());
+
+  // Keep checking until the token appears (covers popup auth storing token after mount).
+  useEffect(() => {
+    if (hasMusicToken) return;
+    const id = setInterval(() => {
+      if (readToken()) {
+        setHasMusicToken(true);
+        clearInterval(id);
+      }
+    }, 500);
+    return () => clearInterval(id);
+  }, [hasMusicToken]);
+
+  /** Return the stored Music User Token, or null if missing. No refresh — MUT is session-scoped. */
+  const getMusicUserToken = useCallback((): string | null => {
+    const token = readToken();
+    return token?.musicUserToken ?? null;
+  }, []);
+
+  /** Return a valid Developer Token, refetching from the edge function if stale. */
+  const getDeveloperToken = useCallback(async (): Promise<string | null> => {
+    const stored = readToken();
+    if (stored && Date.now() < stored.devTokenExpiresAt) {
+      return stored.developerToken;
+    }
+
+    // Stale or missing — refetch
+    const fresh = await fetchAppleDeveloperToken();
+    if (!fresh) return null;
+
+    if (stored) {
+      // Keep existing MUT, refresh the developer token
+      writeToken({
+        ...stored,
+        developerToken: fresh,
+        devTokenExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      });
+    }
+    return fresh;
+  }, []);
+
+  const clearToken = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setHasMusicToken(false);
+  }, []);
+
+  return { hasMusicToken, getMusicUserToken, getDeveloperToken, clearToken };
+}

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -96,7 +96,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
       try {
         instance = await window.MusicKit.configure({
           developerToken: this.developerToken,
-          app: { name: "MusicNerd TV" },
+          app: { name: "MusicNerd TV", build: "1.0.0" },
         });
       } catch (err) {
         console.error("[AppleMusic] configure failed:", err);
@@ -176,13 +176,13 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   }
 
   /** Sync internal tracking to match an externally-changed track.
-   *  Apple Music has no cross-device detection, so this is only called
-   *  when the engine is swapped in mid-session — rare but harmless. */
-  syncUri(trackUri: string): void {
-    this.lastUri = trackUri;
-    this.hasPlayed = true;
-    this.hasAutoPlayed = true;
-    this._isPlaying = true;
+   *  No-op for Apple Music: MusicKit JS has no cross-device detection,
+   *  so there's no external state to sync to. PlayerContext guards
+   *  syncExternalTrack on service === "spotify", so this is never called
+   *  in current flows — but we implement it to satisfy the PlaybackEngine
+   *  interface without setting phantom state that could mislead consumers. */
+  syncUri(_trackUri: string): void {
+    // intentionally empty
   }
 
   async seek(seconds: number): Promise<void> {

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -9,13 +9,8 @@
 //   - Requires an Apple Music subscription for full tracks (previews otherwise)
 
 import type { PlaybackEngine, PlaybackState } from "./types";
-import { loadMusicKitSDK, _resetMusicKitLoaderForTests } from "@/lib/musickitLoader";
+import { loadMusicKitSDK } from "@/lib/musickitLoader";
 import { getIdFromUri, getServiceFromUri } from "@/lib/trackUri";
-
-/** Reset module-level SDK state — only for tests. Re-exported for backward compat. */
-export function _resetSdkStateForTests(): void {
-  _resetMusicKitLoaderForTests();
-}
 
 // ── Engine ────────────────────────────────────────────────────────────
 
@@ -144,8 +139,13 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   async loadTrack(trackUri: string): Promise<void> {
     if (this.lastUri === trackUri) return;
 
-    // Reset state
-    this.lastUri = null;
+    // Commit lastUri immediately so concurrent loadTrack calls with the
+    // same URI are caught by the dedup guard above. autoPlay's catch
+    // block resets it to null on failure so retries still work.
+    // The pre-load stop() below is a state reset for the new track; the
+    // hasPlayed && lastUri guard in handlePlaybackState ensures this
+    // synchronous stop doesn't trigger a phantom onEnded fire.
+    this.lastUri = trackUri;
     this.hasPlayed = false;
     this.hasAutoPlayed = false;
     this._isPlaying = false;
@@ -158,10 +158,9 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
 
     if (this._ready && this.music) {
       await this.autoPlay(trackUri);
-    } else {
-      // Store for auto-play once init() resolves
-      this.lastUri = trackUri;
     }
+    // If not ready, lastUri is already stored above. The onReady-triggered
+    // autoPlay in init() will pick it up.
   }
 
   async play(): Promise<void> {
@@ -228,6 +227,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     const catalogId = extractAppleCatalogId(uri);
     if (!catalogId) {
       console.error("[AppleMusic] Invalid or non-Apple URI:", uri);
+      this.lastUri = null;  // un-commit so retries with a valid URI aren't blocked
       return;
     }
     if (!this.music) return;
@@ -236,22 +236,20 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // silently fail or return preview clips only. Surface a clear error.
     if (!this.music.isAuthorized) {
       console.error("[AppleMusic] Not authorized — user must connect Apple Music before playback");
+      this.lastUri = null;
       return;
     }
 
-    // Mark as "attempted" only after validation passes, so an invalid URI
-    // followed by a retry with a valid URI isn't blocked by the dedup guard.
     if (this.hasAutoPlayed) return;
     this.hasAutoPlayed = true;
 
     try {
       await this.music.setQueue({ song: catalogId, startPlaying: true });
-      // Only commit lastUri on success so a failed setQueue doesn't poison
-      // the dedup guard and block subsequent retries with the same URI.
-      this.lastUri = uri;
     } catch (err) {
       console.error("[AppleMusic] setQueue failed:", err, "URI:", uri);
-      // Reset the autoplay latch so the caller can retry with the same URI.
+      // Un-commit lastUri and reset the autoplay latch so the caller can
+      // retry with the same URI.
+      this.lastUri = null;
       this.hasAutoPlayed = false;
     }
   }

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -243,12 +243,16 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // followed by a retry with a valid URI isn't blocked by the dedup guard.
     if (this.hasAutoPlayed) return;
     this.hasAutoPlayed = true;
-    this.lastUri = uri;
 
     try {
       await this.music.setQueue({ song: catalogId, startPlaying: true });
+      // Only commit lastUri on success so a failed setQueue doesn't poison
+      // the dedup guard and block subsequent retries with the same URI.
+      this.lastUri = uri;
     } catch (err) {
       console.error("[AppleMusic] setQueue failed:", err, "URI:", uri);
+      // Reset the autoplay latch so the caller can retry with the same URI.
+      this.hasAutoPlayed = false;
     }
   }
 
@@ -263,11 +267,12 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this._isPlaying = isPlaying;
     if (isPlaying) this.hasPlayed = true;
 
-    // End-of-track detection: MusicKit reports one of "completed" (10),
-    // "ended" (5), or "stopped" (4) when a track finishes naturally.
-    // Only fire onEnded if the track actually played at least once
-    // (prevents phantom end events during load).
-    const isEnd = state === PS.completed || state === PS.ended || state === PS.stopped;
+    // End-of-track detection: MusicKit reports "completed" (10) or "ended"
+    // (5) when a track finishes naturally. "stopped" is deliberately NOT
+    // included — MusicKit also emits it during buffering transitions and
+    // when music.stop() is called programmatically (e.g. from loadTrack),
+    // which would cause phantom onEnded fires.
+    const isEnd = state === PS.completed || state === PS.ended;
     if (isEnd && this.hasPlayed && this.lastUri) {
       this.lastUri = null;
       this.hasPlayed = false;

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -1,0 +1,294 @@
+// Apple Music playback engine via MusicKit JS v3.
+// Implements the same PlaybackEngine interface as SpotifyPlaybackEngine so
+// PlayerContext can swap between providers.
+//
+// Key differences from Spotify:
+//   - Native playbackTimeDidChange events (no 250ms polling)
+//   - setQueue + play instead of REST API calls
+//   - No device ID / no cross-device transfer (browser-only)
+//   - Requires an Apple Music subscription for full tracks (previews otherwise)
+
+import type { PlaybackEngine, PlaybackState } from "./types";
+import { loadMusicKitSDK, _resetMusicKitLoaderForTests } from "@/lib/musickitLoader";
+import { getIdFromUri, getServiceFromUri } from "@/lib/trackUri";
+
+/** Reset module-level SDK state — only for tests. Re-exported for backward compat. */
+export function _resetSdkStateForTests(): void {
+  _resetMusicKitLoaderForTests();
+}
+
+// ── Engine ────────────────────────────────────────────────────────────
+
+export interface AppleMusicPlaybackEngineOptions {
+  developerToken: string;
+  /** Called when MusicKit is configured and ready. */
+  onReady?: (deviceId: string | null) => void;
+}
+
+/** Extract the catalog ID from an apple:song:{id} URI.
+ *  Returns empty string for non-Apple URIs (e.g. spotify:track:abc), which
+ *  prevents a wrong-service URI from being silently passed to setQueue. */
+function extractAppleCatalogId(trackUri: string): string {
+  if (getServiceFromUri(trackUri) !== "apple-music") return "";
+  const id = getIdFromUri(trackUri);
+  // Apple Music catalog IDs are numeric strings
+  if (!/^\d+$/.test(id)) return "";
+  return id;
+}
+
+export class AppleMusicPlaybackEngine implements PlaybackEngine {
+  readonly service = "apple-music" as const;
+
+  private music: MusicKit.MusicKitInstance | null = null;
+  private _ready = false;
+  private cancelled = false;
+  private initStarted = false;
+
+  // Internal tracking
+  private lastUri: string | null = null;
+  private hasPlayed = false;
+  private hasAutoPlayed = false;
+  private _isPlaying = false;
+
+  // Subscribers
+  private stateListeners: Set<(s: PlaybackState) => void> = new Set();
+  private endListeners: Set<() => void> = new Set();
+
+  // Bound event handlers (kept as props so removeEventListener can match)
+  private boundStateHandler: (event: unknown) => void;
+  private boundTimeHandler: (event: unknown) => void;
+
+  private developerToken: string;
+  private onReadyCb?: (deviceId: string | null) => void;
+
+  constructor(opts: AppleMusicPlaybackEngineOptions) {
+    this.developerToken = opts.developerToken;
+    this.onReadyCb = opts.onReady;
+    this.boundStateHandler = (e) => this.handlePlaybackState(e as MusicKit.PlaybackStateEvent);
+    this.boundTimeHandler = (e) => this.handleTimeChange(e as MusicKit.PlaybackTimeEvent);
+  }
+
+  get ready() { return this._ready; }
+  /** Apple Music has no device ID concept — always null. */
+  get deviceId() { return null; }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────
+
+  async init(): Promise<void> {
+    // Re-entrancy guard: attaching event listeners twice doubles emissions
+    if (this.initStarted) return;
+    this.initStarted = true;
+
+    await loadMusicKitSDK();
+    if (this.cancelled) return;
+
+    if (!window.MusicKit) {
+      console.error("[AppleMusic] MusicKit failed to load");
+      return;
+    }
+
+    // MusicKit.configure() is a one-shot singleton per page load. If it's
+    // already configured (e.g. from useAppleMusicAuth during onboarding),
+    // reuse the existing instance instead of re-configuring.
+    let instance: MusicKit.MusicKitInstance | null = null;
+    try {
+      instance = window.MusicKit.getInstance();
+    } catch {
+      // Not configured yet, fall through
+    }
+
+    if (!instance) {
+      try {
+        instance = await window.MusicKit.configure({
+          developerToken: this.developerToken,
+          app: { name: "MusicNerd TV" },
+        });
+      } catch (err) {
+        console.error("[AppleMusic] configure failed:", err);
+        return;
+      }
+    }
+
+    if (this.cancelled) return;
+    this.music = instance;
+    this._ready = true;
+    this.onReadyCb?.(null);
+
+    // Wire up native events (no polling needed)
+    instance.addEventListener("playbackStateDidChange", this.boundStateHandler);
+    instance.addEventListener("playbackTimeDidChange", this.boundTimeHandler);
+
+    // Auto-play pending URI that was stored before configure resolved
+    if (this.lastUri && !this.hasAutoPlayed) {
+      this.autoPlay(this.lastUri);
+    }
+  }
+
+  cleanup(): void {
+    this.cancelled = true;
+    if (this.music) {
+      try {
+        this.music.removeEventListener("playbackStateDidChange", this.boundStateHandler);
+        this.music.removeEventListener("playbackTimeDidChange", this.boundTimeHandler);
+        this.music.stop();
+      } catch (err) {
+        console.warn("[AppleMusic] cleanup error:", err);
+      }
+      // Don't null the MusicKit singleton — other code may still reference it.
+      this.music = null;
+    }
+  }
+
+  // ── Playback control ────────────────────────────────────────────────
+
+  async loadTrack(trackUri: string): Promise<void> {
+    if (this.lastUri === trackUri) return;
+
+    // Reset state
+    this.lastUri = null;
+    this.hasPlayed = false;
+    this.hasAutoPlayed = false;
+    this._isPlaying = false;
+
+    try { this.music?.stop(); } catch { /* already stopped */ }
+
+    this.emitState({ isPlaying: false, currentTime: 0, duration: 0 });
+
+    if (!trackUri) return;
+
+    if (this._ready && this.music) {
+      await this.autoPlay(trackUri);
+    } else {
+      // Store for auto-play once init() resolves
+      this.lastUri = trackUri;
+    }
+  }
+
+  async play(): Promise<void> {
+    try {
+      await this.music?.play();
+    } catch (err) {
+      console.error("[AppleMusic] play failed:", err);
+    }
+  }
+
+  async pause(): Promise<void> {
+    try { this.music?.pause(); } catch { /* already paused */ }
+  }
+
+  /** Sync internal tracking to match an externally-changed track.
+   *  Apple Music has no cross-device detection, so this is only called
+   *  when the engine is swapped in mid-session — rare but harmless. */
+  syncUri(trackUri: string): void {
+    this.lastUri = trackUri;
+    this.hasPlayed = true;
+    this.hasAutoPlayed = true;
+    this._isPlaying = true;
+  }
+
+  async seek(seconds: number): Promise<void> {
+    try {
+      await this.music?.seekToTime(seconds);
+    } catch (err) {
+      console.error("[AppleMusic] seek failed:", err);
+    }
+    // Optimistically update time — omit duration so subscribers keep current value
+    this.emitState({ isPlaying: this._isPlaying, currentTime: seconds });
+  }
+
+  stop(): void {
+    try { this.music?.stop(); } catch { /* already stopped */ }
+    this.lastUri = null;
+  }
+
+  // ── Subscriptions ───────────────────────────────────────────────────
+
+  onStateChange(cb: (s: PlaybackState) => void): () => void {
+    this.stateListeners.add(cb);
+    return () => { this.stateListeners.delete(cb); };
+  }
+
+  onTrackEnd(cb: () => void): () => void {
+    this.endListeners.add(cb);
+    return () => { this.endListeners.delete(cb); };
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private emitState(partial: { isPlaying: boolean; currentTime: number; duration?: number }) {
+    const state: PlaybackState = {
+      isPlaying: partial.isPlaying,
+      currentTime: partial.currentTime,
+      duration: partial.duration,
+    };
+    for (const cb of this.stateListeners) cb(state);
+  }
+
+  private async autoPlay(uri: string): Promise<void> {
+    const catalogId = extractAppleCatalogId(uri);
+    if (!catalogId) {
+      console.error("[AppleMusic] Invalid or non-Apple URI:", uri);
+      return;
+    }
+    if (!this.music) return;
+
+    // Apple Music playback requires authorization. Without it, setQueue will
+    // silently fail or return preview clips only. Surface a clear error.
+    if (!this.music.isAuthorized) {
+      console.error("[AppleMusic] Not authorized — user must connect Apple Music before playback");
+      return;
+    }
+
+    // Mark as "attempted" only after validation passes, so an invalid URI
+    // followed by a retry with a valid URI isn't blocked by the dedup guard.
+    if (this.hasAutoPlayed) return;
+    this.hasAutoPlayed = true;
+    this.lastUri = uri;
+
+    try {
+      await this.music.setQueue({ song: catalogId, startPlaying: true });
+    } catch (err) {
+      console.error("[AppleMusic] setQueue failed:", err, "URI:", uri);
+    }
+  }
+
+  private handlePlaybackState(event: MusicKit.PlaybackStateEvent): void {
+    if (this.cancelled || !this.music) return;
+
+    const state = event.state;
+    const PS = window.MusicKit?.PlaybackStates;
+    if (!PS) return;
+
+    const isPlaying = state === PS.playing;
+    this._isPlaying = isPlaying;
+    if (isPlaying) this.hasPlayed = true;
+
+    // End-of-track detection: MusicKit reports one of "completed" (10),
+    // "ended" (5), or "stopped" (4) when a track finishes naturally.
+    // Only fire onEnded if the track actually played at least once
+    // (prevents phantom end events during load).
+    const isEnd = state === PS.completed || state === PS.ended || state === PS.stopped;
+    if (isEnd && this.hasPlayed && this.lastUri) {
+      this.lastUri = null;
+      this.hasPlayed = false;
+      for (const cb of this.endListeners) cb();
+      return;
+    }
+
+    // Emit state update with latest time/duration from the instance
+    this.emitState({
+      isPlaying,
+      currentTime: this.music.currentPlaybackTime || 0,
+      duration: this.music.currentPlaybackDuration || 0,
+    });
+  }
+
+  private handleTimeChange(event: MusicKit.PlaybackTimeEvent): void {
+    if (this.cancelled) return;
+    this.emitState({
+      isPlaying: this._isPlaying,
+      currentTime: event.currentPlaybackTime || 0,
+      duration: event.currentPlaybackDuration || 0,
+    });
+  }
+}

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -25,6 +25,12 @@ export interface PlaybackEngine {
   seek(seconds: number): Promise<void>;
   stop(): void;
 
+  /** Sync internal tracking to match an externally-changed track.
+   *  Called when a track change is detected outside our control (e.g. user
+   *  skips on their phone via Spotify Connect). Engines that don't support
+   *  cross-device detection should treat this as a hint/no-op. */
+  syncUri(trackUri: string): void;
+
   /** Subscribe to playback state changes. Returns unsubscribe function. */
   onStateChange(cb: (state: PlaybackState) => void): () => void;
   /** Subscribe to track-end events. Returns unsubscribe function. */

--- a/src/lib/musickitLoader.ts
+++ b/src/lib/musickitLoader.ts
@@ -3,6 +3,7 @@
 // "musickitloaded" events when both call sites race.
 
 const MUSICKIT_SRC = "https://js-cdn.music.apple.com/musickit/v3/musickit.js";
+const LOAD_TIMEOUT_MS = 15_000;
 
 let sdkPromise: Promise<void> | null = null;
 
@@ -17,34 +18,39 @@ export function loadMusicKitSDK(): Promise<void> {
   if (sdkPromise) return sdkPromise;
 
   sdkPromise = new Promise((resolve, reject) => {
-    // Guard against synchronous SDK install (cached service worker, etc.)
-    // that could set window.MusicKit before we attach our listener.
-    const checkAndResolve = () => {
-      if (window.MusicKit) {
-        window.removeEventListener("musickitloaded", onLoaded);
-        resolve();
-        return true;
-      }
-      return false;
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      window.removeEventListener("musickitloaded", onLoaded);
+      fn();
     };
 
-    const onLoaded = () => {
-      window.removeEventListener("musickitloaded", onLoaded);
-      resolve();
-    };
+    // Bail out after 15s if Apple's CDN is unreachable or the musickitloaded
+    // event never fires — prevents the engine and auth flow from hanging forever.
+    const timeoutId = setTimeout(() => {
+      sdkPromise = null;
+      settle(() => reject(new Error(`MusicKit JS load timed out after ${LOAD_TIMEOUT_MS}ms`)));
+    }, LOAD_TIMEOUT_MS);
+
+    const onLoaded = () => settle(() => resolve());
     window.addEventListener("musickitloaded", onLoaded);
 
-    // Re-check after listener registration in case MusicKit installed between
-    // the top-of-function check and the listener attach.
-    if (checkAndResolve()) return;
+    // Guard against synchronous SDK install (cached service worker, etc.)
+    // that could set window.MusicKit between the top-of-function check and
+    // the listener attach.
+    if (window.MusicKit) {
+      settle(() => resolve());
+      return;
+    }
 
     const script = document.createElement("script");
     script.src = MUSICKIT_SRC;
     script.async = true;
     script.onerror = () => {
-      window.removeEventListener("musickitloaded", onLoaded);
       sdkPromise = null;
-      reject(new Error("Failed to load MusicKit JS"));
+      settle(() => reject(new Error("Failed to load MusicKit JS")));
     };
     document.head.appendChild(script);
   });

--- a/src/lib/musickitLoader.ts
+++ b/src/lib/musickitLoader.ts
@@ -1,0 +1,53 @@
+// Shared MusicKit JS v3 SDK loader — singleton used by both the Apple Music
+// playback engine and the auth hook. Prevents double script tags and missed
+// "musickitloaded" events when both call sites race.
+
+const MUSICKIT_SRC = "https://js-cdn.music.apple.com/musickit/v3/musickit.js";
+
+let sdkPromise: Promise<void> | null = null;
+
+/** Reset module-level SDK state — only for tests. */
+export function _resetMusicKitLoaderForTests(): void {
+  sdkPromise = null;
+}
+
+export function loadMusicKitSDK(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.MusicKit) return Promise.resolve();
+  if (sdkPromise) return sdkPromise;
+
+  sdkPromise = new Promise((resolve, reject) => {
+    // Guard against synchronous SDK install (cached service worker, etc.)
+    // that could set window.MusicKit before we attach our listener.
+    const checkAndResolve = () => {
+      if (window.MusicKit) {
+        window.removeEventListener("musickitloaded", onLoaded);
+        resolve();
+        return true;
+      }
+      return false;
+    };
+
+    const onLoaded = () => {
+      window.removeEventListener("musickitloaded", onLoaded);
+      resolve();
+    };
+    window.addEventListener("musickitloaded", onLoaded);
+
+    // Re-check after listener registration in case MusicKit installed between
+    // the top-of-function check and the listener attach.
+    if (checkAndResolve()) return;
+
+    const script = document.createElement("script");
+    script.src = MUSICKIT_SRC;
+    script.async = true;
+    script.onerror = () => {
+      window.removeEventListener("musickitloaded", onLoaded);
+      sdkPromise = null;
+      reject(new Error("Failed to load MusicKit JS"));
+    };
+    document.head.appendChild(script);
+  });
+
+  return sdkPromise;
+}

--- a/src/lib/musickitLoader.ts
+++ b/src/lib/musickitLoader.ts
@@ -45,7 +45,20 @@ export function loadMusicKitSDK(): Promise<void> {
       return;
     }
 
-    const script = document.createElement("script");
+    // Reuse an existing <script> tag if a previous load attempt timed out
+    // or errored. Without this, each retry would append a duplicate tag.
+    let script = document.querySelector<HTMLScriptElement>(
+      `script[src="${MUSICKIT_SRC}"]`
+    );
+    if (script) {
+      script.addEventListener("error", () => {
+        sdkPromise = null;
+        settle(() => reject(new Error("Failed to load MusicKit JS")));
+      });
+      return;
+    }
+
+    script = document.createElement("script");
     script.src = MUSICKIT_SRC;
     script.async = true;
     script.onerror = () => {

--- a/src/lib/routeParsing.test.ts
+++ b/src/lib/routeParsing.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   isSpotifyPrefix,
   isRealPrefix,
+  isApplePrefix,
   parseSpotifyArtist,
   parseRealArtist,
   parseSpotifyAlbum,
+  parseAppleArtist,
+  parseAppleAlbum,
 } from "./routeParsing";
 
 describe("isSpotifyPrefix", () => {
@@ -152,5 +155,96 @@ describe("parseSpotifyAlbum", () => {
       artistName: "Daft Punk",
       artistSpotifyId: artistId,
     });
+  });
+});
+
+describe("isApplePrefix", () => {
+  it("detects raw apple:: prefix", () => {
+    expect(isApplePrefix("apple::178834::Radiohead")).toBe(true);
+  });
+
+  it("detects URL-encoded apple:: prefix", () => {
+    expect(isApplePrefix("apple%3A%3A178834%3A%3ARadiohead")).toBe(true);
+  });
+
+  it("rejects spotify:: prefix", () => {
+    expect(isApplePrefix("spotify::abc123::Radiohead")).toBe(false);
+  });
+
+  it("rejects real:: prefix", () => {
+    expect(isApplePrefix("real::Radiohead")).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isApplePrefix(undefined)).toBe(false);
+  });
+});
+
+describe("parseAppleArtist", () => {
+  it("parses raw apple::{id}::{name}", () => {
+    const result = parseAppleArtist("apple::178834::Radiohead");
+    expect(result).toEqual({ appleId: "178834", artistName: "Radiohead" });
+  });
+
+  it("parses URL-encoded input", () => {
+    const raw = encodeURIComponent("apple::178834::Radiohead");
+    const result = parseAppleArtist(raw);
+    expect(result).toEqual({ appleId: "178834", artistName: "Radiohead" });
+  });
+
+  it("handles names with special characters", () => {
+    const result = parseAppleArtist("apple::1234::Beyoncé");
+    expect(result).toEqual({ appleId: "1234", artistName: "Beyoncé" });
+  });
+
+  it("returns null for missing ID", () => {
+    expect(parseAppleArtist("apple::::Radiohead")).toBeNull();
+  });
+
+  it("returns null for non-apple prefix", () => {
+    expect(parseAppleArtist("spotify::abc::name")).toBeNull();
+  });
+
+  it("returns empty artistName when name segment is missing", () => {
+    const result = parseAppleArtist("apple::178834");
+    expect(result).toEqual({ appleId: "178834", artistName: "" });
+  });
+});
+
+describe("parseAppleAlbum", () => {
+  it("parses apple::{albumId}::{artistName}::{artistId}", () => {
+    const result = parseAppleAlbum("apple::1440833060::Radiohead::178834");
+    expect(result).toEqual({
+      appleAlbumId: "1440833060",
+      artistName: "Radiohead",
+      artistAppleId: "178834",
+    });
+  });
+
+  it("parses URL-encoded input", () => {
+    const raw = encodeURIComponent("apple::1440833060::Radiohead::178834");
+    const result = parseAppleAlbum(raw);
+    expect(result).toEqual({
+      appleAlbumId: "1440833060",
+      artistName: "Radiohead",
+      artistAppleId: "178834",
+    });
+  });
+
+  it("handles missing artistAppleId", () => {
+    const result = parseAppleAlbum("apple::1440833060::Some Artist");
+    expect(result).toEqual({
+      appleAlbumId: "1440833060",
+      artistName: "Some Artist",
+      artistAppleId: "",
+    });
+  });
+
+  it("returns null for missing albumId", () => {
+    expect(parseAppleAlbum("apple::::ArtistName::artistId")).toBeNull();
+  });
+
+  it("returns null for non-apple prefix", () => {
+    expect(parseAppleAlbum("spotify::something::artist")).toBeNull();
   });
 });

--- a/src/lib/trackUri.test.ts
+++ b/src/lib/trackUri.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { getServiceFromUri, getIdFromUri } from "./trackUri";
+
+describe("getServiceFromUri", () => {
+  it("detects spotify URIs", () => {
+    expect(getServiceFromUri("spotify:track:7KXjTSCq5nL1LoYtL7XAwS")).toBe("spotify");
+  });
+
+  it("detects apple URIs", () => {
+    expect(getServiceFromUri("apple:song:1440833060")).toBe("apple-music");
+  });
+
+  it("returns none for unknown prefix", () => {
+    expect(getServiceFromUri("youtube:video:abc")).toBe("none");
+  });
+
+  it("returns none for empty string", () => {
+    expect(getServiceFromUri("")).toBe("none");
+  });
+});
+
+describe("getIdFromUri", () => {
+  it("extracts Spotify track ID", () => {
+    expect(getIdFromUri("spotify:track:7KXjTSCq5nL1LoYtL7XAwS")).toBe("7KXjTSCq5nL1LoYtL7XAwS");
+  });
+
+  it("extracts Apple Music catalog ID", () => {
+    expect(getIdFromUri("apple:song:1440833060")).toBe("1440833060");
+  });
+
+  it("returns last segment for unknown format", () => {
+    expect(getIdFromUri("random:foo:bar:baz")).toBe("baz");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(getIdFromUri("")).toBe("");
+  });
+});

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -51,7 +51,8 @@ vi.stubGlobal("MusicKit", {
 // Short-circuit the SDK script loader by pretending it's already loaded
 (window as any).MusicKit = (window as any).MusicKit || globalThis.MusicKit;
 
-import { AppleMusicPlaybackEngine, _resetSdkStateForTests } from "@/lib/engines/AppleMusicPlaybackEngine";
+import { AppleMusicPlaybackEngine } from "@/lib/engines/AppleMusicPlaybackEngine";
+import { _resetMusicKitLoaderForTests } from "@/lib/musickitLoader";
 
 describe("AppleMusicPlaybackEngine", () => {
   const onReady = vi.fn();
@@ -59,7 +60,7 @@ describe("AppleMusicPlaybackEngine", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     eventListeners.clear();
-    _resetSdkStateForTests();
+    _resetMusicKitLoaderForTests();
 
     // Re-attach the MusicKit stub onto window for each test
     (window as any).MusicKit = {

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -88,7 +88,7 @@ describe("AppleMusicPlaybackEngine", () => {
 
     expect(window.MusicKit!.configure).toHaveBeenCalledWith({
       developerToken: "dev-token",
-      app: { name: "MusicNerd TV" },
+      app: { name: "MusicNerd TV", build: "1.0.0" },
     });
     expect(engine.ready).toBe(true);
     expect(onReady).toHaveBeenCalledWith(null);

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture event listeners registered on the MusicKit instance
+const eventListeners = new Map<string, Function>();
+
+const mockMusic = {
+  developerToken: "dev",
+  musicUserToken: "mut",
+  isAuthorized: true,
+  storefrontCountryCode: "us",
+  nowPlayingItem: null,
+  currentPlaybackTime: 0,
+  currentPlaybackDuration: 0,
+  currentPlaybackTimeRemaining: 0,
+  playbackState: 0,
+  authorize: vi.fn().mockResolvedValue("mut"),
+  unauthorize: vi.fn(),
+  play: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  stop: vi.fn(),
+  seekToTime: vi.fn().mockResolvedValue(undefined),
+  skipToNextItem: vi.fn(),
+  skipToPreviousItem: vi.fn(),
+  setQueue: vi.fn().mockResolvedValue(undefined),
+  addEventListener: vi.fn((event: string, cb: Function) => {
+    eventListeners.set(event, cb);
+  }),
+  removeEventListener: vi.fn(),
+};
+
+// Mock window.MusicKit before importing the engine
+vi.stubGlobal("MusicKit", {
+  configure: vi.fn().mockResolvedValue(mockMusic),
+  getInstance: vi.fn(() => {
+    throw new Error("not configured yet");
+  }),
+  PlaybackStates: {
+    none: 0,
+    loading: 1,
+    playing: 2,
+    paused: 3,
+    stopped: 4,
+    ended: 5,
+    seeking: 6,
+    waiting: 8,
+    stalled: 9,
+    completed: 10,
+  },
+});
+
+// Short-circuit the SDK script loader by pretending it's already loaded
+(window as any).MusicKit = (window as any).MusicKit || globalThis.MusicKit;
+
+import { AppleMusicPlaybackEngine, _resetSdkStateForTests } from "@/lib/engines/AppleMusicPlaybackEngine";
+
+describe("AppleMusicPlaybackEngine", () => {
+  const onReady = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventListeners.clear();
+    _resetSdkStateForTests();
+
+    // Re-attach the MusicKit stub onto window for each test
+    (window as any).MusicKit = {
+      configure: vi.fn().mockResolvedValue(mockMusic),
+      getInstance: vi.fn(() => {
+        throw new Error("not configured yet");
+      }),
+      PlaybackStates: globalThis.MusicKit.PlaybackStates,
+    };
+  });
+
+  it("service property is apple-music and deviceId is null", () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    expect(engine.service).toBe("apple-music");
+    expect(engine.deviceId).toBeNull();
+  });
+
+  it("init() configures MusicKit and becomes ready", async () => {
+    const engine = new AppleMusicPlaybackEngine({
+      developerToken: "dev-token",
+      onReady,
+    });
+
+    await engine.init();
+
+    expect(window.MusicKit!.configure).toHaveBeenCalledWith({
+      developerToken: "dev-token",
+      app: { name: "MusicNerd TV" },
+    });
+    expect(engine.ready).toBe(true);
+    expect(onReady).toHaveBeenCalledWith(null);
+  });
+
+  it("loadTrack extracts catalog ID and calls setQueue", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    await engine.loadTrack("apple:song:1440833060");
+
+    expect(mockMusic.setQueue).toHaveBeenCalledWith({
+      song: "1440833060",
+      startPlaying: true,
+    });
+  });
+
+  it("loadTrack deduplicates repeat calls with the same URI", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    await engine.loadTrack("apple:song:1");
+    await engine.loadTrack("apple:song:1"); // same URI — should be ignored
+
+    expect(mockMusic.setQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("loadTrack before init() stores URI and plays when ready", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+
+    // Call loadTrack before init resolves
+    await engine.loadTrack("apple:song:999");
+    expect(mockMusic.setQueue).not.toHaveBeenCalled();
+
+    await engine.init();
+    // Give autoPlay a tick to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMusic.setQueue).toHaveBeenCalledWith({
+      song: "999",
+      startPlaying: true,
+    });
+  });
+
+  it("onStateChange receives updates from playbackTimeDidChange events", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    const stateSpy = vi.fn();
+    engine.onStateChange(stateSpy);
+
+    const timeCb = eventListeners.get("playbackTimeDidChange");
+    expect(timeCb).toBeDefined();
+
+    timeCb!({ currentPlaybackTime: 42, currentPlaybackDuration: 200, currentPlaybackTimeRemaining: 158 });
+
+    expect(stateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ currentTime: 42, duration: 200 })
+    );
+  });
+
+  it("onTrackEnd fires when playback reaches completed state", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    // Start playing a track so hasPlayed becomes true
+    await engine.loadTrack("apple:song:1");
+    const stateCb = eventListeners.get("playbackStateDidChange");
+    expect(stateCb).toBeDefined();
+
+    // Simulate "playing" state first
+    stateCb!({ state: 2 /* playing */ });
+
+    const endSpy = vi.fn();
+    engine.onTrackEnd(endSpy);
+
+    // Then simulate "completed" state
+    stateCb!({ state: 10 /* completed */ });
+    expect(endSpy).toHaveBeenCalled();
+  });
+
+  it("onTrackEnd does NOT fire if the track never played", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    const endSpy = vi.fn();
+    engine.onTrackEnd(endSpy);
+
+    const stateCb = eventListeners.get("playbackStateDidChange");
+    // Directly fire "completed" without a prior "playing" state
+    stateCb!({ state: 10 });
+
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  it("cleanup removes listeners and stops playback", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    engine.cleanup();
+
+    expect(mockMusic.removeEventListener).toHaveBeenCalledWith("playbackStateDidChange", expect.any(Function));
+    expect(mockMusic.removeEventListener).toHaveBeenCalledWith("playbackTimeDidChange", expect.any(Function));
+    expect(mockMusic.stop).toHaveBeenCalled();
+  });
+});

--- a/src/test/useAppleMusicToken.test.ts
+++ b/src/test/useAppleMusicToken.test.ts
@@ -100,7 +100,7 @@ describe("useAppleMusicToken", () => {
     const { result } = renderHook(() => useAppleMusicToken());
     const token = await result.current.getDeveloperToken();
 
-    expect(supabase.functions.invoke).toHaveBeenCalledWith("apple-dev-token", expect.anything());
+    expect(supabase.functions.invoke).toHaveBeenCalledWith("apple-dev-token");
     expect(token).toBe("fresh-dev-token");
 
     // The stored token should have been updated

--- a/src/test/useAppleMusicToken.test.ts
+++ b/src/test/useAppleMusicToken.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Mock supabase client before importing the hook so the mocked function
+// is in place when useAppleMusicToken's module-level imports resolve.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+import { useAppleMusicToken, saveAppleMusicToken, fetchAppleDeveloperToken } from "@/hooks/useAppleMusicToken";
+import { supabase } from "@/integrations/supabase/client";
+
+const STORAGE_KEY = "apple_music_token";
+
+describe("saveAppleMusicToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists both tokens to localStorage", () => {
+    saveAppleMusicToken("user-token", "dev-token");
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const stored = JSON.parse(raw!);
+    expect(stored.musicUserToken).toBe("user-token");
+    expect(stored.developerToken).toBe("dev-token");
+    expect(stored.devTokenExpiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("sets expiry ~30 days in the future", () => {
+    const before = Date.now();
+    saveAppleMusicToken("u", "d");
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+    expect(stored.devTokenExpiresAt).toBeGreaterThanOrEqual(before + thirtyDays - 1000);
+    expect(stored.devTokenExpiresAt).toBeLessThanOrEqual(before + thirtyDays + 1000);
+  });
+});
+
+describe("useAppleMusicToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("reports no token when localStorage is empty", () => {
+    const { result } = renderHook(() => useAppleMusicToken());
+    expect(result.current.hasMusicToken).toBe(false);
+    expect(result.current.getMusicUserToken()).toBeNull();
+  });
+
+  it("reports token when present in localStorage", () => {
+    saveAppleMusicToken("user-token-abc", "dev-token-xyz");
+    const { result } = renderHook(() => useAppleMusicToken());
+    expect(result.current.hasMusicToken).toBe(true);
+    expect(result.current.getMusicUserToken()).toBe("user-token-abc");
+  });
+
+  it("clearToken removes the stored token and updates state", () => {
+    saveAppleMusicToken("u", "d");
+    const { result } = renderHook(() => useAppleMusicToken());
+    expect(result.current.hasMusicToken).toBe(true);
+
+    act(() => {
+      result.current.clearToken();
+    });
+
+    expect(result.current.hasMusicToken).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("getDeveloperToken returns cached token when still fresh", async () => {
+    saveAppleMusicToken("u", "cached-dev-token");
+    const { result } = renderHook(() => useAppleMusicToken());
+
+    const token = await result.current.getDeveloperToken();
+    expect(token).toBe("cached-dev-token");
+    // Should NOT have called the edge function
+    expect(supabase.functions.invoke).not.toHaveBeenCalled();
+  });
+
+  it("getDeveloperToken refetches when token is expired", async () => {
+    // Write a stale token directly (expiresAt in the past)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      musicUserToken: "u",
+      developerToken: "stale-dev-token",
+      devTokenExpiresAt: Date.now() - 1000,
+    }));
+
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: { token: "fresh-dev-token" },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAppleMusicToken());
+    const token = await result.current.getDeveloperToken();
+
+    expect(supabase.functions.invoke).toHaveBeenCalledWith("apple-dev-token", expect.anything());
+    expect(token).toBe("fresh-dev-token");
+
+    // The stored token should have been updated
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.developerToken).toBe("fresh-dev-token");
+    expect(stored.musicUserToken).toBe("u"); // MUT preserved
+  });
+});
+
+describe("fetchAppleDeveloperToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns token on success", async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: { token: "jwt-token" },
+      error: null,
+    });
+
+    const token = await fetchAppleDeveloperToken();
+    expect(token).toBe("jwt-token");
+  });
+
+  it("returns null on edge function error", async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: null,
+      error: { message: "server error" },
+    });
+
+    const token = await fetchAppleDeveloperToken();
+    expect(token).toBeNull();
+  });
+
+  it("returns null on network exception", async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network"));
+
+    const token = await fetchAppleDeveloperToken();
+    expect(token).toBeNull();
+  });
+});

--- a/src/types/musickit.d.ts
+++ b/src/types/musickit.d.ts
@@ -1,0 +1,121 @@
+// MusicKit JS v3 type stubs.
+// Covers the subset of APIs used by AppleMusicPlaybackEngine and useAppleMusicAuth.
+// Full reference: https://js-cdn.music.apple.com/musickit/v3/docs/
+
+declare namespace MusicKit {
+  interface ConfigureOptions {
+    developerToken: string;
+    app: {
+      name: string;
+      build?: string;
+    };
+    storefrontId?: string;
+    suppressErrorDialog?: boolean;
+  }
+
+  /** Playback state enum — integer values per MusicKit v3 spec */
+  enum PlaybackStates {
+    none = 0,
+    loading = 1,
+    playing = 2,
+    paused = 3,
+    stopped = 4,
+    ended = 5,
+    seeking = 6,
+    waiting = 8,
+    stalled = 9,
+    completed = 10,
+  }
+
+  interface Artwork {
+    url?: string;         // Contains {w}x{h} template placeholders
+    width?: number;
+    height?: number;
+    bgColor?: string;
+  }
+
+  interface MediaItem {
+    id: string;
+    type: string;         // "song", "album", etc.
+    attributes?: {
+      name?: string;
+      artistName?: string;
+      albumName?: string;
+      artwork?: Artwork;
+      durationInMillis?: number;
+      url?: string;
+    };
+  }
+
+  interface SetQueueOptions {
+    song?: string;        // Catalog song ID
+    songs?: string[];
+    album?: string;
+    playlist?: string;
+    startWith?: number;
+    startPlaying?: boolean;
+  }
+
+  interface PlaybackTimeEvent {
+    currentPlaybackDuration: number;  // seconds
+    currentPlaybackTime: number;      // seconds
+    currentPlaybackTimeRemaining: number;
+  }
+
+  interface PlaybackStateEvent {
+    state: PlaybackStates;
+    oldState?: PlaybackStates;
+  }
+
+  interface MediaItemEvent {
+    oldItem?: MediaItem;
+    item?: MediaItem;
+  }
+
+  type EventCallback<T = unknown> = (event: T) => void;
+
+  interface MusicKitInstance {
+    readonly developerToken: string;
+    readonly musicUserToken: string;
+    readonly isAuthorized: boolean;
+    readonly storefrontCountryCode: string;
+    readonly nowPlayingItem: MediaItem | null;
+    readonly currentPlaybackTime: number;
+    readonly currentPlaybackDuration: number;
+    readonly currentPlaybackTimeRemaining: number;
+    readonly playbackState: PlaybackStates;
+
+    // Auth
+    authorize(): Promise<string>;   // Returns Music User Token
+    unauthorize(): Promise<void>;
+
+    // Playback control
+    play(): Promise<void>;
+    pause(): void;
+    stop(): void;
+    seekToTime(time: number): Promise<void>;
+    skipToNextItem(): Promise<void>;
+    skipToPreviousItem(): Promise<void>;
+
+    // Queue
+    setQueue(options: SetQueueOptions): Promise<void>;
+
+    // Events
+    addEventListener(event: "playbackStateDidChange", cb: EventCallback<PlaybackStateEvent>): void;
+    addEventListener(event: "playbackTimeDidChange", cb: EventCallback<PlaybackTimeEvent>): void;
+    addEventListener(event: "playbackDurationDidChange", cb: EventCallback<{ duration: number }>): void;
+    addEventListener(event: "mediaItemDidChange", cb: EventCallback<MediaItemEvent>): void;
+    addEventListener(event: "queueItemsDidChange", cb: EventCallback<MediaItem[]>): void;
+    addEventListener(event: "authorizationStatusDidChange", cb: EventCallback<{ authorizationStatus: number }>): void;
+    addEventListener(event: string, cb: EventCallback): void;
+    removeEventListener(event: string, cb: EventCallback): void;
+  }
+
+  function configure(options: ConfigureOptions): Promise<MusicKitInstance>;
+  function getInstance(): MusicKitInstance;
+}
+
+interface Window {
+  MusicKit?: typeof MusicKit;
+  musicKitLoaded?: boolean;
+}

--- a/src/types/musickit.d.ts
+++ b/src/types/musickit.d.ts
@@ -13,19 +13,23 @@ declare namespace MusicKit {
     suppressErrorDialog?: boolean;
   }
 
-  /** Playback state enum — integer values per MusicKit v3 spec */
-  enum PlaybackStates {
-    none = 0,
-    loading = 1,
-    playing = 2,
-    paused = 3,
-    stopped = 4,
-    ended = 5,
-    seeking = 6,
-    waiting = 8,
-    stalled = 9,
-    completed = 10,
-  }
+  /** Playback state values per MusicKit v3 spec. Declared as a runtime
+   *  object (not a TS enum) so ambient emit semantics stay predictable
+   *  across bundlers. The engine reads window.MusicKit.PlaybackStates at
+   *  runtime and compares numeric values. */
+  const PlaybackStates: {
+    readonly none: 0;
+    readonly loading: 1;
+    readonly playing: 2;
+    readonly paused: 3;
+    readonly stopped: 4;
+    readonly ended: 5;
+    readonly seeking: 6;
+    readonly waiting: 8;
+    readonly stalled: 9;
+    readonly completed: 10;
+  };
+  type PlaybackStates = typeof PlaybackStates[keyof typeof PlaybackStates];
 
   interface Artwork {
     url?: string;         // Contains {w}x{h} template placeholders

--- a/supabase/functions/_shared/apple-token.ts
+++ b/supabase/functions/_shared/apple-token.ts
@@ -1,0 +1,93 @@
+// Shared Apple Music Developer Token generation.
+// Import as: import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
+//
+// Generates an ES256-signed JWT using the Apple Music private key (.p8 file).
+// Max JWT lifetime is 180 days per Apple's requirements. Cached in-memory with
+// 1-day buffer so we regenerate well before expiry. Each Deno isolate caches
+// independently — cold starts re-generate (fast local CPU operation, no network).
+//
+// Required secrets:
+//   APPLE_MUSIC_KEY_ID     — 10-char Key ID from Apple Developer portal
+//   APPLE_MUSIC_TEAM_ID    — 10-char Team ID
+//   APPLE_MUSIC_PRIVATE_KEY — Contents of the .p8 file (PEM format)
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+const MAX_LIFETIME_SEC = 180 * 24 * 60 * 60;  // 180 days (Apple's max)
+const BUFFER_SEC = 24 * 60 * 60;              // 1-day buffer
+
+/** Get an Apple Developer Token (ES256 JWT). Cached in-memory, regenerated well before expiry. */
+export async function getAppleDeveloperToken(): Promise<string> {
+  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
+
+  const keyId = Deno.env.get("APPLE_MUSIC_KEY_ID");
+  const teamId = Deno.env.get("APPLE_MUSIC_TEAM_ID");
+  const privateKeyPem = Deno.env.get("APPLE_MUSIC_PRIVATE_KEY");
+
+  if (!keyId || !teamId || !privateKeyPem) {
+    throw new Error("Missing Apple Music credentials (APPLE_MUSIC_KEY_ID, APPLE_MUSIC_TEAM_ID, APPLE_MUSIC_PRIVATE_KEY)");
+  }
+
+  const cryptoKey = await importPrivateKey(privateKeyPem);
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "ES256", kid: keyId, typ: "JWT" };
+  const payload = { iss: teamId, iat: now, exp: now + MAX_LIFETIME_SEC };
+
+  const headerB64 = base64UrlEncode(new TextEncoder().encode(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  );
+
+  // Web Crypto outputs ECDSA signatures in IEEE P1363 format (raw r||s),
+  // which is exactly what JWT ES256 requires.
+  const signatureB64 = base64UrlEncode(new Uint8Array(signature));
+  const token = `${signingInput}.${signatureB64}`;
+
+  cachedToken = token;
+  tokenExpiresAt = Date.now() + (MAX_LIFETIME_SEC - BUFFER_SEC) * 1000;
+  return token;
+}
+
+/** Clear cached token (for testing or forced refresh). */
+export function clearAppleDeveloperToken(): void {
+  cachedToken = null;
+  tokenExpiresAt = 0;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  // Strip PEM headers/footers and whitespace, decode base64 to DER bytes.
+  // Global regex so multi-line or duplicated markers are handled correctly.
+  // Apple provides PKCS8-format keys (-----BEGIN PRIVATE KEY-----); we reject
+  // EC-specific PEM formats early with a clear error so users know to re-export.
+  if (pem.includes("-----BEGIN EC PRIVATE KEY-----")) {
+    throw new Error("Apple Music private key must be in PKCS8 format, not EC format");
+  }
+  const pemBody = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s/g, "");
+  const binary = Uint8Array.from(atob(pemBody), (c) => c.charCodeAt(0));
+
+  return await crypto.subtle.importKey(
+    "pkcs8",
+    binary,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}

--- a/supabase/functions/_shared/apple-token.ts
+++ b/supabase/functions/_shared/apple-token.ts
@@ -10,6 +10,11 @@
 //   APPLE_MUSIC_KEY_ID     — 10-char Key ID from Apple Developer portal
 //   APPLE_MUSIC_TEAM_ID    — 10-char Team ID
 //   APPLE_MUSIC_PRIVATE_KEY — Contents of the .p8 file (PEM format)
+//
+// Key rotation: if APPLE_MUSIC_PRIVATE_KEY is rotated (e.g. due to compromise),
+// warm Deno isolates will continue serving the old cached JWT until they cold-
+// start. To force an immediate rotation across all isolates, redeploy the
+// edge function after setting the new secret — that replaces all workers.
 
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;

--- a/supabase/functions/apple-dev-token/index.ts
+++ b/supabase/functions/apple-dev-token/index.ts
@@ -1,0 +1,37 @@
+// Serves an Apple Music Developer Token (ES256 JWT) to the client.
+// The client passes this to MusicKit.configure() before prompting the user
+// to authorize (which then returns a Music User Token for library/history access).
+//
+// Called by useAppleMusicAuth on the client before initiateAppleMusicAuth().
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const token = await getAppleDeveloperToken();
+    return new Response(
+      JSON.stringify({ token }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    // Log the full error server-side but return a generic message to the client
+    // so we don't leak internal config, key material, or env var names.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[apple-dev-token] Failed to generate token:", message);
+    return new Response(
+      JSON.stringify({ error: "Service temporarily unavailable" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/functions/apple-dev-token/index.ts
+++ b/supabase/functions/apple-dev-token/index.ts
@@ -11,6 +11,9 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
 
+// Wildcard origin is safe here — access is gated by the Supabase JWT
+// validation below, so no unauthenticated cross-origin caller can obtain
+// a token. Matches the CORS pattern used across the repo's edge functions.
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":

--- a/supabase/functions/apple-dev-token/index.ts
+++ b/supabase/functions/apple-dev-token/index.ts
@@ -1,10 +1,14 @@
-// Serves an Apple Music Developer Token (ES256 JWT) to the client.
+// Serves an Apple Music Developer Token (ES256 JWT) to authenticated clients.
 // The client passes this to MusicKit.configure() before prompting the user
 // to authorize (which then returns a Music User Token for library/history access).
+//
+// Requires a valid Supabase user session — prevents anonymous abuse of the
+// Apple Music API quota by third parties scraping the endpoint.
 //
 // Called by useAppleMusicAuth on the client before initiateAppleMusicAuth().
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
 
 const corsHeaders = {
@@ -18,7 +22,34 @@ serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
 
+  // Require a valid Supabase session — the client library includes the user's
+  // JWT automatically via supabase.functions.invoke.
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+
   try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error("Supabase environment not configured");
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey);
+    const { data: userData, error: userError } = await supabase.auth.getUser(
+      authHeader.replace(/^Bearer\s+/i, "")
+    );
+    if (userError || !userData?.user) {
+      return new Response(
+        JSON.stringify({ error: "Unauthorized" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
     const token = await getAppleDeveloperToken();
     return new Response(
       JSON.stringify({ token }),


### PR DESCRIPTION
## Summary
- Adds `AppleMusicPlaybackEngine` implementing the same `PlaybackEngine` interface as `SpotifyPlaybackEngine`, using MusicKit JS v3 with native event-driven playback (no polling)
- Adds full auth infrastructure: `apple-token.ts` shared module (ES256 JWT), `apple-dev-token` edge function, `useAppleMusicAuth` hook (popup authorize), `useAppleMusicToken` hook (localStorage + refresh)
- `PlayerContext` branches engine creation on `profile.streamingService` — Spotify and Apple Music are mutually exclusive, user picks one
- MusicKit JS v3 type stubs for the subset of APIs used
- Security: `.p8` files added to `.gitignore` (Apple Music private keys)

## What's NOT in this PR (deferred to Phase 5+6)
- `apple-taste` edge function (the client calls it but it's not implemented yet — `useAppleMusicAuth.fetchAppleMusicTaste` will return null until Phase 5)
- Connect.tsx onboarding button (Apple Music option still disabled — Phase 6)
- Artist/Album/Search/Listen page integration for `apple::` prefixed routes (Phase 6)

## Required deployment steps
1. `supabase secrets set APPLE_MUSIC_KEY_ID=...` ✓ done
2. `supabase secrets set APPLE_MUSIC_TEAM_ID=...` ✓ done
3. `supabase secrets set APPLE_MUSIC_PRIVATE_KEY="$(cat AuthKey_XXXXXXXX.p8)"` ✓ done
4. `supabase functions deploy apple-dev-token` — **required before this PR merges**

## Test plan
### Unit tests (automated, 85 total, +43 new)
- [x] `routeParsing.test.ts` — Apple prefix/artist/album parsing (16 new)
- [x] `trackUri.test.ts` — service detection + ID extraction (8 new)
- [x] `useAppleMusicToken.test.ts` — localStorage state, hook transitions, token refresh (10 new)
- [x] `AppleMusicPlaybackEngine.test.ts` — lifecycle, state events, track-end detection (9 new)
- [x] `npm run build` passes
- [x] `npm test` — 85/85 passing

### End-to-end tests (manual, after deploy)
**Requires an Apple Music subscription on the test account.**

**Regression (Spotify — should be unchanged):**
- [ ] Sign in with Spotify → browse → play track → full playback works
- [ ] Track end triggers nugget generation (onEnded still fires)
- [ ] External playback detection (play on phone) still works
- [ ] Seek, pause, resume all still work
- [ ] No console errors

**Apple Music happy path:**
- [ ] Open DevTools, manually set `localStorage.spotify_playback_token` to null and set `profile.streamingService = "Apple Music"` (until Connect.tsx is wired in Phase 6)
- [ ] Hard-reload → PlayerContext should create an AppleMusicPlaybackEngine instead of Spotify
- [ ] Manually call `initiateAppleMusicAuth()` from console → Apple popup appears
- [ ] After authorize, localStorage has `apple_music_token` with both tokens
- [ ] Navigate to `/listen/real::Radiohead::Weird Fishes/Arpeggi::In Rainbows::apple:song:1109714940` (use a real Apple Music catalog ID)
- [ ] Engine calls `setQueue({ song: "1109714940", startPlaying: true })`
- [ ] Track plays, position updates via `playbackTimeDidChange` events (verify in DevTools: no 250ms polling interval)
- [ ] Play/pause/seek controls work
- [ ] Track reaches end → `onEnded` fires → next track navigation triggers

**Apple Music error paths:**
- [ ] User without subscription: playback should fail gracefully (console error, no crash)
- [ ] User cancels the authorize popup: `initiateAppleMusicAuth()` returns null, no token stored
- [ ] Revoked authorization mid-session: next playback attempt should error cleanly
- [ ] Expired Developer Token: `getDeveloperToken()` refetches from the edge function

**Edge function verification:**
- [ ] `curl` the `apple-dev-token` function directly — returns `{ token: "eyJ..." }` (valid JWT)
- [ ] Decode the JWT at jwt.io — verify `alg: ES256`, `kid` matches Key ID, `iss` matches Team ID, `exp` ~180 days out

### What will break if shipped alone (documented, not blockers)
- Users who select Apple Music during onboarding currently can't (Connect.tsx button still disabled)
- `fetchAppleMusicTaste` calls a non-existent `apple-taste` function → returns null, falls through to empty taste profile
- Apple Music users can't search, view artists, or view albums yet (those use Spotify-only edge functions)

These gaps are filled in Phase 5+6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)