### PR TITLE
fix: smooth Apple Music progress bar + preview diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ scripts/pipeline-comparison/
 # Supabase local CLI state
 supabase/.temp/
 .vercel
+.gstack/

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -143,7 +143,18 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
    *  requires a valid Music User Token).
    *
    *  Only booleans are logged for any token field — the Music User Token
-   *  is a short-lived credential and must never be logged in full. */
+   *  is a short-lived credential and must never be logged in full.
+   *
+   *  TODO: This diagnostic is intentionally always-on to investigate a
+   *  live preview-playback bug on staging. Once that's resolved, either
+   *  gate behind `import.meta.env.DEV` or a `debug` option in
+   *  AppleMusicPlaybackEngineOptions, or remove entirely.
+   *
+   *  The `as unknown as {...}` cast below bypasses the MusicKit JS v3
+   *  type definitions to read fields the official types don't expose
+   *  (e.g. `storefrontId`, `musicUserToken`). Verified against MusicKit
+   *  JS v3. If Apple renames/moves these, the optional chaining below
+   *  will silently log `undefined` instead of throwing. */
   private async logSubscriptionStatus(): Promise<void> {
     if (!this.music) return;
     const m = this.music as unknown as {

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -12,6 +12,11 @@ import type { PlaybackEngine, PlaybackState } from "./types";
 import { loadMusicKitSDK } from "@/lib/musickitLoader";
 import { getIdFromUri, getServiceFromUri } from "@/lib/trackUri";
 
+/** Apple Music preview clips are exactly 30 seconds. Anything at or below
+ *  this at playback start means MusicKit served a preview instead of the
+ *  full track — almost always a subscription issue. */
+const APPLE_MUSIC_PREVIEW_DURATION_S = 30;
+
 // ── Engine ────────────────────────────────────────────────────────────
 
 export interface AppleMusicPlaybackEngineOptions {
@@ -45,6 +50,9 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   private hasAutoPlayed = false;
   private _isPlaying = false;
   private pollInterval: number | null = null;
+  private lastPolledTime = -1;
+  private lastPolledDuration = -1;
+  private hasLoggedSubscriptionStatus = false;
 
   // Subscribers
   private stateListeners: Set<(s: PlaybackState) => void> = new Set();
@@ -116,11 +124,10 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     instance.addEventListener("playbackStateDidChange", this.boundStateHandler);
     instance.addEventListener("playbackTimeDidChange", this.boundTimeHandler);
 
-    // Log subscription status for diagnostics. Preview-mode playback
-    // (30s clips instead of full tracks) almost always means the Apple ID
-    // has no active Apple Music subscription, but other causes exist
-    // (dev token scope, auth state) — dump everything observable.
-    this.logSubscriptionStatus();
+    // NOTE: subscription diagnostics fire on the first playbackStateDidChange,
+    // not here. At configure() resolve time, isAuthorized/musicUserToken
+    // may not be fully populated yet — MusicKit finalizes auth state
+    // asynchronously after the configure promise resolves.
 
     // Auto-play pending URI that was stored before configure resolved
     if (this.lastUri && !this.hasAutoPlayed) {
@@ -132,7 +139,10 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
    *  user's authorization and storefront. Apple doesn't publish a
    *  `/v1/me/subscription` endpoint, so we lean on `isAuthorized`,
    *  `storefrontCountryCode`, and a `/v1/me/storefront` round-trip (which
-   *  requires a valid Music User Token). */
+   *  requires a valid Music User Token).
+   *
+   *  Only booleans are logged for any token field — the Music User Token
+   *  is a short-lived credential and must never be logged in full. */
   private async logSubscriptionStatus(): Promise<void> {
     if (!this.music) return;
     const m = this.music as unknown as {
@@ -149,8 +159,8 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
       isAuthorized: m.isAuthorized,
       storefrontCountryCode: m.storefrontCountryCode,
       storefrontId: m.storefrontId,
-      hasMusicUserToken: !!m.musicUserToken,
-      hasDeveloperToken: !!m.developerToken,
+      hasMusicUserToken: !!m.musicUserToken, // boolean only — never log the token value
+      hasDeveloperToken: !!m.developerToken, // boolean only — never log the token value
     };
     console.log("[AppleMusic] subscription snapshot:", snapshot);
 
@@ -301,6 +311,13 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   private handlePlaybackState(event: MusicKit.PlaybackStateEvent): void {
     if (this.cancelled || !this.music) return;
 
+    // First state change after configure — now that MusicKit has settled,
+    // log the subscription snapshot. Guarded so it only fires once.
+    if (!this.hasLoggedSubscriptionStatus) {
+      this.hasLoggedSubscriptionStatus = true;
+      this.logSubscriptionStatus();
+    }
+
     const state = event.state;
     const PS = window.MusicKit?.PlaybackStates;
     if (!PS) return;
@@ -310,11 +327,16 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     if (isPlaying) this.hasPlayed = true;
 
     // Preview detection: a full-track setQueue that reports
-    // currentPlaybackDuration ≤ 30s means MusicKit handed us a preview
-    // clip instead of the full track — almost always a subscription issue.
-    if (isPlaying && this.music.currentPlaybackDuration && this.music.currentPlaybackDuration <= 30) {
+    // currentPlaybackDuration ≤ APPLE_MUSIC_PREVIEW_DURATION_S means
+    // MusicKit handed us a preview clip instead of the full track —
+    // almost always a subscription issue.
+    if (
+      isPlaying &&
+      this.music.currentPlaybackDuration &&
+      this.music.currentPlaybackDuration <= APPLE_MUSIC_PREVIEW_DURATION_S
+    ) {
       console.warn(
-        "[AppleMusic] Playing a 30s preview clip, not full track.",
+        "[AppleMusic] Playing a preview clip, not full track.",
         "Duration:", this.music.currentPlaybackDuration,
         "— check Apple Music subscription status."
       );
@@ -359,15 +381,22 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
 
   /** Poll currentPlaybackTime at 250ms to smooth the progress bar. MusicKit's
    *  playbackTimeDidChange event fires ~1s which makes the bar look chunky
-   *  vs Spotify's 250ms cadence. */
+   *  vs Spotify's 250ms cadence. Skips emission when time and duration
+   *  haven't changed since the last poll to avoid forcing no-op React
+   *  re-renders during buffering/stalled playback. */
   private startPolling(): void {
     if (this.pollInterval !== null) return;
     this.pollInterval = window.setInterval(() => {
       if (!this.music || this.cancelled) return;
+      const t = this.music.currentPlaybackTime || 0;
+      const d = this.music.currentPlaybackDuration || 0;
+      if (t === this.lastPolledTime && d === this.lastPolledDuration) return;
+      this.lastPolledTime = t;
+      this.lastPolledDuration = d;
       this.emitState({
         isPlaying: this._isPlaying,
-        currentTime: this.music.currentPlaybackTime || 0,
-        duration: this.music.currentPlaybackDuration || 0,
+        currentTime: t,
+        duration: d,
       });
     }, 250);
   }
@@ -377,5 +406,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
       window.clearInterval(this.pollInterval);
       this.pollInterval = null;
     }
+    this.lastPolledTime = -1;
+    this.lastPolledDuration = -1;
   }
 }

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -165,9 +165,19 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     };
     console.log("[AppleMusic] subscription snapshot:", snapshot);
 
+    // The /v1/me/storefront call is a MUT validity probe. Log just the
+    // extracted storefront id rather than the whole response so the
+    // diagnostic stays tight — the rest of the payload (supported
+    // languages, etc.) is noise for what we're trying to diagnose.
     try {
-      const storefront = await m.api?.music?.("v1/me/storefront");
-      console.log("[AppleMusic] /v1/me/storefront:", storefront);
+      const storefront = await m.api?.music?.("v1/me/storefront") as {
+        data?: Array<{ id?: string; attributes?: { name?: string } }>;
+      } | undefined;
+      const entry = storefront?.data?.[0];
+      console.log("[AppleMusic] /v1/me/storefront ok:", {
+        id: entry?.id,
+        name: entry?.attributes?.name,
+      });
     } catch (err) {
       console.warn("[AppleMusic] /v1/me/storefront failed:", err);
     }
@@ -330,12 +340,14 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this._isPlaying = isPlaying;
     if (isPlaying) this.hasPlayed = true;
 
-    // Preview detection: a full-track setQueue that reports
-    // currentPlaybackDuration ≤ APPLE_MUSIC_PREVIEW_DURATION_S means
-    // MusicKit handed us a preview clip instead of the full track —
-    // almost always a subscription issue. Gated by hasWarnedPreview so
-    // a short track paused/resumed many times doesn't spam the console;
-    // reset in loadTrack() when a new URI commits.
+    // Short-duration detection: currentPlaybackDuration ≤
+    // APPLE_MUSIC_PREVIEW_DURATION_S often means MusicKit served a
+    // preview clip instead of the full track (subscription issue), but
+    // a genuinely short track (interlude, ambient, skit) will also hit
+    // this. The warning includes the URI so a developer can verify at
+    // a glance whether the short duration is legit. Gated by
+    // hasWarnedPreview to avoid console spam on pause/resume; reset
+    // in loadTrack() when a new URI commits.
     if (
       !this.hasWarnedPreview &&
       isPlaying &&
@@ -344,9 +356,9 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     ) {
       this.hasWarnedPreview = true;
       console.warn(
-        "[AppleMusic] Playing a preview clip, not full track.",
-        "Duration:", this.music.currentPlaybackDuration,
-        "— check Apple Music subscription status."
+        "[AppleMusic] Short duration detected (likely preview clip).",
+        { duration: this.music.currentPlaybackDuration, trackUri: this.lastUri },
+        "— verify the track is not legitimately short and check Apple Music subscription."
       );
     }
 

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -53,6 +53,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   private lastPolledTime = -1;
   private lastPolledDuration = -1;
   private hasLoggedSubscriptionStatus = false;
+  private hasWarnedPreview = false;
 
   // Subscribers
   private stateListeners: Set<(s: PlaybackState) => void> = new Set();
@@ -203,6 +204,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this.hasPlayed = false;
     this.hasAutoPlayed = false;
     this._isPlaying = false;
+    this.hasWarnedPreview = false;
 
     try { this.music?.stop(); } catch { /* already stopped */ }
 
@@ -313,9 +315,11 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
 
     // First state change after configure — now that MusicKit has settled,
     // log the subscription snapshot. Guarded so it only fires once.
+    // .catch() handles any unexpected rejection from the fire-and-forget
+    // async call; the method already catches its own API errors.
     if (!this.hasLoggedSubscriptionStatus) {
       this.hasLoggedSubscriptionStatus = true;
-      this.logSubscriptionStatus();
+      this.logSubscriptionStatus().catch(() => { /* diagnostic only */ });
     }
 
     const state = event.state;
@@ -329,12 +333,16 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // Preview detection: a full-track setQueue that reports
     // currentPlaybackDuration ≤ APPLE_MUSIC_PREVIEW_DURATION_S means
     // MusicKit handed us a preview clip instead of the full track —
-    // almost always a subscription issue.
+    // almost always a subscription issue. Gated by hasWarnedPreview so
+    // a short track paused/resumed many times doesn't spam the console;
+    // reset in loadTrack() when a new URI commits.
     if (
+      !this.hasWarnedPreview &&
       isPlaying &&
       this.music.currentPlaybackDuration &&
       this.music.currentPlaybackDuration <= APPLE_MUSIC_PREVIEW_DURATION_S
     ) {
+      this.hasWarnedPreview = true;
       console.warn(
         "[AppleMusic] Playing a preview clip, not full track.",
         "Duration:", this.music.currentPlaybackDuration,
@@ -370,6 +378,12 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     });
   }
 
+  /** Native playbackTimeDidChange events fire at ~1s cadence. This path
+   *  coexists with the 250ms poll in startPolling() intentionally: the
+   *  event gives us the authoritative value from MusicKit whenever it
+   *  fires, and the poll smooths the gaps between fires so the progress
+   *  bar doesn't look chunky. Both call emitState — don't delete one
+   *  thinking the other makes it redundant. */
   private handleTimeChange(event: MusicKit.PlaybackTimeEvent): void {
     if (this.cancelled) return;
     this.emitState({

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -44,6 +44,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   private hasPlayed = false;
   private hasAutoPlayed = false;
   private _isPlaying = false;
+  private pollInterval: number | null = null;
 
   // Subscribers
   private stateListeners: Set<(s: PlaybackState) => void> = new Set();
@@ -109,9 +110,17 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this._ready = true;
     this.onReadyCb?.(null);
 
-    // Wire up native events (no polling needed)
+    // Wire up native playback events. We still poll at 250ms for smooth
+    // progress-bar updates — playbackTimeDidChange fires ~1s which looks
+    // chunky compared to Spotify's 250ms cadence.
     instance.addEventListener("playbackStateDidChange", this.boundStateHandler);
     instance.addEventListener("playbackTimeDidChange", this.boundTimeHandler);
+
+    // Log subscription status for diagnostics. Preview-mode playback
+    // (30s clips instead of full tracks) almost always means the Apple ID
+    // has no active Apple Music subscription, but other causes exist
+    // (dev token scope, auth state) — dump everything observable.
+    this.logSubscriptionStatus();
 
     // Auto-play pending URI that was stored before configure resolved
     if (this.lastUri && !this.hasAutoPlayed) {
@@ -119,8 +128,43 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     }
   }
 
+  /** Best-effort subscription probe. Logs what MusicKit exposes about the
+   *  user's authorization and storefront. Apple doesn't publish a
+   *  `/v1/me/subscription` endpoint, so we lean on `isAuthorized`,
+   *  `storefrontCountryCode`, and a `/v1/me/storefront` round-trip (which
+   *  requires a valid Music User Token). */
+  private async logSubscriptionStatus(): Promise<void> {
+    if (!this.music) return;
+    const m = this.music as unknown as {
+      isAuthorized?: boolean;
+      storefrontCountryCode?: string;
+      storefrontId?: string;
+      musicUserToken?: string;
+      developerToken?: string;
+      api?: {
+        music?: (path: string, params?: unknown) => Promise<unknown>;
+      };
+    };
+    const snapshot = {
+      isAuthorized: m.isAuthorized,
+      storefrontCountryCode: m.storefrontCountryCode,
+      storefrontId: m.storefrontId,
+      hasMusicUserToken: !!m.musicUserToken,
+      hasDeveloperToken: !!m.developerToken,
+    };
+    console.log("[AppleMusic] subscription snapshot:", snapshot);
+
+    try {
+      const storefront = await m.api?.music?.("v1/me/storefront");
+      console.log("[AppleMusic] /v1/me/storefront:", storefront);
+    } catch (err) {
+      console.warn("[AppleMusic] /v1/me/storefront failed:", err);
+    }
+  }
+
   cleanup(): void {
     this.cancelled = true;
+    this.stopPolling();
     if (this.music) {
       try {
         this.music.removeEventListener("playbackStateDidChange", this.boundStateHandler);
@@ -265,6 +309,17 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this._isPlaying = isPlaying;
     if (isPlaying) this.hasPlayed = true;
 
+    // Preview detection: a full-track setQueue that reports
+    // currentPlaybackDuration ≤ 30s means MusicKit handed us a preview
+    // clip instead of the full track — almost always a subscription issue.
+    if (isPlaying && this.music.currentPlaybackDuration && this.music.currentPlaybackDuration <= 30) {
+      console.warn(
+        "[AppleMusic] Playing a 30s preview clip, not full track.",
+        "Duration:", this.music.currentPlaybackDuration,
+        "— check Apple Music subscription status."
+      );
+    }
+
     // End-of-track detection: MusicKit reports "completed" (10) or "ended"
     // (5) when a track finishes naturally. "stopped" is deliberately NOT
     // included — MusicKit also emits it during buffering transitions and
@@ -272,11 +327,18 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // which would cause phantom onEnded fires.
     const isEnd = state === PS.completed || state === PS.ended;
     if (isEnd && this.hasPlayed && this.lastUri) {
+      this.stopPolling();
       this.lastUri = null;
       this.hasPlayed = false;
       for (const cb of this.endListeners) cb();
       return;
     }
+
+    // Drive the progress bar at 250ms while playing. Stop the interval
+    // whenever playback isn't active so we don't leak timers or emit
+    // spurious time updates while paused/buffering.
+    if (isPlaying) this.startPolling();
+    else this.stopPolling();
 
     // Emit state update with latest time/duration from the instance
     this.emitState({
@@ -293,5 +355,27 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
       currentTime: event.currentPlaybackTime || 0,
       duration: event.currentPlaybackDuration || 0,
     });
+  }
+
+  /** Poll currentPlaybackTime at 250ms to smooth the progress bar. MusicKit's
+   *  playbackTimeDidChange event fires ~1s which makes the bar look chunky
+   *  vs Spotify's 250ms cadence. */
+  private startPolling(): void {
+    if (this.pollInterval !== null) return;
+    this.pollInterval = window.setInterval(() => {
+      if (!this.music || this.cancelled) return;
+      this.emitState({
+        isPlaying: this._isPlaying,
+        currentTime: this.music.currentPlaybackTime || 0,
+        duration: this.music.currentPlaybackDuration || 0,
+      });
+    }, 250);
+  }
+
+  private stopPolling(): void {
+    if (this.pollInterval !== null) {
+      window.clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    }
   }
 }

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -194,4 +194,200 @@ describe("AppleMusicPlaybackEngine", () => {
     expect(mockMusic.removeEventListener).toHaveBeenCalledWith("playbackTimeDidChange", expect.any(Function));
     expect(mockMusic.stop).toHaveBeenCalled();
   });
+
+  // ── Polling lifecycle ─────────────────────────────────────────────────
+
+  it("polls currentPlaybackTime at 250ms while playing", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 10;
+      mockMusic.currentPlaybackDuration = 200;
+
+      // Enter playing state — starts the interval
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+      stateSpy.mockClear();
+
+      mockMusic.currentPlaybackTime = 10.25;
+      vi.advanceTimersByTime(250);
+      expect(stateSpy).toHaveBeenCalledWith(expect.objectContaining({ currentTime: 10.25 }));
+
+      mockMusic.currentPlaybackTime = 10.5;
+      vi.advanceTimersByTime(250);
+      expect(stateSpy).toHaveBeenCalledWith(expect.objectContaining({ currentTime: 10.5 }));
+
+      expect(stateSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops polling when playback pauses", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 5;
+      mockMusic.currentPlaybackDuration = 200;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+      vi.advanceTimersByTime(250);
+      stateCb!({ state: 3 /* paused */ });
+      stateSpy.mockClear();
+
+      // Time advances past several poll intervals but we're paused — no more ticks
+      mockMusic.currentPlaybackTime = 6;
+      vi.advanceTimersByTime(1000);
+
+      // Only the state-change event itself may emit; the interval must not fire.
+      // Filter the spy to just "driven by the poll" calls — those would be the
+      // ones fired without an accompanying state-change event. Since we cleared
+      // above and don't fire another state-change, any call means the poll leaked.
+      expect(stateSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips emission when polled time and duration are unchanged", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 7;
+      mockMusic.currentPlaybackDuration = 200;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+      stateSpy.mockClear();
+
+      // First tick records values
+      vi.advanceTimersByTime(250);
+      const firstCallCount = stateSpy.mock.calls.length;
+
+      // Subsequent ticks with no change should not emit
+      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
+
+      expect(stateSpy.mock.calls.length).toBe(firstCallCount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cleanup() stops polling so no interval leaks", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+
+      engine.cleanup();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 99;
+      vi.advanceTimersByTime(1000);
+
+      expect(stateSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("warns when currentPlaybackDuration is ≤30s at playback start", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 30;
+      mockMusic.currentPlaybackTime = 0;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("preview clip"),
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not warn when currentPlaybackDuration is a full track", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 429;
+      mockMusic.currentPlaybackTime = 0;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+
+      const previewWarns = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("preview clip")
+      );
+      expect(previewWarns.length).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("logs subscription snapshot once, on the first state change (not during init)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      // init() must NOT emit the snapshot — auth state isn't guaranteed
+      // populated at configure() resolve time.
+      const initSnapshots = logSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("subscription snapshot")
+      );
+      expect(initSnapshots.length).toBe(0);
+
+      // First state change fires the snapshot
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+
+      const afterFirst = logSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("subscription snapshot")
+      );
+      expect(afterFirst.length).toBe(1);
+
+      // A second state change must not log the snapshot again
+      stateCb!({ state: 3 });
+      const afterSecond = logSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("subscription snapshot")
+      );
+      expect(afterSecond.length).toBe(1);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -327,9 +327,8 @@ describe("AppleMusicPlaybackEngine", () => {
       stateCb!({ state: 2 /* playing */ });
 
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("preview clip"),
-        expect.anything(),
-        expect.anything(),
+        expect.stringContaining("Short duration"),
+        expect.objectContaining({ duration: 30 }),
         expect.anything()
       );
     } finally {
@@ -355,7 +354,7 @@ describe("AppleMusicPlaybackEngine", () => {
       stateCb!({ state: 2 });
 
       const previewWarns = warnSpy.mock.calls.filter((args) =>
-        typeof args[0] === "string" && args[0].includes("preview clip")
+        typeof args[0] === "string" && args[0].includes("Short duration")
       );
       expect(previewWarns.length).toBe(1);
     } finally {
@@ -379,7 +378,7 @@ describe("AppleMusicPlaybackEngine", () => {
       stateCb!({ state: 2 });
 
       const previewWarns = warnSpy.mock.calls.filter((args) =>
-        typeof args[0] === "string" && args[0].includes("preview clip")
+        typeof args[0] === "string" && args[0].includes("Short duration")
       );
       expect(previewWarns.length).toBe(2);
     } finally {
@@ -430,7 +429,7 @@ describe("AppleMusicPlaybackEngine", () => {
       stateCb!({ state: 2 });
 
       const previewWarns = warnSpy.mock.calls.filter((args) =>
-        typeof args[0] === "string" && args[0].includes("preview clip")
+        typeof args[0] === "string" && args[0].includes("Short duration")
       );
       expect(previewWarns.length).toBe(0);
     } finally {

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -337,6 +337,86 @@ describe("AppleMusicPlaybackEngine", () => {
     }
   });
 
+  it("preview warn fires once per track even across multiple pause/resume cycles", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 30;
+      mockMusic.currentPlaybackTime = 0;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      // playing → paused → playing → paused → playing
+      stateCb!({ state: 2 });
+      stateCb!({ state: 3 });
+      stateCb!({ state: 2 });
+      stateCb!({ state: 3 });
+      stateCb!({ state: 2 });
+
+      const previewWarns = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("preview clip")
+      );
+      expect(previewWarns.length).toBe(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preview warn re-arms when loadTrack commits a new URI", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 30;
+      const stateCb = eventListeners.get("playbackStateDidChange");
+
+      await engine.loadTrack("apple:song:111");
+      stateCb!({ state: 2 });
+
+      await engine.loadTrack("apple:song:222");
+      stateCb!({ state: 2 });
+
+      const previewWarns = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("preview clip")
+      );
+      expect(previewWarns.length).toBe(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("stopPolling resets lastPolledTime so first tick after resume always emits", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 42;
+      mockMusic.currentPlaybackDuration = 200;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+      vi.advanceTimersByTime(250); // records t=42
+      stateCb!({ state: 3 /* paused — stopPolling, reset last* */ });
+      stateSpy.mockClear();
+
+      // Resume with the SAME time — without the reset, the poll would
+      // skip this tick because t hasn't changed.
+      stateCb!({ state: 2 });
+      stateSpy.mockClear();
+      vi.advanceTimersByTime(250);
+
+      expect(stateSpy).toHaveBeenCalledWith(expect.objectContaining({ currentTime: 42 }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not warn when currentPlaybackDuration is a full track", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {


### PR DESCRIPTION
## Summary
- Drives the Apple Music progress bar at 250ms via `setInterval`, matching Spotify. MusicKit's `playbackTimeDidChange` event only fires ~1s which made the bar chunky. Polling reads `currentPlaybackTime` continuously so UI updates are smooth.
- Adds subscription diagnostics: logs `isAuthorized`, storefront, token presence, and a `/v1/me/storefront` round-trip when the engine boots. Also warns when a track starts playback with `currentPlaybackDuration ≤ 30s`, which almost always means MusicKit handed us a preview clip instead of a full track.
- Polling is started when `handlePlaybackState` reports playing and stopped on pause / end-of-track / cleanup — no leaked timers.

## Test plan
- [x] `npm test` — 107 passed
- [x] `npm run build` — clean
- [ ] Manually verify on staging: Apple Music progress bar updates smoothly (~250ms cadence) instead of jumping in 1s chunks
- [ ] Console should log the subscription snapshot and `/v1/me/storefront` response on engine init — use this to diagnose the 30s preview issue reported against https://mntv-c6d81rant-musicnerd.vercel.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)