### PR TITLE
fix: client-side headline guard for empty server headlines

### DIFF
--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -44,15 +44,19 @@ export function makeTimestamp(index: number, totalNuggets: number, durationSec: 
   return Math.min(Math.floor(earlyStart + spacing * (index + 1)), durationSec - 10);
 }
 
-function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {
+export function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {
   // Client-side headline guard — if server sent an empty headline,
   // derive one from the text (same logic as server-side generateHeadlineFromText).
-  let headline = n.headline || "";
-  if (!headline.trim() && n.text?.trim()) {
-    const first = n.text.split(/[.!?]\s/)[0]?.trim();
+  let headline = n.headline;
+  if (!headline.trim() && n.text.trim()) {
+    const first = n.text.split(/[.!?]\s+/)[0]?.trim();
     headline = first && first.length > 10
       ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
-      : n.text.slice(0, 80);
+      : (n.text.length > 80 ? n.text.slice(0, 77) + "..." : n.text);
+  }
+  // Last resort — both headline and text empty (malformed server response)
+  if (!headline.trim()) {
+    headline = "Music Fact";
   }
   return {
     id: nuggetId, trackId, timestampSec, durationMs: 7000,

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -49,7 +49,7 @@ export function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, 
   // derive one from the text (same logic as server-side generateHeadlineFromText).
   let headline = n.headline;
   if (!headline.trim() && n.text.trim()) {
-    const first = n.text.split(/[.!?]\s+/)[0]?.trim();
+    const first = n.text.split(/[.!?]\s+/)[0].trim().replace(/[.!?]+$/, "");
     headline = first && first.length > 10
       ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
       : (n.text.length > 80 ? n.text.slice(0, 77) + "..." : n.text);

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -45,9 +45,18 @@ export function makeTimestamp(index: number, totalNuggets: number, durationSec: 
 }
 
 function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {
+  // Client-side headline guard — if server sent an empty headline,
+  // derive one from the text (same logic as server-side generateHeadlineFromText).
+  let headline = n.headline || "";
+  if (!headline.trim() && n.text?.trim()) {
+    const first = n.text.split(/[.!?]\s/)[0]?.trim();
+    headline = first && first.length > 10
+      ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
+      : n.text.slice(0, 80);
+  }
   return {
     id: nuggetId, trackId, timestampSec, durationMs: 7000,
-    headline: n.headline, text: n.text, kind: n.kind,
+    headline, text: n.text, kind: n.kind,
     listenFor: n.listenFor || false, sourceId,
     imageUrl: n.imageUrl, imageCaption: n.imageCaption,
   };

--- a/src/test/makeNugget.test.ts
+++ b/src/test/makeNugget.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { makeNugget } from "@/hooks/useAINuggets";
+
+const baseSource = {
+  type: "article" as const,
+  title: "Test Source",
+  publisher: "Pitchfork",
+};
+
+const make = (overrides: { headline?: string; text?: string }) => ({
+  headline: overrides.headline ?? "",
+  text: overrides.text ?? "",
+  kind: "artist" as const,
+  source: baseSource,
+});
+
+describe("makeNugget headline derivation", () => {
+  it("passes through a provided headline unchanged", () => {
+    const n = make({ headline: "A Great Fact", text: "Some body text." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("A Great Fact");
+  });
+
+  it("derives headline from the first sentence when headline is empty", () => {
+    const n = make({ headline: "", text: "He played guitar on the track. The album was released later." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("He played guitar on the track");
+  });
+
+  it("splits on newline-separated sentences (not just space)", () => {
+    const n = make({ headline: "", text: "He played guitar.\nThe album dropped in 1975." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("He played guitar");
+  });
+
+  it("falls back to truncated text when first sentence is too short (≤ 10 chars)", () => {
+    const longTail = "A".repeat(120);
+    const n = make({ headline: "", text: `Hi. ${longTail}` });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe(`Hi. ${longTail}`.slice(0, 77) + "...");
+  });
+
+  it("truncates long first sentences with ellipsis", () => {
+    const longSentence = "A".repeat(100) + ". Second sentence.";
+    const n = make({ headline: "", text: longSentence });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("A".repeat(77) + "...");
+    expect(result.headline.length).toBe(80);
+  });
+
+  it("truncates short-first-sentence fallback consistently with ellipsis", () => {
+    const longTail = "B".repeat(100);
+    const n = make({ headline: "", text: `Ok. ${longTail}` });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline.endsWith("...")).toBe(true);
+    expect(result.headline.length).toBe(80);
+  });
+
+  it("uses 'Music Fact' placeholder when both headline and text are empty", () => {
+    const n = make({ headline: "", text: "" });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("Music Fact");
+  });
+
+  it("uses placeholder when both fields are whitespace-only", () => {
+    const n = make({ headline: "   ", text: "\n\t " });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("Music Fact");
+  });
+
+  it("preserves other nugget fields", () => {
+    const n = make({ headline: "Hello", text: "Body." });
+    const result = makeNugget(n, "nug-42", "src-42", "track-99", 123);
+    expect(result.id).toBe("nug-42");
+    expect(result.sourceId).toBe("src-42");
+    expect(result.trackId).toBe("track-99");
+    expect(result.timestampSec).toBe(123);
+    expect(result.text).toBe("Body.");
+    expect(result.kind).toBe("artist");
+  });
+});

--- a/src/test/makeNugget.test.ts
+++ b/src/test/makeNugget.test.ts
@@ -56,6 +56,26 @@ describe("makeNugget headline derivation", () => {
     expect(result.headline.length).toBe(80);
   });
 
+  it("derives headline when server sends whitespace-only headline + valid text", () => {
+    const n = make({ headline: "   ", text: "He played guitar on the track. More text." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("He played guitar on the track");
+  });
+
+  it("handles ! and ? sentence endings", () => {
+    const exclaim = make({ headline: "", text: "What a solo! This is the key part." });
+    expect(makeNugget(exclaim, "nug-1", "src-1", "track-1", 60).headline).toBe("What a solo");
+
+    const question = make({ headline: "", text: "Did you hear that riff? It changed rock music." });
+    expect(makeNugget(question, "nug-2", "src-2", "track-1", 60).headline).toBe("Did you hear that riff");
+  });
+
+  it("strips trailing punctuation from single-sentence text", () => {
+    const n = make({ headline: "", text: "Only sentence." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("Only sentence");
+  });
+
   it("uses 'Music Fact' placeholder when both headline and text are empty", () => {
     const n = make({ headline: "", text: "" });
     const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);


### PR DESCRIPTION
## Problem
Nuggets arriving with empty headlines show a blank area in the immersive view (no headline, no typewriter). The server-side `generateHeadlineFromText` guard exists in the edge function but hadn't been deployed to the new xdjs Supabase project.

## Fix
1. **Redeployed `generate-nuggets` edge function** to `ofuayztvadxtacmsevxk` with the headline guard
2. **Client-side guard in `makeNugget`** — derives a headline from the first sentence of the text if the server sends an empty one. Belt-and-suspenders with the server-side fix.