### PR TITLE
release: Apple Music playback + headline guard fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ scripts/pipeline-comparison/
 # Supabase local CLI state
 supabase/.temp/
 .vercel
+.gstack/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ dist-ssr
 .env
 .env.*
 
+# Apple Music private keys (NEVER commit these)
+*.p8
+AuthKey_*.p8
+
 # Scripts with DB credentials
 scripts/fix-caches.sh
 scripts/seed-demo-resumable.sh

--- a/src/components/AppleMusicComingSoon.tsx
+++ b/src/components/AppleMusicComingSoon.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+import PageTransition from "@/components/PageTransition";
+
+/** Shared "coming soon" placeholder shown on pages that don't yet support
+ *  Apple Music (artist detail, album detail). Phase 5 wires the underlying
+ *  edge functions; until then, these routes render this stub. */
+export default function AppleMusicComingSoon({
+  emoji,
+  title,
+  description,
+}: {
+  emoji: string;
+  title: string;
+  description: string;
+}) {
+  const navigate = useNavigate();
+  return (
+    <PageTransition>
+      <div className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+        <p className="text-5xl mb-6">{emoji}</p>
+        <h1 className="text-2xl font-black text-foreground mb-2">{title}</h1>
+        <p className="text-sm text-muted-foreground max-w-sm mb-8">{description}</p>
+        <button
+          onClick={() => navigate("/browse")}
+          className="rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity"
+        >
+          Back to Browse
+        </button>
+      </div>
+    </PageTransition>
+  );
+}

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Search, X, Loader2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { supabase } from "@/integrations/supabase/client";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
 
 interface SpotifyArtist { id: string; name: string; imageUrl: string }
 interface SpotifyTrack { title: string; artist: string; album: string; imageUrl: string; uri: string }
@@ -20,6 +21,8 @@ export default function SearchOverlay({ open, onClose }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const navigate = useNavigate();
+  const { profile } = useUserProfile();
+  const isAppleMusicUser = profile?.streamingService === "Apple Music";
 
   const hasSpotifyResults = spotifyResults && (spotifyResults.artists.length + spotifyResults.tracks.length > 0);
 
@@ -46,6 +49,8 @@ export default function SearchOverlay({ open, onClose }: Props) {
   }, []);
 
   useEffect(() => {
+    // Apple Music users: search isn't wired yet (Phase 5). Skip the debounce.
+    if (isAppleMusicUser) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!query.trim()) {
       setSpotifyResults(null);
@@ -55,7 +60,7 @@ export default function SearchOverlay({ open, onClose }: Props) {
     setSpotifyLoading(true);
     debounceRef.current = setTimeout(() => searchSpotify(query), 300);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-  }, [query, searchSpotify]);
+  }, [query, searchSpotify, isAppleMusicUser]);
 
   useEffect(() => {
     if (open) {
@@ -94,8 +99,9 @@ export default function SearchOverlay({ open, onClose }: Props) {
               ref={inputRef}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search artists, albums, tracks…"
-              className="flex-1 bg-transparent text-xl md:text-3xl font-bold text-foreground placeholder:text-muted-foreground/50 outline-none"
+              placeholder={isAppleMusicUser ? "Search coming soon for Apple Music" : "Search artists, albums, tracks…"}
+              disabled={isAppleMusicUser}
+              className="flex-1 bg-transparent text-xl md:text-3xl font-bold text-foreground placeholder:text-muted-foreground/50 outline-none disabled:cursor-not-allowed"
               style={{ fontFamily: "'Nunito Sans', sans-serif" }}
             />
             <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
@@ -105,12 +111,21 @@ export default function SearchOverlay({ open, onClose }: Props) {
 
           {/* Results */}
           <div className="flex-1 overflow-y-auto px-4 md:px-10 pt-6 md:pt-8 pb-20">
-            {noResults && (
+            {isAppleMusicUser && (
+              <div className="flex flex-col items-center justify-center text-center mt-20 px-6">
+                <p className="text-4xl mb-4">🎵</p>
+                <p className="text-xl font-bold text-foreground mb-2">Search is coming soon</p>
+                <p className="text-sm text-muted-foreground max-w-sm">
+                  Apple Music search isn't wired up yet. For now, use the demo tracks on the Browse page to explore MusicNerd TV.
+                </p>
+              </div>
+            )}
+            {!isAppleMusicUser && noResults && (
               <p className="text-muted-foreground text-lg">No results for "{query}"</p>
             )}
 
             {/* === Spotify results === */}
-            {query.trim().length >= 2 && (
+            {!isAppleMusicUser && query.trim().length >= 2 && (
               <>
                 {spotifyLoading && !hasSpotifyResults && (
                   <div className="flex items-center gap-2 text-muted-foreground mt-4">

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -1,8 +1,11 @@
 import { createContext, useContext, useRef, useState, useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { useSpotifyToken } from "@/hooks/useSpotifyToken";
+import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { useCurrentlyPlaying, type ExternalTrack } from "@/hooks/useCurrentlyPlaying";
 import { SpotifyPlaybackEngine, type SpotifyStateTrack } from "@/lib/engines/SpotifyPlaybackEngine";
-import type { ServiceType } from "@/lib/engines/types";
+import { AppleMusicPlaybackEngine } from "@/lib/engines/AppleMusicPlaybackEngine";
+import type { PlaybackEngine, ServiceType } from "@/lib/engines/types";
 import type { Nugget, Source } from "@/mock/types";
 
 // Re-export for consumers that import from PlayerContext
@@ -121,11 +124,13 @@ export function usePlayer(): PlayerContextType {
 
 export function PlayerProvider({ children }: { children: ReactNode }) {
   const { hasSpotifyToken, getValidToken } = useSpotifyToken();
+  const { hasMusicToken, getDeveloperToken } = useAppleMusicToken();
+  const { profile } = useUserProfile();
 
-  // Playback engine ref
-  const engineRef = useRef<SpotifyPlaybackEngine | null>(null);
+  // Playback engine ref (Spotify or Apple Music — selected by profile service)
+  const engineRef = useRef<PlaybackEngine | null>(null);
 
-  // Playback state (driven by engine callbacks)
+  // Playback state (driven by engine callbacks — generic across services)
   const [spReady, setSpReady] = useState(false);
   const [spPlaying, setSpPlaying] = useState(false);
   const [spTime, setSpTime] = useState(0);
@@ -143,10 +148,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
   const currentTrackUriRef = useRef<string | null>(null);
   currentTrackUriRef.current = currentTrackUri;
 
-  // External playback detection
+  // External playback detection — Spotify-only (Apple Music has no cross-device API)
   const [isExternalListenMode, setIsExternalListenMode] = useState(false);
   const externalTrack = useCurrentlyPlaying({
-    suppressPolling: activePlayer !== "none",
+    suppressPolling: activePlayer !== "none" || profile?.streamingService !== "Spotify",
     ownDeviceId: spDeviceId,
   });
   const setExternalListenMode = useCallback((mode: boolean) => {
@@ -220,44 +225,116 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     return prev;
   }, []);
 
-  // ── Engine init (once, on mount if token available) ────────────────
+  // ── Engine init (on profile service change, if token available) ────
+  //
+  // Two string namespaces at play here — don't confuse them:
+  //   • profile.streamingService: display label, "Spotify" | "Apple Music" | ""
+  //     (matches the DB `streaming_service` column and onboarding UI)
+  //   • engine.service (ServiceType): kebab-case id, "spotify" | "apple-music" | "none"
+  //     (used for PlayerContext's activePlayer state and engine dispatch)
+  //
+  // Profile strings are translated to engine strings below; engine.service is
+  // used downstream for setActivePlayer and syncExternalTrack guards.
+  const service = profile?.streamingService;
 
   useEffect(() => {
-    if (!hasSpotifyToken) return;
+    // Determine which engine to create based on profile service + token.
+    // Apple Music and Spotify are mutually exclusive — only one engine at a time.
 
-    const engine = new SpotifyPlaybackEngine({
-      getOAuthToken: getValidToken,
-      onReady: (deviceId) => {
-        setSpReady(true);
-        setSpDeviceId(deviceId);
-      },
-      onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
-      onDeviceLost: () => setSpPlaying(false),
-    });
+    if (service === "Apple Music" && hasMusicToken) {
+      let cancelled = false;
+      let currentEngine: AppleMusicPlaybackEngine | null = null;
+      let unsubState: (() => void) | null = null;
+      let unsubEnd: (() => void) | null = null;
 
-    const unsubState = engine.onStateChange((state) => {
-      setSpPlaying(state.isPlaying);
-      setSpTime(state.currentTime);
-      // duration is optional on PlaybackState (omitted = "keep current").
-      // Use != null to safely handle both undefined and null.
-      if (state.duration != null) setSpDuration(state.duration);
-    });
+      getDeveloperToken().then((devToken) => {
+        if (cancelled || !devToken) return;
+        const am = new AppleMusicPlaybackEngine({
+          developerToken: devToken,
+          onReady: () => {
+            // Guard against late onReady firing after the effect was cancelled
+            if (cancelled) return;
+            setSpReady(true);
+            setSpDeviceId(null);  // Apple Music has no device ID
+          },
+        });
+        currentEngine = am;
 
-    const unsubEnd = engine.onTrackEnd(() => {
-      onEndedRef.current?.();
-    });
+        unsubState = am.onStateChange((state) => {
+          setSpPlaying(state.isPlaying);
+          setSpTime(state.currentTime);
+          if (state.duration != null) setSpDuration(state.duration);
+        });
+        unsubEnd = am.onTrackEnd(() => {
+          onEndedRef.current?.();
+        });
 
-    engine.init();
-    engineRef.current = engine;
+        // Assign ref BEFORE init so the upgrade-to-engine effect can read
+        // engineRef.current?.service when spReady flips later.
+        engineRef.current = am;
+        am.init().catch((err) => {
+          console.error("[Player] Apple Music engine init failed:", err);
+          // Prevent a broken engine from poisoning engineRef — downstream
+          // code guards on spReady but this keeps the invariant clean.
+          if (engineRef.current === am) engineRef.current = null;
+        });
+      });
 
-    return () => {
-      unsubState();
-      unsubEnd();
-      engine.cleanup();
-      engineRef.current = null;
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasSpotifyToken]);
+      return () => {
+        cancelled = true;
+        unsubState?.();
+        unsubEnd?.();
+        currentEngine?.cleanup();
+        if (engineRef.current === currentEngine) engineRef.current = null;
+        setSpReady(false);
+        setSpDeviceId(null);
+      };
+    }
+
+    if (service === "Spotify" && hasSpotifyToken) {
+      const sp = new SpotifyPlaybackEngine({
+        getOAuthToken: getValidToken,
+        onReady: (deviceId) => {
+          setSpReady(true);
+          setSpDeviceId(deviceId);
+        },
+        onSpotifyStateTrack: (track) => setSpotifyStateTrack(track),
+        onDeviceLost: () => setSpPlaying(false),
+      });
+
+      const unsubState = sp.onStateChange((state) => {
+        setSpPlaying(state.isPlaying);
+        setSpTime(state.currentTime);
+        if (state.duration != null) setSpDuration(state.duration);
+      });
+      const unsubEnd = sp.onTrackEnd(() => {
+        onEndedRef.current?.();
+      });
+
+      // Assign ref BEFORE init so the upgrade-to-engine effect can read
+      // engineRef.current?.service when spReady flips later.
+      engineRef.current = sp;
+      sp.init().catch((err) => {
+        console.error("[Player] Spotify engine init failed:", err);
+        if (engineRef.current === sp) engineRef.current = null;
+      });
+
+      return () => {
+        unsubState();
+        unsubEnd();
+        sp.cleanup();
+        // Only null the ref if it still points to THIS engine — prevents
+        // clobbering a newer engine created by a rapid service switch.
+        if (engineRef.current === sp) engineRef.current = null;
+        setSpReady(false);
+        setSpDeviceId(null);
+      };
+    }
+
+    // No engine — user hasn't connected a service yet
+    return;
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- getValidToken and getDeveloperToken are useCallback([])-stable; re-including them would churn the effect on every parent re-render and destroy/recreate engines
+  }, [service, hasSpotifyToken, hasMusicToken]);
 
   // ── loadTrack ─────────────────────────────────────────────────────
 
@@ -276,14 +353,17 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     setSpDuration(0);
     setSpPlaying(false);
 
+    const engineService = engineRef.current?.service;
     setCurrentTrackUri(trackUri || null);
-    setActivePlayer(spReady && trackUri ? "spotify" : "none");
+    setActivePlayer(spReady && trackUri && engineService ? engineService : "none");
   }, [spReady]);
 
   /** Sync tracking state to match an externally-changed track.
+   *  Spotify-only — Apple Music has no cross-device detection.
    *  Unlike loadTrack, this does NOT pause or restart playback — the SDK
    *  is already playing the right track. */
   const syncExternalTrack = useCallback((trackUri: string) => {
+    if (engineRef.current?.service !== "spotify") return;
     setCurrentTrackUri(trackUri);
     currentTrackUriRef.current = trackUri;
     hasAutoPlayedRef.current = true;
@@ -293,19 +373,20 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     engineRef.current?.syncUri(trackUri);
   }, []);
 
-  // ── Upgrade to Spotify when SDK becomes ready after loadTrack ─────
+  // ── Upgrade to active engine when SDK becomes ready after loadTrack ─
   useEffect(() => {
-    if (spReady && currentTrackUri && activePlayer !== "spotify") {
-      console.log("[Player] Spotify SDK ready — switching to Spotify");
-      setActivePlayer("spotify");
+    const engineService = engineRef.current?.service;
+    if (spReady && currentTrackUri && engineService && activePlayer !== engineService) {
+      console.log(`[Player] ${engineService} SDK ready — switching`);
+      setActivePlayer(engineService);
       hasAutoPlayedRef.current = false;
     }
   }, [spReady, currentTrackUri, activePlayer]);
 
-  // ── Auto-play when Spotify is active and ready ────────────────────
+  // ── Auto-play when engine is active and ready ─────────────────────
 
   useEffect(() => {
-    if (activePlayer === "spotify" && spReady && currentTrackUri && !hasAutoPlayedRef.current) {
+    if (activePlayer !== "none" && spReady && currentTrackUri && !hasAutoPlayedRef.current) {
       hasAutoPlayedRef.current = true;
       engineRef.current?.loadTrack(currentTrackUri);
     }
@@ -323,8 +404,9 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
   const toggle = useCallback(() => {
     if (activePlayer === "none") {
-      if (currentTrackUri && spReady) {
-        setActivePlayer("spotify");
+      const engineService = engineRef.current?.service;
+      if (currentTrackUri && spReady && engineService) {
+        setActivePlayer(engineService);
         hasAutoPlayedRef.current = false;
       }
       return;

--- a/src/data/seedNuggets.test.ts
+++ b/src/data/seedNuggets.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { DEMO_TRACKS, getDemoTrackUri, getDemoTrackById, type DemoTrackMeta } from "./seedNuggets";
+
+describe("getDemoTrackUri", () => {
+  const withApple: DemoTrackMeta = {
+    id: "test-with-apple",
+    artist: "Daft Punk",
+    title: "Around the World",
+    album: "Homework",
+    trackUri: "spotify:track:1pKYYY0dkg23sQQXi0Q5zN",
+    appleMusicUri: "apple:song:1609438415",
+    coverArtUrl: "https://example.com/cover.jpg",
+    slug: "daftpunk",
+  };
+
+  const withoutApple: DemoTrackMeta = {
+    id: "test-no-apple",
+    artist: "Radiohead",
+    title: "Weird Fishes/Arpeggi",
+    album: "In Rainbows",
+    trackUri: "spotify:track:4wajJ1o7jWIg62YqpkHC7S",
+    coverArtUrl: "https://example.com/cover.jpg",
+    slug: "radiohead",
+  };
+
+  it("returns appleMusicUri when service is 'Apple Music' and appleMusicUri is set", () => {
+    expect(getDemoTrackUri(withApple, "Apple Music")).toBe("apple:song:1609438415");
+  });
+
+  it("falls back to trackUri when service is 'Apple Music' but appleMusicUri is missing", () => {
+    expect(getDemoTrackUri(withoutApple, "Apple Music")).toBe("spotify:track:4wajJ1o7jWIg62YqpkHC7S");
+  });
+
+  it("returns trackUri when service is 'Spotify'", () => {
+    expect(getDemoTrackUri(withApple, "Spotify")).toBe("spotify:track:1pKYYY0dkg23sQQXi0Q5zN");
+  });
+
+  it("returns trackUri when service is undefined (guest)", () => {
+    expect(getDemoTrackUri(withApple, undefined)).toBe("spotify:track:1pKYYY0dkg23sQQXi0Q5zN");
+  });
+
+  it("returns trackUri when service is empty string", () => {
+    expect(getDemoTrackUri(withApple, "")).toBe("spotify:track:1pKYYY0dkg23sQQXi0Q5zN");
+  });
+
+  it("returns trackUri when service is 'YouTube Music' (no handling yet)", () => {
+    expect(getDemoTrackUri(withApple, "YouTube Music")).toBe("spotify:track:1pKYYY0dkg23sQQXi0Q5zN");
+  });
+});
+
+describe("DEMO_TRACKS shape", () => {
+  it("every demo track has a valid trackUri", () => {
+    for (const demo of DEMO_TRACKS) {
+      expect(demo.trackUri).toMatch(/^spotify:track:/);
+    }
+  });
+
+  it("at least one demo track has an Apple Music URI (fast-path playability)", () => {
+    const withApple = DEMO_TRACKS.filter((d) => d.appleMusicUri);
+    expect(withApple.length).toBeGreaterThan(0);
+  });
+
+  it("Apple Music URIs follow the apple:song:{id} format", () => {
+    for (const demo of DEMO_TRACKS) {
+      if (demo.appleMusicUri) {
+        expect(demo.appleMusicUri).toMatch(/^apple:song:\d+$/);
+      }
+    }
+  });
+
+  it("Around the World has an appleMusicUri (regression: fast-path testing track)", () => {
+    const track = getDemoTrackById("demo-around-the-world");
+    expect(track).not.toBeNull();
+    expect(track?.appleMusicUri).toBe("apple:song:1609438415");
+  });
+});
+
+describe("getDemoTrackById", () => {
+  it("returns the full metadata for a known id", () => {
+    const track = getDemoTrackById("demo-around-the-world");
+    expect(track?.artist).toBe("Daft Punk");
+    expect(track?.title).toBe("Around the World");
+    expect(track?.slug).toBe("daftpunk");
+  });
+
+  it("returns null for unknown id", () => {
+    expect(getDemoTrackById("demo-nonexistent")).toBeNull();
+  });
+
+  it("returns null for empty id", () => {
+    expect(getDemoTrackById("")).toBeNull();
+  });
+});

--- a/src/data/seedNuggets.test.ts
+++ b/src/data/seedNuggets.test.ts
@@ -55,9 +55,10 @@ describe("DEMO_TRACKS shape", () => {
     }
   });
 
-  it("at least one demo track has an Apple Music URI (fast-path playability)", () => {
-    const withApple = DEMO_TRACKS.filter((d) => d.appleMusicUri);
-    expect(withApple.length).toBeGreaterThan(0);
+  it("every demo track has an Apple Music URI (cross-service playability)", () => {
+    for (const demo of DEMO_TRACKS) {
+      expect(demo.appleMusicUri, `${demo.id} is missing appleMusicUri`).toBeTruthy();
+    }
   });
 
   it("Apple Music URIs follow the apple:song:{id} format", () => {

--- a/src/data/seedNuggets.ts
+++ b/src/data/seedNuggets.ts
@@ -71,11 +71,11 @@ export interface DemoTrackMeta {
 /** All demo tracks — single source of truth for Browse tiles + Listen playback. */
 export const DEMO_TRACKS: DemoTrackMeta[] = [
   { id: "demo-around-the-world", artist: "Daft Punk", title: "Around the World", album: "Homework", trackUri: "spotify:track:1pKYYY0dkg23sQQXi0Q5zN", appleMusicUri: "apple:song:1609438415", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738ac778cc7d88779f74d33311", slug: "daftpunk" },
-  { id: "demo-weird-fishes", artist: "Radiohead", title: "Weird Fishes/Arpeggi", album: "In Rainbows", trackUri: "spotify:track:4wajJ1o7jWIg62YqpkHC7S", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273de3c04b5fc750b68899b20a9", slug: "radiohead" },
-  { id: "demo-oms-at-play", artist: "Pete Rango", title: "Oms at Play", album: "Savage Planet", trackUri: "spotify:track:7mYphBaMfblb6iu1saj3MC", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27305b43e15352510b1b9c9a5a5", slug: "peterango" },
-  { id: "demo-slack", artist: "Jamee Cornelia", title: "SLACK", album: "HARVEST", trackUri: "spotify:track:5bU8cB57AfhTtO0qj9zy3X", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273e9c4a69ecd5c43229cfd03f3", slug: "jameecornelia" },
-  { id: "demo-humble", artist: "Kendrick Lamar", title: "HUMBLE.", album: "DAMN.", trackUri: "spotify:track:7KXjTSCq5nL1LoYtL7XAwS", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738b52c6b9bc4e43d873869699", slug: "kendrick" },
-  { id: "demo-bad-guy", artist: "Billie Eilish", title: "bad guy", album: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?", trackUri: "spotify:track:2Fxmhks0bxGSBdJ92vM42m", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27350a3147b4edd7701a876c6ce", slug: "billie" },
+  { id: "demo-weird-fishes", artist: "Radiohead", title: "Weird Fishes/Arpeggi", album: "In Rainbows", trackUri: "spotify:track:4wajJ1o7jWIg62YqpkHC7S", appleMusicUri: "apple:song:1109715168", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273de3c04b5fc750b68899b20a9", slug: "radiohead" },
+  { id: "demo-oms-at-play", artist: "Pete Rango", title: "Oms at Play", album: "Savage Planet", trackUri: "spotify:track:7mYphBaMfblb6iu1saj3MC", appleMusicUri: "apple:song:1649816935", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27305b43e15352510b1b9c9a5a5", slug: "peterango" },
+  { id: "demo-slack", artist: "Jamee Cornelia", title: "SLACK", album: "HARVEST", trackUri: "spotify:track:5bU8cB57AfhTtO0qj9zy3X", appleMusicUri: "apple:song:1871405273", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273e9c4a69ecd5c43229cfd03f3", slug: "jameecornelia" },
+  { id: "demo-humble", artist: "Kendrick Lamar", title: "HUMBLE.", album: "DAMN.", trackUri: "spotify:track:7KXjTSCq5nL1LoYtL7XAwS", appleMusicUri: "apple:song:1440882165", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738b52c6b9bc4e43d873869699", slug: "kendrick" },
+  { id: "demo-bad-guy", artist: "Billie Eilish", title: "bad guy", album: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?", trackUri: "spotify:track:2Fxmhks0bxGSBdJ92vM42m", appleMusicUri: "apple:song:1450695739", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27350a3147b4edd7701a876c6ce", slug: "billie" },
 ];
 
 /**

--- a/src/data/seedNuggets.ts
+++ b/src/data/seedNuggets.ts
@@ -59,7 +59,10 @@ export interface DemoTrackMeta {
   artist: string;
   title: string;
   album: string;
+  /** Spotify track URI — the default/primary URI. Used when the user's service is Spotify. */
   trackUri: string;
+  /** Optional Apple Music song URI — used when the user's service is Apple Music. */
+  appleMusicUri?: string;
   coverArtUrl: string;
   /** File-name slug used in src/data/seed/ */
   slug: string;
@@ -67,13 +70,30 @@ export interface DemoTrackMeta {
 
 /** All demo tracks — single source of truth for Browse tiles + Listen playback. */
 export const DEMO_TRACKS: DemoTrackMeta[] = [
-  { id: "demo-around-the-world", artist: "Daft Punk", title: "Around the World", album: "Homework", trackUri: "spotify:track:1pKYYY0dkg23sQQXi0Q5zN", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738ac778cc7d88779f74d33311", slug: "daftpunk" },
+  { id: "demo-around-the-world", artist: "Daft Punk", title: "Around the World", album: "Homework", trackUri: "spotify:track:1pKYYY0dkg23sQQXi0Q5zN", appleMusicUri: "apple:song:1609438415", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738ac778cc7d88779f74d33311", slug: "daftpunk" },
   { id: "demo-weird-fishes", artist: "Radiohead", title: "Weird Fishes/Arpeggi", album: "In Rainbows", trackUri: "spotify:track:4wajJ1o7jWIg62YqpkHC7S", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273de3c04b5fc750b68899b20a9", slug: "radiohead" },
   { id: "demo-oms-at-play", artist: "Pete Rango", title: "Oms at Play", album: "Savage Planet", trackUri: "spotify:track:7mYphBaMfblb6iu1saj3MC", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27305b43e15352510b1b9c9a5a5", slug: "peterango" },
   { id: "demo-slack", artist: "Jamee Cornelia", title: "SLACK", album: "HARVEST", trackUri: "spotify:track:5bU8cB57AfhTtO0qj9zy3X", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b273e9c4a69ecd5c43229cfd03f3", slug: "jameecornelia" },
   { id: "demo-humble", artist: "Kendrick Lamar", title: "HUMBLE.", album: "DAMN.", trackUri: "spotify:track:7KXjTSCq5nL1LoYtL7XAwS", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b2738b52c6b9bc4e43d873869699", slug: "kendrick" },
   { id: "demo-bad-guy", artist: "Billie Eilish", title: "bad guy", album: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?", trackUri: "spotify:track:2Fxmhks0bxGSBdJ92vM42m", coverArtUrl: "https://i.scdn.co/image/ab67616d0000b27350a3147b4edd7701a876c6ce", slug: "billie" },
 ];
+
+/**
+ * Pick the right playable URI for this demo track based on the user's active service.
+ *
+ * CAUTION — silent Spotify fallback: Apple Music users asking for a demo
+ * without an `appleMusicUri` will receive a `spotify:track:...` URI that
+ * the Apple Music engine cannot play. Callers that route tracks into the
+ * engine must pre-filter the demo list (see Listen.tsx's P5 fallback,
+ * which filters `DEMO_TRACKS` by `!!d.appleMusicUri` for Apple users).
+ * Browse.tsx is safe because every tile the user can click has an
+ * `appleMusicUri` set when the demo appears in the catalog; once more
+ * Apple IDs are added to DEMO_TRACKS in Phase 6b/7, this caveat shrinks.
+ */
+export function getDemoTrackUri(demo: DemoTrackMeta, service: string | undefined): string {
+  if (service === "Apple Music" && demo.appleMusicUri) return demo.appleMusicUri;
+  return demo.trackUri;
+}
 
 /** Look up a demo track by its simple ID (e.g. "demo-weird-fishes"). */
 export function getDemoTrackById(id: string): DemoTrackMeta | null {

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -44,10 +44,23 @@ export function makeTimestamp(index: number, totalNuggets: number, durationSec: 
   return Math.min(Math.floor(earlyStart + spacing * (index + 1)), durationSec - 10);
 }
 
-function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {
+export function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {
+  // Client-side headline guard — if server sent an empty headline,
+  // derive one from the text (same logic as server-side generateHeadlineFromText).
+  let headline = n.headline;
+  if (!headline.trim() && n.text.trim()) {
+    const first = n.text.split(/[.!?]\s+/)[0].trim().replace(/[.!?]+$/, "");
+    headline = first && first.length > 10
+      ? (first.length > 80 ? first.slice(0, 77) + "..." : first)
+      : (n.text.length > 80 ? n.text.slice(0, 77) + "..." : n.text);
+  }
+  // Last resort — both headline and text empty (malformed server response)
+  if (!headline.trim()) {
+    headline = "Music Fact";
+  }
   return {
     id: nuggetId, trackId, timestampSec, durationMs: 7000,
-    headline: n.headline, text: n.text, kind: n.kind,
+    headline, text: n.text, kind: n.kind,
     listenFor: n.listenFor || false, sourceId,
     imageUrl: n.imageUrl, imageCaption: n.imageCaption,
   };

--- a/src/hooks/useAppleMusicAuth.ts
+++ b/src/hooks/useAppleMusicAuth.ts
@@ -1,0 +1,87 @@
+/**
+ * Apple Music authorization via MusicKit JS v3.
+ *
+ * Unlike Spotify's PKCE redirect flow, Apple Music uses a popup:
+ *   1. Fetch Developer Token from our edge function
+ *   2. Load MusicKit JS SDK (lazy singleton)
+ *   3. Configure MusicKit with the Developer Token
+ *   4. Call MusicKit.getInstance().authorize() — shows Apple popup
+ *   5. Returns a Music User Token directly (no redirect, no callback page)
+ *
+ * The Music User Token has no refresh mechanism — if it expires or the user
+ * revokes access, the app must prompt them to re-authorize.
+ */
+
+import { loadMusicKitSDK } from "@/lib/musickitLoader";
+import { fetchAppleDeveloperToken, saveAppleMusicToken } from "./useAppleMusicToken";
+
+// ── Auth flow ─────────────────────────────────────────────────────────
+
+/**
+ * Kick off Apple Music authorization.
+ * On success, persists tokens to localStorage and returns the Music User Token.
+ * On cancellation or failure, returns null.
+ */
+export async function initiateAppleMusicAuth(): Promise<string | null> {
+  try {
+    // 1. Fetch Developer Token from edge function
+    const developerToken = await fetchAppleDeveloperToken();
+    if (!developerToken) {
+      console.error("[AppleMusic] No developer token — cannot authorize");
+      return null;
+    }
+
+    // 2. Load MusicKit JS
+    await loadMusicKitSDK();
+    if (!window.MusicKit) {
+      console.error("[AppleMusic] MusicKit failed to load");
+      return null;
+    }
+
+    // 3. Configure MusicKit with the Developer Token
+    await window.MusicKit.configure({
+      developerToken,
+      app: { name: "MusicNerd TV", build: "1.0.0" },
+    });
+
+    const music = window.MusicKit.getInstance();
+
+    // 4. Open authorize popup — resolves with Music User Token
+    const musicUserToken = await music.authorize();
+    if (!musicUserToken) {
+      console.warn("[AppleMusic] Authorization cancelled or denied");
+      return null;
+    }
+
+    // 5. Persist tokens
+    saveAppleMusicToken(musicUserToken, developerToken);
+    return musicUserToken;
+  } catch (err) {
+    console.error("[AppleMusic] initiateAppleMusicAuth failed:", err);
+    return null;
+  }
+}
+
+// ── Taste profile fetch (mirrors useSpotifyAuth.fetchSpotifyTaste) ────
+
+export interface AppleMusicTaste {
+  topArtists: string[];
+  topTracks: string[];
+  artistImages: Record<string, string>;
+  artistIds: Record<string, string>;
+  trackImages: { title: string; artist: string; imageUrl: string; uri?: string }[];
+  displayName: string | null;
+  partial?: boolean;   // true = weaker signal than Spotify's user-top-read
+}
+
+/**
+ * Fetch a taste profile from the user's Apple Music library.
+ *
+ * TODO(Phase 5): implement the `apple-taste` edge function. Apple Music has
+ * no `/me/top/artists` equivalent, so Phase 5 will combine `heavy-rotation`
+ * + `recent/played/tracks` into a best-effort profile marked `partial: true`.
+ */
+export async function fetchAppleMusicTaste(_musicUserToken: string): Promise<AppleMusicTaste | null> {
+  console.warn("[AppleMusic] fetchAppleMusicTaste: apple-taste edge function not yet deployed (Phase 5)");
+  return null;
+}

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -1,0 +1,137 @@
+import { useCallback, useState, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+// Apple Music uses a two-token system:
+//   - Developer Token: ES256 JWT, generated server-side, 180-day lifetime.
+//     Fetched from our apple-dev-token edge function.
+//   - Music User Token: obtained via MusicKit.authorize() popup.
+//     No refresh mechanism — if expired/revoked, user must re-authorize.
+
+const STORAGE_KEY = "apple_music_token";
+const TOKEN_SAVED_EVENT = "apple-music-token-saved";
+
+interface StoredToken {
+  musicUserToken: string;
+  developerToken: string;
+  devTokenExpiresAt: number;  // ms epoch
+}
+
+function readToken(): StoredToken | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as StoredToken;
+  } catch {
+    return null;
+  }
+}
+
+function writeToken(token: StoredToken) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(token));
+}
+
+// In-flight promise dedup — concurrent callers share a single edge function
+// invocation rather than firing N parallel requests.
+let inFlightFetch: Promise<string | null> | null = null;
+
+/** Fetch a fresh Developer Token from the edge function. */
+export async function fetchAppleDeveloperToken(): Promise<string | null> {
+  if (inFlightFetch) return inFlightFetch;
+
+  inFlightFetch = (async () => {
+    try {
+      const { data, error } = await supabase.functions.invoke("apple-dev-token");
+      if (error || !data?.token) {
+        console.error("[AppleMusic] Failed to fetch developer token:", error);
+        return null;
+      }
+      return data.token as string;
+    } catch (err) {
+      console.error("[AppleMusic] Developer token fetch exception:", err);
+      return null;
+    } finally {
+      inFlightFetch = null;
+    }
+  })();
+
+  return inFlightFetch;
+}
+
+/** Persist a newly obtained token pair to localStorage. */
+export function saveAppleMusicToken(musicUserToken: string, developerToken: string): void {
+  // Developer token lifetime is 180 days server-side, but we refetch every 30 days
+  // from the client to reduce staleness risk from key rotations.
+  const devTokenExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
+  writeToken({ musicUserToken, developerToken, devTokenExpiresAt });
+  // Notify same-tab listeners — the `storage` event only fires cross-tab.
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(TOKEN_SAVED_EVENT));
+  }
+}
+
+export function useAppleMusicToken() {
+  const [hasMusicToken, setHasMusicToken] = useState(() => !!readToken());
+
+  // Sync hasMusicToken with localStorage writes from outside this hook —
+  //  • same tab: saveAppleMusicToken dispatches TOKEN_SAVED_EVENT
+  //  • cross-tab: the native `storage` event fires when localStorage changes
+  //    in another tab (add, update, or remove the key)
+  // Event-driven instead of polling so we don't burn CPU forever after
+  // clearToken() if the user never re-authorizes, and we correctly reflect
+  // cross-tab clears (tab B logs out → tab A flips to hasMusicToken=false).
+  useEffect(() => {
+    const syncFromStorage = () => {
+      const present = !!readToken();
+      setHasMusicToken((prev) => (prev === present ? prev : present));
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) syncFromStorage();
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(TOKEN_SAVED_EVENT, syncFromStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(TOKEN_SAVED_EVENT, syncFromStorage);
+    };
+  }, []);
+
+  /** Return the stored Music User Token, or null if missing. No refresh — MUT is session-scoped. */
+  const getMusicUserToken = useCallback((): string | null => {
+    const token = readToken();
+    return token?.musicUserToken ?? null;
+  }, []);
+
+  /** Return a valid Developer Token, refetching from the edge function if stale. */
+  const getDeveloperToken = useCallback(async (): Promise<string | null> => {
+    const stored = readToken();
+    if (stored && Date.now() < stored.devTokenExpiresAt) {
+      return stored.developerToken;
+    }
+
+    // Stale or missing — refetch
+    const fresh = await fetchAppleDeveloperToken();
+    if (!fresh) return null;
+
+    // Only persist when we have a Music User Token to pair it with. In
+    // practice this always runs from PlayerContext after hasMusicToken
+    // flipped true, so `stored` is non-null; this guard is defensive.
+    // If called pre-auth (no stored token yet), the fresh token is
+    // returned unpersisted — the caller gets a working token and the
+    // next authorize() flow will persist the pair via saveAppleMusicToken.
+    if (stored) {
+      writeToken({
+        ...stored,
+        developerToken: fresh,
+        devTokenExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      });
+    }
+    return fresh;
+  }, []);
+
+  const clearToken = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setHasMusicToken(false);
+  }, []);
+
+  return { hasMusicToken, getMusicUserToken, getDeveloperToken, clearToken };
+}

--- a/src/hooks/useAppleMusicToken.ts
+++ b/src/hooks/useAppleMusicToken.ts
@@ -8,7 +8,7 @@ import { supabase } from "@/integrations/supabase/client";
 //     No refresh mechanism — if expired/revoked, user must re-authorize.
 
 const STORAGE_KEY = "apple_music_token";
-const TOKEN_SAVED_EVENT = "apple-music-token-saved";
+const TOKEN_CHANGED_EVENT = "apple-music-token-changed";
 
 interface StoredToken {
   musicUserToken: string;
@@ -65,7 +65,7 @@ export function saveAppleMusicToken(musicUserToken: string, developerToken: stri
   writeToken({ musicUserToken, developerToken, devTokenExpiresAt });
   // Notify same-tab listeners — the `storage` event only fires cross-tab.
   if (typeof window !== "undefined") {
-    window.dispatchEvent(new Event(TOKEN_SAVED_EVENT));
+    window.dispatchEvent(new Event(TOKEN_CHANGED_EVENT));
   }
 }
 
@@ -73,7 +73,7 @@ export function useAppleMusicToken() {
   const [hasMusicToken, setHasMusicToken] = useState(() => !!readToken());
 
   // Sync hasMusicToken with localStorage writes from outside this hook —
-  //  • same tab: saveAppleMusicToken dispatches TOKEN_SAVED_EVENT
+  //  • same tab: saveAppleMusicToken / clearToken dispatch TOKEN_CHANGED_EVENT
   //  • cross-tab: the native `storage` event fires when localStorage changes
   //    in another tab (add, update, or remove the key)
   // Event-driven instead of polling so we don't burn CPU forever after
@@ -88,10 +88,10 @@ export function useAppleMusicToken() {
       if (e.key === STORAGE_KEY) syncFromStorage();
     };
     window.addEventListener("storage", onStorage);
-    window.addEventListener(TOKEN_SAVED_EVENT, syncFromStorage);
+    window.addEventListener(TOKEN_CHANGED_EVENT, syncFromStorage);
     return () => {
       window.removeEventListener("storage", onStorage);
-      window.removeEventListener(TOKEN_SAVED_EVENT, syncFromStorage);
+      window.removeEventListener(TOKEN_CHANGED_EVENT, syncFromStorage);
     };
   }, []);
 
@@ -131,6 +131,11 @@ export function useAppleMusicToken() {
   const clearToken = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);
     setHasMusicToken(false);
+    // Mirror saveAppleMusicToken — notify same-tab listeners so sibling hook
+    // instances flip to hasMusicToken=false without waiting for a reload.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(TOKEN_CHANGED_EVENT));
+    }
   }, []);
 
   return { hasMusicToken, getMusicUserToken, getDeveloperToken, clearToken };

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -4,6 +4,16 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 
 const PROFILE_KEY = "musicnerd_profile";
+const PROFILE_UPDATED_EVENT = "musicnerd-profile-updated";
+
+/** Dispatch a custom event so other useUserProfile hook instances re-read
+ *  localStorage. Each useState call creates its own state slot — without
+ *  this sync, PlayerProvider's profile goes stale when Connect.tsx saves,
+ *  and the Apple Music engine never initializes.
+ *  Vite SPA — no SSR guard needed. */
+function notifyProfileUpdated(): void {
+  window.dispatchEvent(new Event(PROFILE_UPDATED_EVENT));
+}
 
 // ── DB profile sync ───────────────────────────────────────────────────────────
 // Accept userId as a param — callers obtain it from AuthContext (no extra getSession() calls).
@@ -111,6 +121,32 @@ export function useUserProfile() {
     }
   });
 
+  // Sync across hook instances: every call to useUserProfile has its own
+  // independent useState slot, so when Connect.tsx saves a profile, other
+  // instances (like PlayerProvider) never see it. Listen for the custom
+  // event fired by saveProfile/clearProfile and re-read from localStorage.
+  // Also listens to the native `storage` event for cross-tab sync.
+  useEffect(() => {
+    const sync = () => {
+      try {
+        const raw = localStorage.getItem(PROFILE_KEY);
+        const next = raw ? (JSON.parse(raw) as UserProfile) : null;
+        setProfileState(next);
+      } catch {
+        setProfileState(null);
+      }
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === PROFILE_KEY) sync();
+    };
+    window.addEventListener(PROFILE_UPDATED_EVENT, sync);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(PROFILE_UPDATED_EVENT, sync);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
   // Re-load from DB whenever the signed-in user changes.
   // Local (localStorage) data is treated as fresher than DB — it may contain a profile
   // that was just saved but whose async DB write hasn't landed yet.
@@ -139,7 +175,7 @@ export function useUserProfile() {
           ),
         };
         localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
-        setProfileState(merged);
+        notifyProfileUpdated();
         return;
       }
 
@@ -155,20 +191,24 @@ export function useUserProfile() {
         spotifyTrackImages: dbProfile.spotifyTrackImages ?? local?.spotifyTrackImages,
       };
       localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
-      setProfileState(merged);
+      notifyProfileUpdated();
     });
     return () => { cancelled = true; };
   }, [user?.id]);
 
+  // Mutating callbacks write to localStorage then dispatch the profile-updated
+  // event. The event fires synchronously and the listener above re-reads
+  // localStorage, so the originating instance gets its own update through the
+  // same path as every other instance — single data flow, no double-set.
   const saveProfile = useCallback(async (p: UserProfile) => {
     localStorage.setItem(PROFILE_KEY, JSON.stringify(p));
-    setProfileState(p);
+    notifyProfileUpdated();
     if (user?.id) await saveProfileToDB(p, user.id);
   }, [user?.id]);
 
   const clearProfile = useCallback(() => {
     localStorage.removeItem(PROFILE_KEY);
-    setProfileState(null);
+    notifyProfileUpdated();
   }, []);
 
   return { profile, saveProfile, clearProfile };

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -46,6 +46,26 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   };
 }
 
+/**
+ * Resolve which streamingService to use when merging a local and DB profile.
+ *
+ * Priority:
+ *  1. Preserve an explicit streamingService on whichever source is the base
+ *  2. Fall back to "Spotify" only if spotifyTopArtists is populated (legacy
+ *     profile rows from before streaming_service was persisted)
+ *  3. Otherwise empty string (guest-like state)
+ *
+ * Exported for unit testing. Used by useUserProfile's hydrate effect.
+ */
+export function resolveStreamingService(
+  baseService: UserProfile["streamingService"] | undefined,
+  spotifyTopArtistsCount: number
+): UserProfile["streamingService"] {
+  if (baseService) return baseService;
+  if (spotifyTopArtistsCount > 0) return "Spotify";
+  return "";
+}
+
 async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
   // Build taste data from profile fields
   const tasteData: TasteData | null =
@@ -103,7 +123,9 @@ export function useUserProfile() {
         try { return JSON.parse(localStorage.getItem(PROFILE_KEY) || "null"); } catch { return null; }
       })() as UserProfile | null;
 
-      // If local already has Spotify taste data, it's fresher — don't overwrite it with stale DB
+      // If local already has Spotify taste data, it's fresher — don't overwrite it with stale DB.
+      // Preserve local's streamingService if set (handles Apple Music users who previously
+      // had Spotify data in the same profile row).
       if (local?.spotifyTopArtists?.length && local.spotifyArtistImages
           && Object.keys(local.spotifyArtistImages).length > 0) {
         // Only pull non-Spotify fields from DB (tier, lastFm) if local is missing them
@@ -111,17 +133,23 @@ export function useUserProfile() {
           ...local,
           calculatedTier: local.calculatedTier || dbProfile.calculatedTier,
           lastFmUsername: local.lastFmUsername || dbProfile.lastFmUsername,
-          streamingService: "Spotify",
+          streamingService: resolveStreamingService(
+            local.streamingService,
+            local.spotifyTopArtists?.length ?? 0
+          ),
         };
         localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
         setProfileState(merged);
         return;
       }
 
-      // No local Spotify data — use DB profile (e.g. new device sign-in)
+      // No local Spotify data — use DB profile (e.g. new device sign-in).
       const merged: UserProfile = {
         ...dbProfile,
-        streamingService: (dbProfile.spotifyTopArtists?.length ?? 0) > 0 ? "Spotify" : dbProfile.streamingService,
+        streamingService: resolveStreamingService(
+          dbProfile.streamingService,
+          dbProfile.spotifyTopArtists?.length ?? 0
+        ),
         spotifyArtistImages: dbProfile.spotifyArtistImages ?? local?.spotifyArtistImages,
         spotifyArtistIds: dbProfile.spotifyArtistIds ?? local?.spotifyArtistIds,
         spotifyTrackImages: dbProfile.spotifyTrackImages ?? local?.spotifyTrackImages,

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -12,6 +12,11 @@ import type { PlaybackEngine, PlaybackState } from "./types";
 import { loadMusicKitSDK } from "@/lib/musickitLoader";
 import { getIdFromUri, getServiceFromUri } from "@/lib/trackUri";
 
+/** Apple Music preview clips are exactly 30 seconds. Anything at or below
+ *  this at playback start means MusicKit served a preview instead of the
+ *  full track — almost always a subscription issue. */
+const APPLE_MUSIC_PREVIEW_DURATION_S = 30;
+
 // ── Engine ────────────────────────────────────────────────────────────
 
 export interface AppleMusicPlaybackEngineOptions {
@@ -44,6 +49,11 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   private hasPlayed = false;
   private hasAutoPlayed = false;
   private _isPlaying = false;
+  private pollInterval: number | null = null;
+  private lastPolledTime = -1;
+  private lastPolledDuration = -1;
+  private hasLoggedSubscriptionStatus = false;
+  private hasWarnedPreview = false;
 
   // Subscribers
   private stateListeners: Set<(s: PlaybackState) => void> = new Set();
@@ -109,9 +119,16 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this._ready = true;
     this.onReadyCb?.(null);
 
-    // Wire up native events (no polling needed)
+    // Wire up native playback events. We still poll at 250ms for smooth
+    // progress-bar updates — playbackTimeDidChange fires ~1s which looks
+    // chunky compared to Spotify's 250ms cadence.
     instance.addEventListener("playbackStateDidChange", this.boundStateHandler);
     instance.addEventListener("playbackTimeDidChange", this.boundTimeHandler);
+
+    // NOTE: subscription diagnostics fire on the first playbackStateDidChange,
+    // not here. At configure() resolve time, isAuthorized/musicUserToken
+    // may not be fully populated yet — MusicKit finalizes auth state
+    // asynchronously after the configure promise resolves.
 
     // Auto-play pending URI that was stored before configure resolved
     if (this.lastUri && !this.hasAutoPlayed) {
@@ -119,8 +136,67 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     }
   }
 
+  /** Best-effort subscription probe. Logs what MusicKit exposes about the
+   *  user's authorization and storefront. Apple doesn't publish a
+   *  `/v1/me/subscription` endpoint, so we lean on `isAuthorized`,
+   *  `storefrontCountryCode`, and a `/v1/me/storefront` round-trip (which
+   *  requires a valid Music User Token).
+   *
+   *  Only booleans are logged for any token field — the Music User Token
+   *  is a short-lived credential and must never be logged in full.
+   *
+   *  TODO: This diagnostic is intentionally always-on to investigate a
+   *  live preview-playback bug on staging. Once that's resolved, either
+   *  gate behind `import.meta.env.DEV` or a `debug` option in
+   *  AppleMusicPlaybackEngineOptions, or remove entirely.
+   *
+   *  The `as unknown as {...}` cast below bypasses the MusicKit JS v3
+   *  type definitions to read fields the official types don't expose
+   *  (e.g. `storefrontId`, `musicUserToken`). Verified against MusicKit
+   *  JS v3. If Apple renames/moves these, the optional chaining below
+   *  will silently log `undefined` instead of throwing. */
+  private async logSubscriptionStatus(): Promise<void> {
+    if (!this.music) return;
+    const m = this.music as unknown as {
+      isAuthorized?: boolean;
+      storefrontCountryCode?: string;
+      storefrontId?: string;
+      musicUserToken?: string;
+      developerToken?: string;
+      api?: {
+        music?: (path: string, params?: unknown) => Promise<unknown>;
+      };
+    };
+    const snapshot = {
+      isAuthorized: m.isAuthorized,
+      storefrontCountryCode: m.storefrontCountryCode,
+      storefrontId: m.storefrontId,
+      hasMusicUserToken: !!m.musicUserToken, // boolean only — never log the token value
+      hasDeveloperToken: !!m.developerToken, // boolean only — never log the token value
+    };
+    console.log("[AppleMusic] subscription snapshot:", snapshot);
+
+    // The /v1/me/storefront call is a MUT validity probe. Log just the
+    // extracted storefront id rather than the whole response so the
+    // diagnostic stays tight — the rest of the payload (supported
+    // languages, etc.) is noise for what we're trying to diagnose.
+    try {
+      const storefront = await m.api?.music?.("v1/me/storefront") as {
+        data?: Array<{ id?: string; attributes?: { name?: string } }>;
+      } | undefined;
+      const entry = storefront?.data?.[0];
+      console.log("[AppleMusic] /v1/me/storefront ok:", {
+        id: entry?.id,
+        name: entry?.attributes?.name,
+      });
+    } catch (err) {
+      console.warn("[AppleMusic] /v1/me/storefront failed:", err);
+    }
+  }
+
   cleanup(): void {
     this.cancelled = true;
+    this.stopPolling();
     if (this.music) {
       try {
         this.music.removeEventListener("playbackStateDidChange", this.boundStateHandler);
@@ -149,6 +225,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this.hasPlayed = false;
     this.hasAutoPlayed = false;
     this._isPlaying = false;
+    this.hasWarnedPreview = false;
 
     try { this.music?.stop(); } catch { /* already stopped */ }
 
@@ -257,6 +334,15 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
   private handlePlaybackState(event: MusicKit.PlaybackStateEvent): void {
     if (this.cancelled || !this.music) return;
 
+    // First state change after configure — now that MusicKit has settled,
+    // log the subscription snapshot. Guarded so it only fires once.
+    // .catch() handles any unexpected rejection from the fire-and-forget
+    // async call; the method already catches its own API errors.
+    if (!this.hasLoggedSubscriptionStatus) {
+      this.hasLoggedSubscriptionStatus = true;
+      this.logSubscriptionStatus().catch(() => { /* diagnostic only */ });
+    }
+
     const state = event.state;
     const PS = window.MusicKit?.PlaybackStates;
     if (!PS) return;
@@ -265,6 +351,28 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     this._isPlaying = isPlaying;
     if (isPlaying) this.hasPlayed = true;
 
+    // Short-duration detection: currentPlaybackDuration ≤
+    // APPLE_MUSIC_PREVIEW_DURATION_S often means MusicKit served a
+    // preview clip instead of the full track (subscription issue), but
+    // a genuinely short track (interlude, ambient, skit) will also hit
+    // this. The warning includes the URI so a developer can verify at
+    // a glance whether the short duration is legit. Gated by
+    // hasWarnedPreview to avoid console spam on pause/resume; reset
+    // in loadTrack() when a new URI commits.
+    if (
+      !this.hasWarnedPreview &&
+      isPlaying &&
+      this.music.currentPlaybackDuration &&
+      this.music.currentPlaybackDuration <= APPLE_MUSIC_PREVIEW_DURATION_S
+    ) {
+      this.hasWarnedPreview = true;
+      console.warn(
+        "[AppleMusic] Short duration detected (likely preview clip).",
+        { duration: this.music.currentPlaybackDuration, trackUri: this.lastUri },
+        "— verify the track is not legitimately short and check Apple Music subscription."
+      );
+    }
+
     // End-of-track detection: MusicKit reports "completed" (10) or "ended"
     // (5) when a track finishes naturally. "stopped" is deliberately NOT
     // included — MusicKit also emits it during buffering transitions and
@@ -272,11 +380,18 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // which would cause phantom onEnded fires.
     const isEnd = state === PS.completed || state === PS.ended;
     if (isEnd && this.hasPlayed && this.lastUri) {
+      this.stopPolling();
       this.lastUri = null;
       this.hasPlayed = false;
       for (const cb of this.endListeners) cb();
       return;
     }
+
+    // Drive the progress bar at 250ms while playing. Stop the interval
+    // whenever playback isn't active so we don't leak timers or emit
+    // spurious time updates while paused/buffering.
+    if (isPlaying) this.startPolling();
+    else this.stopPolling();
 
     // Emit state update with latest time/duration from the instance
     this.emitState({
@@ -286,6 +401,12 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     });
   }
 
+  /** Native playbackTimeDidChange events fire at ~1s cadence. This path
+   *  coexists with the 250ms poll in startPolling() intentionally: the
+   *  event gives us the authoritative value from MusicKit whenever it
+   *  fires, and the poll smooths the gaps between fires so the progress
+   *  bar doesn't look chunky. Both call emitState — don't delete one
+   *  thinking the other makes it redundant. */
   private handleTimeChange(event: MusicKit.PlaybackTimeEvent): void {
     if (this.cancelled) return;
     this.emitState({
@@ -293,5 +414,36 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
       currentTime: event.currentPlaybackTime || 0,
       duration: event.currentPlaybackDuration || 0,
     });
+  }
+
+  /** Poll currentPlaybackTime at 250ms to smooth the progress bar. MusicKit's
+   *  playbackTimeDidChange event fires ~1s which makes the bar look chunky
+   *  vs Spotify's 250ms cadence. Skips emission when time and duration
+   *  haven't changed since the last poll to avoid forcing no-op React
+   *  re-renders during buffering/stalled playback. */
+  private startPolling(): void {
+    if (this.pollInterval !== null) return;
+    this.pollInterval = window.setInterval(() => {
+      if (!this.music || this.cancelled) return;
+      const t = this.music.currentPlaybackTime || 0;
+      const d = this.music.currentPlaybackDuration || 0;
+      if (t === this.lastPolledTime && d === this.lastPolledDuration) return;
+      this.lastPolledTime = t;
+      this.lastPolledDuration = d;
+      this.emitState({
+        isPlaying: this._isPlaying,
+        currentTime: t,
+        duration: d,
+      });
+    }, 250);
+  }
+
+  private stopPolling(): void {
+    if (this.pollInterval !== null) {
+      window.clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    }
+    this.lastPolledTime = -1;
+    this.lastPolledDuration = -1;
   }
 }

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -1,0 +1,297 @@
+// Apple Music playback engine via MusicKit JS v3.
+// Implements the same PlaybackEngine interface as SpotifyPlaybackEngine so
+// PlayerContext can swap between providers.
+//
+// Key differences from Spotify:
+//   - Native playbackTimeDidChange events (no 250ms polling)
+//   - setQueue + play instead of REST API calls
+//   - No device ID / no cross-device transfer (browser-only)
+//   - Requires an Apple Music subscription for full tracks (previews otherwise)
+
+import type { PlaybackEngine, PlaybackState } from "./types";
+import { loadMusicKitSDK } from "@/lib/musickitLoader";
+import { getIdFromUri, getServiceFromUri } from "@/lib/trackUri";
+
+// ── Engine ────────────────────────────────────────────────────────────
+
+export interface AppleMusicPlaybackEngineOptions {
+  developerToken: string;
+  /** Called when MusicKit is configured and ready. */
+  onReady?: (deviceId: string | null) => void;
+}
+
+/** Extract the catalog ID from an apple:song:{id} URI.
+ *  Returns empty string for non-Apple URIs (e.g. spotify:track:abc), which
+ *  prevents a wrong-service URI from being silently passed to setQueue. */
+function extractAppleCatalogId(trackUri: string): string {
+  if (getServiceFromUri(trackUri) !== "apple-music") return "";
+  const id = getIdFromUri(trackUri);
+  // Apple Music catalog IDs are numeric strings
+  if (!/^\d+$/.test(id)) return "";
+  return id;
+}
+
+export class AppleMusicPlaybackEngine implements PlaybackEngine {
+  readonly service = "apple-music" as const;
+
+  private music: MusicKit.MusicKitInstance | null = null;
+  private _ready = false;
+  private cancelled = false;
+  private initStarted = false;
+
+  // Internal tracking
+  private lastUri: string | null = null;
+  private hasPlayed = false;
+  private hasAutoPlayed = false;
+  private _isPlaying = false;
+
+  // Subscribers
+  private stateListeners: Set<(s: PlaybackState) => void> = new Set();
+  private endListeners: Set<() => void> = new Set();
+
+  // Bound event handlers (kept as props so removeEventListener can match)
+  private boundStateHandler: (event: unknown) => void;
+  private boundTimeHandler: (event: unknown) => void;
+
+  private developerToken: string;
+  private onReadyCb?: (deviceId: string | null) => void;
+
+  constructor(opts: AppleMusicPlaybackEngineOptions) {
+    this.developerToken = opts.developerToken;
+    this.onReadyCb = opts.onReady;
+    this.boundStateHandler = (e) => this.handlePlaybackState(e as MusicKit.PlaybackStateEvent);
+    this.boundTimeHandler = (e) => this.handleTimeChange(e as MusicKit.PlaybackTimeEvent);
+  }
+
+  get ready() { return this._ready; }
+  /** Apple Music has no device ID concept — always null. */
+  get deviceId() { return null; }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────
+
+  async init(): Promise<void> {
+    // Re-entrancy guard: attaching event listeners twice doubles emissions
+    if (this.initStarted) return;
+    this.initStarted = true;
+
+    await loadMusicKitSDK();
+    if (this.cancelled) return;
+
+    if (!window.MusicKit) {
+      console.error("[AppleMusic] MusicKit failed to load");
+      return;
+    }
+
+    // MusicKit.configure() is a one-shot singleton per page load. If it's
+    // already configured (e.g. from useAppleMusicAuth during onboarding),
+    // reuse the existing instance instead of re-configuring.
+    let instance: MusicKit.MusicKitInstance | null = null;
+    try {
+      instance = window.MusicKit.getInstance();
+    } catch {
+      // Not configured yet, fall through
+    }
+
+    if (!instance) {
+      try {
+        instance = await window.MusicKit.configure({
+          developerToken: this.developerToken,
+          app: { name: "MusicNerd TV", build: "1.0.0" },
+        });
+      } catch (err) {
+        console.error("[AppleMusic] configure failed:", err);
+        return;
+      }
+    }
+
+    if (this.cancelled) return;
+    this.music = instance;
+    this._ready = true;
+    this.onReadyCb?.(null);
+
+    // Wire up native events (no polling needed)
+    instance.addEventListener("playbackStateDidChange", this.boundStateHandler);
+    instance.addEventListener("playbackTimeDidChange", this.boundTimeHandler);
+
+    // Auto-play pending URI that was stored before configure resolved
+    if (this.lastUri && !this.hasAutoPlayed) {
+      this.autoPlay(this.lastUri);
+    }
+  }
+
+  cleanup(): void {
+    this.cancelled = true;
+    if (this.music) {
+      try {
+        this.music.removeEventListener("playbackStateDidChange", this.boundStateHandler);
+        this.music.removeEventListener("playbackTimeDidChange", this.boundTimeHandler);
+        this.music.stop();
+      } catch (err) {
+        console.warn("[AppleMusic] cleanup error:", err);
+      }
+      // Don't null the MusicKit singleton — other code may still reference it.
+      this.music = null;
+    }
+  }
+
+  // ── Playback control ────────────────────────────────────────────────
+
+  async loadTrack(trackUri: string): Promise<void> {
+    if (this.lastUri === trackUri) return;
+
+    // Commit lastUri immediately so concurrent loadTrack calls with the
+    // same URI are caught by the dedup guard above. autoPlay's catch
+    // block resets it to null on failure so retries still work.
+    // The pre-load stop() below is a state reset for the new track; the
+    // hasPlayed && lastUri guard in handlePlaybackState ensures this
+    // synchronous stop doesn't trigger a phantom onEnded fire.
+    this.lastUri = trackUri;
+    this.hasPlayed = false;
+    this.hasAutoPlayed = false;
+    this._isPlaying = false;
+
+    try { this.music?.stop(); } catch { /* already stopped */ }
+
+    this.emitState({ isPlaying: false, currentTime: 0, duration: 0 });
+
+    if (!trackUri) return;
+
+    if (this._ready && this.music) {
+      await this.autoPlay(trackUri);
+    }
+    // If not ready, lastUri is already stored above. The onReady-triggered
+    // autoPlay in init() will pick it up.
+  }
+
+  async play(): Promise<void> {
+    try {
+      await this.music?.play();
+    } catch (err) {
+      console.error("[AppleMusic] play failed:", err);
+    }
+  }
+
+  async pause(): Promise<void> {
+    try { this.music?.pause(); } catch { /* already paused */ }
+  }
+
+  /** Sync internal tracking to match an externally-changed track.
+   *  No-op for Apple Music: MusicKit JS has no cross-device detection,
+   *  so there's no external state to sync to. PlayerContext guards
+   *  syncExternalTrack on service === "spotify", so this is never called
+   *  in current flows — but we implement it to satisfy the PlaybackEngine
+   *  interface without setting phantom state that could mislead consumers. */
+  syncUri(_trackUri: string): void {
+    // intentionally empty
+  }
+
+  async seek(seconds: number): Promise<void> {
+    try {
+      await this.music?.seekToTime(seconds);
+    } catch (err) {
+      console.error("[AppleMusic] seek failed:", err);
+    }
+    // Optimistically update time — omit duration so subscribers keep current value
+    this.emitState({ isPlaying: this._isPlaying, currentTime: seconds });
+  }
+
+  stop(): void {
+    try { this.music?.stop(); } catch { /* already stopped */ }
+    this.lastUri = null;
+  }
+
+  // ── Subscriptions ───────────────────────────────────────────────────
+
+  onStateChange(cb: (s: PlaybackState) => void): () => void {
+    this.stateListeners.add(cb);
+    return () => { this.stateListeners.delete(cb); };
+  }
+
+  onTrackEnd(cb: () => void): () => void {
+    this.endListeners.add(cb);
+    return () => { this.endListeners.delete(cb); };
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private emitState(partial: { isPlaying: boolean; currentTime: number; duration?: number }) {
+    const state: PlaybackState = {
+      isPlaying: partial.isPlaying,
+      currentTime: partial.currentTime,
+      duration: partial.duration,
+    };
+    for (const cb of this.stateListeners) cb(state);
+  }
+
+  private async autoPlay(uri: string): Promise<void> {
+    const catalogId = extractAppleCatalogId(uri);
+    if (!catalogId) {
+      console.error("[AppleMusic] Invalid or non-Apple URI:", uri);
+      this.lastUri = null;  // un-commit so retries with a valid URI aren't blocked
+      return;
+    }
+    if (!this.music) return;
+
+    // Apple Music playback requires authorization. Without it, setQueue will
+    // silently fail or return preview clips only. Surface a clear error.
+    if (!this.music.isAuthorized) {
+      console.error("[AppleMusic] Not authorized — user must connect Apple Music before playback");
+      this.lastUri = null;
+      return;
+    }
+
+    if (this.hasAutoPlayed) return;
+    this.hasAutoPlayed = true;
+
+    try {
+      await this.music.setQueue({ song: catalogId, startPlaying: true });
+    } catch (err) {
+      console.error("[AppleMusic] setQueue failed:", err, "URI:", uri);
+      // Un-commit lastUri and reset the autoplay latch so the caller can
+      // retry with the same URI.
+      this.lastUri = null;
+      this.hasAutoPlayed = false;
+    }
+  }
+
+  private handlePlaybackState(event: MusicKit.PlaybackStateEvent): void {
+    if (this.cancelled || !this.music) return;
+
+    const state = event.state;
+    const PS = window.MusicKit?.PlaybackStates;
+    if (!PS) return;
+
+    const isPlaying = state === PS.playing;
+    this._isPlaying = isPlaying;
+    if (isPlaying) this.hasPlayed = true;
+
+    // End-of-track detection: MusicKit reports "completed" (10) or "ended"
+    // (5) when a track finishes naturally. "stopped" is deliberately NOT
+    // included — MusicKit also emits it during buffering transitions and
+    // when music.stop() is called programmatically (e.g. from loadTrack),
+    // which would cause phantom onEnded fires.
+    const isEnd = state === PS.completed || state === PS.ended;
+    if (isEnd && this.hasPlayed && this.lastUri) {
+      this.lastUri = null;
+      this.hasPlayed = false;
+      for (const cb of this.endListeners) cb();
+      return;
+    }
+
+    // Emit state update with latest time/duration from the instance
+    this.emitState({
+      isPlaying,
+      currentTime: this.music.currentPlaybackTime || 0,
+      duration: this.music.currentPlaybackDuration || 0,
+    });
+  }
+
+  private handleTimeChange(event: MusicKit.PlaybackTimeEvent): void {
+    if (this.cancelled) return;
+    this.emitState({
+      isPlaying: this._isPlaying,
+      currentTime: event.currentPlaybackTime || 0,
+      duration: event.currentPlaybackDuration || 0,
+    });
+  }
+}

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -145,10 +145,8 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
    *  Only booleans are logged for any token field — the Music User Token
    *  is a short-lived credential and must never be logged in full.
    *
-   *  TODO: This diagnostic is intentionally always-on to investigate a
-   *  live preview-playback bug on staging. Once that's resolved, either
-   *  gate behind `import.meta.env.DEV` or a `debug` option in
-   *  AppleMusicPlaybackEngineOptions, or remove entirely.
+   *  Gated behind `import.meta.env.DEV` — costs a `/v1/me/storefront`
+   *  round-trip and was leaking to production console output otherwise.
    *
    *  The `as unknown as {...}` cast below bypasses the MusicKit JS v3
    *  type definitions to read fields the official types don't expose
@@ -338,7 +336,7 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // log the subscription snapshot. Guarded so it only fires once.
     // .catch() handles any unexpected rejection from the fire-and-forget
     // async call; the method already catches its own API errors.
-    if (!this.hasLoggedSubscriptionStatus) {
+    if (!this.hasLoggedSubscriptionStatus && import.meta.env.DEV) {
       this.hasLoggedSubscriptionStatus = true;
       this.logSubscriptionStatus().catch(() => { /* diagnostic only */ });
     }

--- a/src/lib/engines/types.ts
+++ b/src/lib/engines/types.ts
@@ -25,6 +25,12 @@ export interface PlaybackEngine {
   seek(seconds: number): Promise<void>;
   stop(): void;
 
+  /** Sync internal tracking to match an externally-changed track.
+   *  Called when a track change is detected outside our control (e.g. user
+   *  skips on their phone via Spotify Connect). Engines that don't support
+   *  cross-device detection should treat this as a hint/no-op. */
+  syncUri(trackUri: string): void;
+
   /** Subscribe to playback state changes. Returns unsubscribe function. */
   onStateChange(cb: (state: PlaybackState) => void): () => void;
   /** Subscribe to track-end events. Returns unsubscribe function. */

--- a/src/lib/musickitLoader.ts
+++ b/src/lib/musickitLoader.ts
@@ -1,0 +1,72 @@
+// Shared MusicKit JS v3 SDK loader — singleton used by both the Apple Music
+// playback engine and the auth hook. Prevents double script tags and missed
+// "musickitloaded" events when both call sites race.
+
+const MUSICKIT_SRC = "https://js-cdn.music.apple.com/musickit/v3/musickit.js";
+const LOAD_TIMEOUT_MS = 15_000;
+
+let sdkPromise: Promise<void> | null = null;
+
+/** Reset module-level SDK state — only for tests. */
+export function _resetMusicKitLoaderForTests(): void {
+  sdkPromise = null;
+}
+
+export function loadMusicKitSDK(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.MusicKit) return Promise.resolve();
+  if (sdkPromise) return sdkPromise;
+
+  sdkPromise = new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      window.removeEventListener("musickitloaded", onLoaded);
+      fn();
+    };
+
+    // Bail out after 15s if Apple's CDN is unreachable or the musickitloaded
+    // event never fires — prevents the engine and auth flow from hanging forever.
+    const timeoutId = setTimeout(() => {
+      sdkPromise = null;
+      settle(() => reject(new Error(`MusicKit JS load timed out after ${LOAD_TIMEOUT_MS}ms`)));
+    }, LOAD_TIMEOUT_MS);
+
+    const onLoaded = () => settle(() => resolve());
+    window.addEventListener("musickitloaded", onLoaded);
+
+    // Guard against synchronous SDK install (cached service worker, etc.)
+    // that could set window.MusicKit between the top-of-function check and
+    // the listener attach.
+    if (window.MusicKit) {
+      settle(() => resolve());
+      return;
+    }
+
+    // Reuse an existing <script> tag if a previous load attempt timed out
+    // or errored. Without this, each retry would append a duplicate tag.
+    let script = document.querySelector<HTMLScriptElement>(
+      `script[src="${MUSICKIT_SRC}"]`
+    );
+    if (script) {
+      script.addEventListener("error", () => {
+        sdkPromise = null;
+        settle(() => reject(new Error("Failed to load MusicKit JS")));
+      });
+      return;
+    }
+
+    script = document.createElement("script");
+    script.src = MUSICKIT_SRC;
+    script.async = true;
+    script.onerror = () => {
+      sdkPromise = null;
+      settle(() => reject(new Error("Failed to load MusicKit JS")));
+    };
+    document.head.appendChild(script);
+  });
+
+  return sdkPromise;
+}

--- a/src/lib/routeParsing.test.ts
+++ b/src/lib/routeParsing.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   isSpotifyPrefix,
   isRealPrefix,
+  isApplePrefix,
   parseSpotifyArtist,
   parseRealArtist,
   parseSpotifyAlbum,
+  parseAppleArtist,
+  parseAppleAlbum,
 } from "./routeParsing";
 
 describe("isSpotifyPrefix", () => {
@@ -152,5 +155,96 @@ describe("parseSpotifyAlbum", () => {
       artistName: "Daft Punk",
       artistSpotifyId: artistId,
     });
+  });
+});
+
+describe("isApplePrefix", () => {
+  it("detects raw apple:: prefix", () => {
+    expect(isApplePrefix("apple::178834::Radiohead")).toBe(true);
+  });
+
+  it("detects URL-encoded apple:: prefix", () => {
+    expect(isApplePrefix("apple%3A%3A178834%3A%3ARadiohead")).toBe(true);
+  });
+
+  it("rejects spotify:: prefix", () => {
+    expect(isApplePrefix("spotify::abc123::Radiohead")).toBe(false);
+  });
+
+  it("rejects real:: prefix", () => {
+    expect(isApplePrefix("real::Radiohead")).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isApplePrefix(undefined)).toBe(false);
+  });
+});
+
+describe("parseAppleArtist", () => {
+  it("parses raw apple::{id}::{name}", () => {
+    const result = parseAppleArtist("apple::178834::Radiohead");
+    expect(result).toEqual({ appleId: "178834", artistName: "Radiohead" });
+  });
+
+  it("parses URL-encoded input", () => {
+    const raw = encodeURIComponent("apple::178834::Radiohead");
+    const result = parseAppleArtist(raw);
+    expect(result).toEqual({ appleId: "178834", artistName: "Radiohead" });
+  });
+
+  it("handles names with special characters", () => {
+    const result = parseAppleArtist("apple::1234::Beyoncé");
+    expect(result).toEqual({ appleId: "1234", artistName: "Beyoncé" });
+  });
+
+  it("returns null for missing ID", () => {
+    expect(parseAppleArtist("apple::::Radiohead")).toBeNull();
+  });
+
+  it("returns null for non-apple prefix", () => {
+    expect(parseAppleArtist("spotify::abc::name")).toBeNull();
+  });
+
+  it("returns empty artistName when name segment is missing", () => {
+    const result = parseAppleArtist("apple::178834");
+    expect(result).toEqual({ appleId: "178834", artistName: "" });
+  });
+});
+
+describe("parseAppleAlbum", () => {
+  it("parses apple::{albumId}::{artistName}::{artistId}", () => {
+    const result = parseAppleAlbum("apple::1440833060::Radiohead::178834");
+    expect(result).toEqual({
+      appleAlbumId: "1440833060",
+      artistName: "Radiohead",
+      artistAppleId: "178834",
+    });
+  });
+
+  it("parses URL-encoded input", () => {
+    const raw = encodeURIComponent("apple::1440833060::Radiohead::178834");
+    const result = parseAppleAlbum(raw);
+    expect(result).toEqual({
+      appleAlbumId: "1440833060",
+      artistName: "Radiohead",
+      artistAppleId: "178834",
+    });
+  });
+
+  it("handles missing artistAppleId", () => {
+    const result = parseAppleAlbum("apple::1440833060::Some Artist");
+    expect(result).toEqual({
+      appleAlbumId: "1440833060",
+      artistName: "Some Artist",
+      artistAppleId: "",
+    });
+  });
+
+  it("returns null for missing albumId", () => {
+    expect(parseAppleAlbum("apple::::ArtistName::artistId")).toBeNull();
+  });
+
+  it("returns null for non-apple prefix", () => {
+    expect(parseAppleAlbum("spotify::something::artist")).toBeNull();
   });
 });

--- a/src/lib/trackUri.test.ts
+++ b/src/lib/trackUri.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { getServiceFromUri, getIdFromUri } from "./trackUri";
+
+describe("getServiceFromUri", () => {
+  it("detects spotify URIs", () => {
+    expect(getServiceFromUri("spotify:track:7KXjTSCq5nL1LoYtL7XAwS")).toBe("spotify");
+  });
+
+  it("detects apple URIs", () => {
+    expect(getServiceFromUri("apple:song:1440833060")).toBe("apple-music");
+  });
+
+  it("returns none for unknown prefix", () => {
+    expect(getServiceFromUri("youtube:video:abc")).toBe("none");
+  });
+
+  it("returns none for empty string", () => {
+    expect(getServiceFromUri("")).toBe("none");
+  });
+});
+
+describe("getIdFromUri", () => {
+  it("extracts Spotify track ID", () => {
+    expect(getIdFromUri("spotify:track:7KXjTSCq5nL1LoYtL7XAwS")).toBe("7KXjTSCq5nL1LoYtL7XAwS");
+  });
+
+  it("extracts Apple Music catalog ID", () => {
+    expect(getIdFromUri("apple:song:1440833060")).toBe("1440833060");
+  });
+
+  it("returns last segment for unknown format", () => {
+    expect(getIdFromUri("random:foo:bar:baz")).toBe("baz");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(getIdFromUri("")).toBe("");
+  });
+});

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getAlbumById, getTracksForAlbum, getArtistById } from "@/mock/tracks";
 import { supabase } from "@/integrations/supabase/client";
 import PageTransition from "@/components/PageTransition";
+import AppleMusicComingSoon from "@/components/AppleMusicComingSoon";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { isSpotifyPrefix, parseSpotifyAlbum } from "@/lib/routeParsing";
 
 // ── Types for Spotify album data ─────────────────────────────────────
@@ -37,6 +39,7 @@ interface SpotifyAlbumData {
 
 export default function AlbumDetail() {
   const { albumId: rawAlbumId } = useParams<{ albumId: string }>();
+  const { profile } = useUserProfile();
 
   const isSpotifyAlbum = isSpotifyPrefix(rawAlbumId);
 
@@ -44,6 +47,19 @@ export default function AlbumDetail() {
     if (!rawAlbumId) return null;
     return parseSpotifyAlbum(rawAlbumId);
   }, [rawAlbumId]);
+
+  // Apple Music: album detail requires the extended spotify-album edge
+  // function (Phase 5). Show a placeholder until that lands.
+  // Must be checked AFTER all hook calls to satisfy rules of hooks.
+  if (profile?.streamingService === "Apple Music") {
+    return (
+      <AppleMusicComingSoon
+        emoji="💿"
+        title="Album pages are coming soon"
+        description="Album detail for Apple Music isn't wired up yet. For now, head back to Browse and explore the demo tracks."
+      />
+    );
+  }
 
   if (isSpotifyAlbum && parsedSpotify?.spotifyAlbumId) {
     return (

--- a/src/pages/ArtistProfile.tsx
+++ b/src/pages/ArtistProfile.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getArtistById, getAlbumsForArtist, getTracksForArtist, artists } from "@/mock/tracks";
 import { supabase } from "@/integrations/supabase/client";
 import PageTransition from "@/components/PageTransition";
+import AppleMusicComingSoon from "@/components/AppleMusicComingSoon";
 import TileRow from "@/components/TileRow";
 import { useArtistImage } from "@/hooks/useArtistImage";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { isSpotifyPrefix, isRealPrefix, parseSpotifyArtist, parseRealArtist } from "@/lib/routeParsing";
 
 // ── Types for real (Spotify) artist data ─────────────────────────────
@@ -55,6 +57,7 @@ interface RealArtistData {
 
 export default function ArtistProfile() {
   const { artistId: rawArtistId } = useParams<{ artistId: string }>();
+  const { profile } = useUserProfile();
 
   const isSpotifyArtist = isSpotifyPrefix(rawArtistId);
   const isRealArtist = isRealPrefix(rawArtistId);
@@ -68,6 +71,19 @@ export default function ArtistProfile() {
     if (!rawArtistId) return null;
     return parseRealArtist(rawArtistId);
   }, [rawArtistId]);
+
+  // Apple Music: artist detail requires the extended spotify-artist edge
+  // function (Phase 5). Show a placeholder until that lands.
+  // Must be checked AFTER all hook calls to satisfy rules of hooks.
+  if (profile?.streamingService === "Apple Music") {
+    return (
+      <AppleMusicComingSoon
+        emoji="🎵"
+        title="Artist pages are coming soon"
+        description="Artist profiles for Apple Music aren't wired up yet. For now, head back to Browse and explore the demo tracks."
+      />
+    );
+  }
 
   if (isSpotifyArtist && parsedSpotify?.spotifyId) {
     return (

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -36,7 +36,7 @@ export default function Browse() {
       imageUrl: "https://i.scdn.co/image/ab67616d0000b2738ac778cc7d88779f74d33311",
       title: "Around the World",
       subtitle: "Daft Punk",
-      href: "/listen/real::Daft%20Punk::Around%20the%20World::Homework::spotify:track:1pKYYY0dkg23sQQXi0Q5zN?art=https%3A%2F%2Fi.scdn.co%2Fimage%2Fab67616d0000b2738ac778cc7d88779f74d33311",
+      href: "/listen/demo-around-the-world?art=https%3A%2F%2Fi.scdn.co%2Fimage%2Fab67616d0000b2738ac778cc7d88779f74d33311",
     },
     {
       id: "demo-weird-fishes",
@@ -50,14 +50,14 @@ export default function Browse() {
       imageUrl: "https://i.scdn.co/image/ab67616d0000b27305b43e15352510b1b9c9a5a5",
       title: "Oms at Play",
       subtitle: "Pete Rango",
-      href: "/listen/real::Pete%20Rango::Oms%20at%20Play::Savage%20Planet::spotify:track:7mYphBaMfblb6iu1saj3MC?art=https%3A%2F%2Fi.scdn.co%2Fimage%2Fab67616d0000b27305b43e15352510b1b9c9a5a5",
+      href: "/listen/demo-oms-at-play?art=https%3A%2F%2Fi.scdn.co%2Fimage%2Fab67616d0000b27305b43e15352510b1b9c9a5a5",
     },
-{
+    {
       id: "demo-slack",
       imageUrl: "https://i.scdn.co/image/ab67616d0000b273e9c4a69ecd5c43229cfd03f3",
       title: "SLACK",
       subtitle: "Jamee Cornelia",
-      href: "/listen/real::Jamee%20Cornelia::SLACK::HARVEST::spotify:track:5bU8cB57AfhTtO0qj9zy3X?art=https%3A%2F%2Fi.scdn.co%2Fimage%2Fab67616d0000b273e9c4a69ecd5c43229cfd03f3",
+      href: "/listen/demo-slack?art=https%3A%2F%2Fi.scdn.co%2Fimage%2Fab67616d0000b273e9c4a69ecd5c43229cfd03f3",
     },
     {
       id: "demo-humble",
@@ -108,6 +108,7 @@ export default function Browse() {
   const handleSignOut = () => {
     clearProfile();
     localStorage.removeItem("spotify_playback_token");
+    localStorage.removeItem("apple_music_token");
     sessionStorage.removeItem("musicnerd_redirect");
     sessionStorage.removeItem("spotify_pending_taste");
     // Hard navigate to avoid ProtectedRoute redirect race — clearProfile()

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -7,6 +7,8 @@ import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import type { UserProfile } from "@/mock/types";
 import spotifyLogo from "@/assets/spotify-logo.png";
 import { initiateSpotifyAuth } from "@/hooks/useSpotifyAuth";
+import { initiateAppleMusicAuth } from "@/hooks/useAppleMusicAuth";
+import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
 
 type Tier = "casual" | "curious" | "nerd";
 
@@ -34,12 +36,23 @@ export default function Connect() {
   const [step, setStep] = useState(0);
   const [direction, setDirection] = useState(1);
   const [spotifyConnecting, setSpotifyConnecting] = useState(false);
+  const [spotifyConnected, setSpotifyConnected] = useState(false);
   const [pendingSpotifyArtists, setPendingSpotifyArtists] = useState<string[] | null>(null);
   const [pendingSpotifyTracks, setPendingSpotifyTracks] = useState<string[] | null>(null);
   const [pendingArtistImages, setPendingArtistImages] = useState<Record<string, string>>({});
   const [pendingArtistIds, setPendingArtistIds] = useState<Record<string, string>>({});
   const [pendingTrackImages, setPendingTrackImages] = useState<{ title: string; artist: string; imageUrl: string }[]>([]);
   const [pendingDisplayName, setPendingDisplayName] = useState<string | null>(null);
+  // hasMusicToken is live from localStorage so it survives the Spotify OAuth
+  // redirect (React state is wiped on remount, but the token persists).
+  const { hasMusicToken } = useAppleMusicToken();
+  const [appleMusicConnecting, setAppleMusicConnecting] = useState(false);
+  const [appleMusicConnected, setAppleMusicConnected] = useState(() => hasMusicToken);
+  const [appleMusicError, setAppleMusicError] = useState<string | null>(null);
+  // Keep local state in sync when the hook detects a stored token.
+  useEffect(() => {
+    if (hasMusicToken) setAppleMusicConnected(true);
+  }, [hasMusicToken]);
   const [lastFmUsername, setLastFmUsername] = useState("");
   const [lastFmSaved, setLastFmSaved] = useState(false);
   const [showLastFm, setShowLastFm] = useState(false);
@@ -57,6 +70,7 @@ export default function Connect() {
     if (raw) {
       try {
         const { displayName, topArtists, topTracks, artistImages, artistIds, trackImages } = JSON.parse(raw);
+        setSpotifyConnected(true);
         setPendingSpotifyArtists(topArtists);
         setPendingSpotifyTracks(topTracks);
         if (displayName) setPendingDisplayName(displayName);
@@ -78,9 +92,40 @@ export default function Connect() {
     catch (e) { console.error("Spotify auth error:", e); setSpotifyConnecting(false); }
   };
 
+  const handleConnectAppleMusic = async () => {
+    setAppleMusicConnecting(true);
+    setAppleMusicError(null);
+    try {
+      const musicUserToken = await initiateAppleMusicAuth();
+      if (musicUserToken) {
+        setAppleMusicConnected(true);
+        // Phase 5 will wire fetchAppleMusicTaste here. For now, the Music User
+        // Token is already stored in localStorage by initiateAppleMusicAuth.
+      } else {
+        // Null return = popup cancelled, SDK load failure, or dev token fetch failed.
+        // initiateAppleMusicAuth logs the specific cause; surface a generic hint here.
+        setAppleMusicError("Couldn't connect to Apple Music. Try again?");
+      }
+    } catch (e) {
+      console.error("Apple Music auth error:", e);
+      setAppleMusicError("Apple Music connection failed. Check your connection and try again.");
+    } finally {
+      setAppleMusicConnecting(false);
+    }
+  };
+
   const handleTierSelect = (t: Tier) => {
+    // Use explicit connection flags instead of inferring from taste data —
+    // a new Spotify account can legitimately return 0 top artists, which
+    // previously caused us to fall through to "Apple Music" if that was
+    // also tapped. Spotify wins precedence when both are connected.
+    const streamingService = spotifyConnected
+      ? "Spotify"
+      : appleMusicConnected
+        ? "Apple Music"
+        : "";
     const profile: UserProfile = {
-      streamingService: pendingSpotifyArtists?.length ? "Spotify" : "",
+      streamingService,
       spotifyDisplayName: pendingDisplayName || undefined,
       spotifyTopArtists: pendingSpotifyArtists || undefined,
       spotifyTopTracks: pendingSpotifyTracks || undefined,
@@ -185,15 +230,31 @@ export default function Connect() {
                       )}
                     </div>
 
-                    {/* Apple Music — coming soon */}
-                    <div className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground/40 border-foreground/10 cursor-not-allowed">
-                      <span className="text-2xl">🎵</span>
-                      <span className="flex-1">Apple Music</span>
-                      <span className="text-xs text-muted-foreground/60">Coming soon</span>
-                    </div>
+                    {/* Apple Music — connect or show connected */}
+                    {!appleMusicConnected ? (
+                      <div className="w-full">
+                        <button onClick={handleConnectAppleMusic} disabled={appleMusicConnecting} className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground transition-all duration-200 disabled:opacity-70 border-pink-500/40 hover:border-pink-500 hover:shadow-[0_0_20px_rgba(236,72,153,0.3)]">
+                          <span className="text-2xl">🎵</span>
+                          <span className="flex-1">Apple Music</span>
+                          {appleMusicConnecting ? <Spinner className="h-4 w-4 text-pink-400" /> : <span className="text-xs text-muted-foreground">Connect</span>}
+                        </button>
+                        {appleMusicError && (
+                          <p className="mt-1.5 px-1 text-xs text-red-400">{appleMusicError}</p>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground border-pink-500/60 ring-1 ring-pink-500/30">
+                        <span className="text-2xl">🎵</span>
+                        <div className="flex-1 min-w-0">
+                          <p>Apple Music</p>
+                          <p className="text-xs font-normal text-pink-400 truncate">Connected</p>
+                        </div>
+                        <span className="text-xs font-semibold text-pink-400">✓</span>
+                      </div>
+                    )}
 
-                    {/* Continue (only shown after Spotify connected) */}
-                    {pendingSpotifyArtists && (
+                    {/* Continue (shown after any service connected) */}
+                    {(spotifyConnected || appleMusicConnected) && (
                       <button
                         onClick={() => goNext()}
                         className="w-full rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity"

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -9,6 +9,7 @@ import spotifyLogo from "@/assets/spotify-logo.png";
 import { initiateSpotifyAuth } from "@/hooks/useSpotifyAuth";
 import { initiateAppleMusicAuth } from "@/hooks/useAppleMusicAuth";
 import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
+import { supabase } from "@/integrations/supabase/client";
 
 type Tier = "casual" | "curious" | "nerd";
 
@@ -96,6 +97,15 @@ export default function Connect() {
     setAppleMusicConnecting(true);
     setAppleMusicError(null);
     try {
+      // The apple-dev-token edge function requires a Supabase session and
+      // returns 401 otherwise. Pre-flight the check so we surface an
+      // actionable message instead of a generic "couldn't connect" loop.
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        setAppleMusicError("Sign in to MusicNerd before connecting Apple Music.");
+        return;
+      }
+
       const musicUserToken = await initiateAppleMusicAuth();
       if (musicUserToken) {
         setAppleMusicConnected(true);

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -18,7 +18,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 const ImmersiveNuggetView = lazy(() => import("@/components/immersive/ImmersiveNuggetView"));
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useAINuggets } from "@/hooks/useAINuggets";
-import { getSeedCompanion, getDemoTrackById, DEMO_TRACKS } from "@/data/seedNuggets";
+import { getSeedCompanion, getDemoTrackById, getDemoTrackUri, DEMO_TRACKS } from "@/data/seedNuggets";
 import { useSpotifyToken } from "@/hooks/useSpotifyToken";
 import { initiateSpotifyAuth } from "@/hooks/useSpotifyAuth";
 import { usePlayer } from "@/contexts/PlayerContext";
@@ -47,9 +47,16 @@ export default function Listen() {
 
   // ── Track parsing — demo IDs or real::<artist>::<title>::<album>::<uri> ──
   const realTrackMeta = useMemo(() => {
-    // Demo track lookup (e.g. "demo-weird-fishes")
+    // Demo track lookup (e.g. "demo-weird-fishes"). Pick the URI for the
+    // user's active service so Apple Music users get apple:song:X instead
+    // of the Spotify default URI.
     const demo = rawTrackId ? getDemoTrackById(rawTrackId) : null;
-    if (demo) return { artist: demo.artist, title: demo.title, album: demo.album, trackUri: demo.trackUri };
+    if (demo) return {
+      artist: demo.artist,
+      title: demo.title,
+      album: demo.album,
+      trackUri: getDemoTrackUri(demo, profile?.streamingService),
+    };
 
     if (!rawTrackId?.startsWith("real%3A%3A") && !rawTrackId?.startsWith("real::")) return null;
     const decoded = decodeURIComponent(rawTrackId);
@@ -60,7 +67,7 @@ export default function Listen() {
       album: decodeURIComponent(parts[3] || "") || undefined,
       trackUri: decodeURIComponent(parts[4] || "") || undefined,
     };
-  }, [rawTrackId]);
+  }, [rawTrackId, profile?.streamingService]);
 
   const trackId = rawTrackId || "";
 
@@ -104,18 +111,24 @@ export default function Listen() {
   // ── Playback source resolution ───────────────────────────────────────
   const { hasSpotifyToken } = useSpotifyToken();
   const [trackUri, setTrackUri] = useState<string | null>(null);
+  const isAppleMusicUser = profile?.streamingService === "Apple Music";
 
-  // Resolve Spotify URI — from route (real tracks) or by searching Spotify
+  // Resolve track URI — from route (real tracks) or by searching Spotify.
+  // Apple Music users rely on the URI being baked into the route; there's
+  // no apple-search edge function yet (Phase 5).
   useEffect(() => {
     setTrackUri(null);
 
-    // Real track with URI baked into the route
+    // Real track with URI baked into the route — works for both services
     if (realTrackMeta?.trackUri) {
       setTrackUri(realTrackMeta.trackUri);
       return;
     }
 
-    // No Spotify token → skip Spotify search
+    // Gate Spotify search on streamingService (not just hasSpotifyToken) —
+    // an Apple Music user with a stale Spotify token would otherwise pollute
+    // trackUri with a Spotify URI that the Apple engine can't play.
+    if (isAppleMusicUser) return;
     if (!hasSpotifyToken || !track) return;
 
     let cancelled = false;
@@ -171,7 +184,7 @@ export default function Listen() {
     }
     findSpotifyUri();
     return () => { cancelled = true; };
-  }, [hasSpotifyToken, realTrackMeta?.trackUri, track?.artist, track?.title]);
+  }, [hasSpotifyToken, isAppleMusicUser, realTrackMeta?.trackUri, track?.artist, track?.title]);
 
   const [shuffleOn, setShuffleOn] = useState(false); // kept for PlaybackBar UI only
   const isMobile = useIsMobile();
@@ -276,77 +289,88 @@ export default function Listen() {
     const notPlayed = (a: string, t: string) => !player.isInSessionHistory(a, t);
 
     try {
-      // P1: Album continuation — play next track on the same album
-      const albumUri = player.spotifyStateTrack?.spotifyAlbumUri;
-      if (albumUri) {
-        const albumId = albumUri.replace("spotify:album:", "");
-        if (/^[a-zA-Z0-9]{20,25}$/.test(albumId)) {
-          const { data: albumData } = await supabase.functions.invoke("spotify-album", {
-            body: { albumId },
-          });
-          if (albumData?.tracks?.length) {
-            const currentIdx = albumData.tracks.findIndex(
-              (t: any) => t.uri === trackUri
-            );
-            if (currentIdx >= 0 && currentIdx < albumData.tracks.length - 1) {
-              const next = albumData.tracks[currentIdx + 1];
-              if (notPlayed(next.artist, next.title)) {
-                navigateTo(next);
-                return;
+      // P1-P4 are Spotify-only (album continuation, recommendations, artist
+      // top tracks, user catalog). Apple Music users skip straight to P5
+      // demo fallback until Phase 5 wires up Apple equivalents.
+      if (!isAppleMusicUser) {
+        // P1: Album continuation — play next track on the same album
+        const albumUri = player.spotifyStateTrack?.spotifyAlbumUri;
+        if (albumUri) {
+          const albumId = albumUri.replace("spotify:album:", "");
+          if (/^[a-zA-Z0-9]{20,25}$/.test(albumId)) {
+            const { data: albumData } = await supabase.functions.invoke("spotify-album", {
+              body: { albumId },
+            });
+            if (albumData?.tracks?.length) {
+              const currentIdx = albumData.tracks.findIndex(
+                (t: any) => t.uri === trackUri
+              );
+              if (currentIdx >= 0 && currentIdx < albumData.tracks.length - 1) {
+                const next = albumData.tracks[currentIdx + 1];
+                if (notPlayed(next.artist, next.title)) {
+                  navigateTo(next);
+                  return;
+                }
               }
             }
           }
         }
-      }
 
-      // P2: Spotify Recommendations (taste-weighted — prefer user's top artists)
-      if (trackUri) {
-        const { data: recData } = await supabase.functions.invoke("spotify-search", {
-          body: { recommend: trackUri },
+        // P2: Spotify Recommendations (taste-weighted — prefer user's top artists)
+        if (trackUri) {
+          const { data: recData } = await supabase.functions.invoke("spotify-search", {
+            body: { recommend: trackUri },
+          });
+          const recs = ((recData?.tracks || []) as SpotifyTrackResult[]).filter(
+            (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
+          );
+          if (recs.length > 0) {
+            const topArtists = new Set((profile?.spotifyTopArtists || []).map((a: string) => a.toLowerCase()));
+            const boosted = recs.filter((t) => topArtists.has(t.artist.toLowerCase()));
+            const pool = boosted.length > 0 ? boosted : recs;
+            navigateTo(pool[Math.floor(Math.random() * Math.min(pool.length, 3))]);
+            return;
+          }
+        }
+
+        // P3: Same-artist top tracks (via spotify-artist, which caches)
+        const { data: artistData } = await supabase.functions.invoke("spotify-artist", {
+          body: { artistName: track.artist },
         });
-        const recs = ((recData?.tracks || []) as SpotifyTrackResult[]).filter(
-          (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
+        if (artistData?.topTracks?.length) {
+          const candidates = (artistData.topTracks as SpotifyTrackResult[]).filter(
+            (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
+          );
+          if (candidates.length > 0) {
+            navigateTo(candidates[Math.floor(Math.random() * Math.min(candidates.length, 5))]);
+            return;
+          }
+        }
+
+        // P4: User's catalog (prefer different artist, relax if needed)
+        const userTracks = (profile?.spotifyTrackImages || []).filter(
+          (t) => t.uri && notPlayed(t.artist, t.title) && t.artist.toLowerCase() !== artistLower
         );
-        if (recs.length > 0) {
-          const topArtists = new Set((profile?.spotifyTopArtists || []).map((a: string) => a.toLowerCase()));
-          const boosted = recs.filter((t) => topArtists.has(t.artist.toLowerCase()));
-          const pool = boosted.length > 0 ? boosted : recs;
-          navigateTo(pool[Math.floor(Math.random() * Math.min(pool.length, 3))]);
+        const relaxed = userTracks.length > 0 ? userTracks
+          : (profile?.spotifyTrackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
+        if (relaxed.length > 0) {
+          const pick = relaxed[Math.floor(Math.random() * relaxed.length)];
+          navigateTo({ artist: pick.artist, title: pick.title, album: "", uri: pick.uri });
           return;
         }
       }
 
-      // P3: Same-artist top tracks (via spotify-artist, which caches)
-      const { data: artistData } = await supabase.functions.invoke("spotify-artist", {
-        body: { artistName: track.artist },
+      // P5: Demo track fallback. For Apple Music users, filter to tracks
+      // that have an appleMusicUri so we don't navigate to an unplayable URI.
+      const playableDemos = DEMO_TRACKS.filter((d) => {
+        if (!notPlayed(d.artist, d.title)) return false;
+        if (isAppleMusicUser) return !!d.appleMusicUri;
+        return true;
       });
-      if (artistData?.topTracks?.length) {
-        const candidates = (artistData.topTracks as SpotifyTrackResult[]).filter(
-          (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
-        );
-        if (candidates.length > 0) {
-          navigateTo(candidates[Math.floor(Math.random() * Math.min(candidates.length, 5))]);
-          return;
-        }
-      }
-
-      // P4: User's catalog (prefer different artist, relax if needed)
-      const userTracks = (profile?.spotifyTrackImages || []).filter(
-        (t) => t.uri && notPlayed(t.artist, t.title) && t.artist.toLowerCase() !== artistLower
-      );
-      const relaxed = userTracks.length > 0 ? userTracks
-        : (profile?.spotifyTrackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
-      if (relaxed.length > 0) {
-        const pick = relaxed[Math.floor(Math.random() * relaxed.length)];
-        navigateTo({ artist: pick.artist, title: pick.title, album: "", uri: pick.uri });
-        return;
-      }
-
-      // P5: Demo track fallback
-      const demos = DEMO_TRACKS.filter((d) => notPlayed(d.artist, d.title));
-      if (demos.length > 0) {
-        const pick = demos[Math.floor(Math.random() * demos.length)];
-        navigateTo({ artist: pick.artist, title: pick.title, album: pick.album, uri: pick.trackUri });
+      if (playableDemos.length > 0) {
+        const pick = playableDemos[Math.floor(Math.random() * playableDemos.length)];
+        const uri = getDemoTrackUri(pick, profile?.streamingService);
+        navigateTo({ artist: pick.artist, title: pick.title, album: pick.album, uri });
         return;
       }
 
@@ -358,7 +382,7 @@ export default function Listen() {
       isNavigatingRef.current = false;
       setSkipLoading(false);
     }
-  }, [track, trackUri, navigate, player, profile]);
+  }, [track, trackUri, navigate, player, profile, isAppleMusicUser]);
 
   const handlePrev = useCallback(() => {
     isNavigatingRef.current = true;
@@ -1307,8 +1331,9 @@ export default function Listen() {
           )}
         </motion.div>
 
-        {/* Spotify URI resolving indicator */}
-        {hasSpotifyToken && !trackUri && !isExternalListenMode && (
+        {/* URI resolving indicator (Spotify users only — Apple Music users
+            need a baked-in URI from the route since apple-search isn't wired) */}
+        {hasSpotifyToken && !isAppleMusicUser && !trackUri && !isExternalListenMode && (
           <motion.p
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -1319,7 +1344,7 @@ export default function Listen() {
         )}
 
         {/* Spotify session expired — reconnect prompt */}
-        {!hasSpotifyToken && trackUri && (
+        {!hasSpotifyToken && !isAppleMusicUser && trackUri && (
           <motion.div
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture event listeners registered on the MusicKit instance
+const eventListeners = new Map<string, Function>();
+
+const mockMusic = {
+  developerToken: "dev",
+  musicUserToken: "mut",
+  isAuthorized: true,
+  storefrontCountryCode: "us",
+  nowPlayingItem: null,
+  currentPlaybackTime: 0,
+  currentPlaybackDuration: 0,
+  currentPlaybackTimeRemaining: 0,
+  playbackState: 0,
+  authorize: vi.fn().mockResolvedValue("mut"),
+  unauthorize: vi.fn(),
+  play: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  stop: vi.fn(),
+  seekToTime: vi.fn().mockResolvedValue(undefined),
+  skipToNextItem: vi.fn(),
+  skipToPreviousItem: vi.fn(),
+  setQueue: vi.fn().mockResolvedValue(undefined),
+  addEventListener: vi.fn((event: string, cb: Function) => {
+    eventListeners.set(event, cb);
+  }),
+  removeEventListener: vi.fn(),
+};
+
+// Mock window.MusicKit before importing the engine
+vi.stubGlobal("MusicKit", {
+  configure: vi.fn().mockResolvedValue(mockMusic),
+  getInstance: vi.fn(() => {
+    throw new Error("not configured yet");
+  }),
+  PlaybackStates: {
+    none: 0,
+    loading: 1,
+    playing: 2,
+    paused: 3,
+    stopped: 4,
+    ended: 5,
+    seeking: 6,
+    waiting: 8,
+    stalled: 9,
+    completed: 10,
+  },
+});
+
+// Short-circuit the SDK script loader by pretending it's already loaded
+(window as any).MusicKit = (window as any).MusicKit || globalThis.MusicKit;
+
+import { AppleMusicPlaybackEngine } from "@/lib/engines/AppleMusicPlaybackEngine";
+import { _resetMusicKitLoaderForTests } from "@/lib/musickitLoader";
+
+describe("AppleMusicPlaybackEngine", () => {
+  const onReady = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventListeners.clear();
+    _resetMusicKitLoaderForTests();
+
+    // Re-attach the MusicKit stub onto window for each test
+    (window as any).MusicKit = {
+      configure: vi.fn().mockResolvedValue(mockMusic),
+      getInstance: vi.fn(() => {
+        throw new Error("not configured yet");
+      }),
+      PlaybackStates: globalThis.MusicKit.PlaybackStates,
+    };
+  });
+
+  it("service property is apple-music and deviceId is null", () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    expect(engine.service).toBe("apple-music");
+    expect(engine.deviceId).toBeNull();
+  });
+
+  it("init() configures MusicKit and becomes ready", async () => {
+    const engine = new AppleMusicPlaybackEngine({
+      developerToken: "dev-token",
+      onReady,
+    });
+
+    await engine.init();
+
+    expect(window.MusicKit!.configure).toHaveBeenCalledWith({
+      developerToken: "dev-token",
+      app: { name: "MusicNerd TV", build: "1.0.0" },
+    });
+    expect(engine.ready).toBe(true);
+    expect(onReady).toHaveBeenCalledWith(null);
+  });
+
+  it("loadTrack extracts catalog ID and calls setQueue", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    await engine.loadTrack("apple:song:1440833060");
+
+    expect(mockMusic.setQueue).toHaveBeenCalledWith({
+      song: "1440833060",
+      startPlaying: true,
+    });
+  });
+
+  it("loadTrack deduplicates repeat calls with the same URI", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    await engine.loadTrack("apple:song:1");
+    await engine.loadTrack("apple:song:1"); // same URI — should be ignored
+
+    expect(mockMusic.setQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("loadTrack before init() stores URI and plays when ready", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+
+    // Call loadTrack before init resolves
+    await engine.loadTrack("apple:song:999");
+    expect(mockMusic.setQueue).not.toHaveBeenCalled();
+
+    await engine.init();
+    // Give autoPlay a tick to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMusic.setQueue).toHaveBeenCalledWith({
+      song: "999",
+      startPlaying: true,
+    });
+  });
+
+  it("onStateChange receives updates from playbackTimeDidChange events", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    const stateSpy = vi.fn();
+    engine.onStateChange(stateSpy);
+
+    const timeCb = eventListeners.get("playbackTimeDidChange");
+    expect(timeCb).toBeDefined();
+
+    timeCb!({ currentPlaybackTime: 42, currentPlaybackDuration: 200, currentPlaybackTimeRemaining: 158 });
+
+    expect(stateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ currentTime: 42, duration: 200 })
+    );
+  });
+
+  it("onTrackEnd fires when playback reaches completed state", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    // Start playing a track so hasPlayed becomes true
+    await engine.loadTrack("apple:song:1");
+    const stateCb = eventListeners.get("playbackStateDidChange");
+    expect(stateCb).toBeDefined();
+
+    // Simulate "playing" state first
+    stateCb!({ state: 2 /* playing */ });
+
+    const endSpy = vi.fn();
+    engine.onTrackEnd(endSpy);
+
+    // Then simulate "completed" state
+    stateCb!({ state: 10 /* completed */ });
+    expect(endSpy).toHaveBeenCalled();
+  });
+
+  it("onTrackEnd does NOT fire if the track never played", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    const endSpy = vi.fn();
+    engine.onTrackEnd(endSpy);
+
+    const stateCb = eventListeners.get("playbackStateDidChange");
+    // Directly fire "completed" without a prior "playing" state
+    stateCb!({ state: 10 });
+
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  it("cleanup removes listeners and stops playback", async () => {
+    const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+    await engine.init();
+
+    engine.cleanup();
+
+    expect(mockMusic.removeEventListener).toHaveBeenCalledWith("playbackStateDidChange", expect.any(Function));
+    expect(mockMusic.removeEventListener).toHaveBeenCalledWith("playbackTimeDidChange", expect.any(Function));
+    expect(mockMusic.stop).toHaveBeenCalled();
+  });
+});

--- a/src/test/AppleMusicPlaybackEngine.test.ts
+++ b/src/test/AppleMusicPlaybackEngine.test.ts
@@ -194,4 +194,279 @@ describe("AppleMusicPlaybackEngine", () => {
     expect(mockMusic.removeEventListener).toHaveBeenCalledWith("playbackTimeDidChange", expect.any(Function));
     expect(mockMusic.stop).toHaveBeenCalled();
   });
+
+  // ── Polling lifecycle ─────────────────────────────────────────────────
+
+  it("polls currentPlaybackTime at 250ms while playing", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 10;
+      mockMusic.currentPlaybackDuration = 200;
+
+      // Enter playing state — starts the interval
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+      stateSpy.mockClear();
+
+      mockMusic.currentPlaybackTime = 10.25;
+      vi.advanceTimersByTime(250);
+      expect(stateSpy).toHaveBeenCalledWith(expect.objectContaining({ currentTime: 10.25 }));
+
+      mockMusic.currentPlaybackTime = 10.5;
+      vi.advanceTimersByTime(250);
+      expect(stateSpy).toHaveBeenCalledWith(expect.objectContaining({ currentTime: 10.5 }));
+
+      expect(stateSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops polling when playback pauses", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 5;
+      mockMusic.currentPlaybackDuration = 200;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+      vi.advanceTimersByTime(250);
+      stateCb!({ state: 3 /* paused */ });
+      stateSpy.mockClear();
+
+      // Time advances past several poll intervals but we're paused — no more ticks
+      mockMusic.currentPlaybackTime = 6;
+      vi.advanceTimersByTime(1000);
+
+      // Only the state-change event itself may emit; the interval must not fire.
+      // Filter the spy to just "driven by the poll" calls — those would be the
+      // ones fired without an accompanying state-change event. Since we cleared
+      // above and don't fire another state-change, any call means the poll leaked.
+      expect(stateSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips emission when polled time and duration are unchanged", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 7;
+      mockMusic.currentPlaybackDuration = 200;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+      stateSpy.mockClear();
+
+      // First tick records values
+      vi.advanceTimersByTime(250);
+      const firstCallCount = stateSpy.mock.calls.length;
+
+      // Subsequent ticks with no change should not emit
+      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
+
+      expect(stateSpy.mock.calls.length).toBe(firstCallCount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cleanup() stops polling so no interval leaks", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+
+      engine.cleanup();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 99;
+      vi.advanceTimersByTime(1000);
+
+      expect(stateSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("warns when currentPlaybackDuration is ≤30s at playback start", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 30;
+      mockMusic.currentPlaybackTime = 0;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Short duration"),
+        expect.objectContaining({ duration: 30 }),
+        expect.anything()
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preview warn fires once per track even across multiple pause/resume cycles", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 30;
+      mockMusic.currentPlaybackTime = 0;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      // playing → paused → playing → paused → playing
+      stateCb!({ state: 2 });
+      stateCb!({ state: 3 });
+      stateCb!({ state: 2 });
+      stateCb!({ state: 3 });
+      stateCb!({ state: 2 });
+
+      const previewWarns = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("Short duration")
+      );
+      expect(previewWarns.length).toBe(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("preview warn re-arms when loadTrack commits a new URI", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 30;
+      const stateCb = eventListeners.get("playbackStateDidChange");
+
+      await engine.loadTrack("apple:song:111");
+      stateCb!({ state: 2 });
+
+      await engine.loadTrack("apple:song:222");
+      stateCb!({ state: 2 });
+
+      const previewWarns = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("Short duration")
+      );
+      expect(previewWarns.length).toBe(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("stopPolling resets lastPolledTime so first tick after resume always emits", async () => {
+    vi.useFakeTimers();
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      const stateSpy = vi.fn();
+      engine.onStateChange(stateSpy);
+
+      mockMusic.currentPlaybackTime = 42;
+      mockMusic.currentPlaybackDuration = 200;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 /* playing */ });
+      vi.advanceTimersByTime(250); // records t=42
+      stateCb!({ state: 3 /* paused — stopPolling, reset last* */ });
+      stateSpy.mockClear();
+
+      // Resume with the SAME time — without the reset, the poll would
+      // skip this tick because t hasn't changed.
+      stateCb!({ state: 2 });
+      stateSpy.mockClear();
+      vi.advanceTimersByTime(250);
+
+      expect(stateSpy).toHaveBeenCalledWith(expect.objectContaining({ currentTime: 42 }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not warn when currentPlaybackDuration is a full track", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      mockMusic.currentPlaybackDuration = 429;
+      mockMusic.currentPlaybackTime = 0;
+
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+
+      const previewWarns = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("Short duration")
+      );
+      expect(previewWarns.length).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("logs subscription snapshot once, on the first state change (not during init)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const engine = new AppleMusicPlaybackEngine({ developerToken: "dev-token" });
+      await engine.init();
+
+      // init() must NOT emit the snapshot — auth state isn't guaranteed
+      // populated at configure() resolve time.
+      const initSnapshots = logSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("subscription snapshot")
+      );
+      expect(initSnapshots.length).toBe(0);
+
+      // First state change fires the snapshot
+      const stateCb = eventListeners.get("playbackStateDidChange");
+      stateCb!({ state: 2 });
+
+      const afterFirst = logSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("subscription snapshot")
+      );
+      expect(afterFirst.length).toBe(1);
+
+      // A second state change must not log the snapshot again
+      stateCb!({ state: 3 });
+      const afterSecond = logSpy.mock.calls.filter((args) =>
+        typeof args[0] === "string" && args[0].includes("subscription snapshot")
+      );
+      expect(afterSecond.length).toBe(1);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/src/test/makeNugget.test.ts
+++ b/src/test/makeNugget.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { makeNugget } from "@/hooks/useAINuggets";
+
+const baseSource = {
+  type: "article" as const,
+  title: "Test Source",
+  publisher: "Pitchfork",
+};
+
+const make = (overrides: { headline?: string; text?: string }) => ({
+  headline: overrides.headline ?? "",
+  text: overrides.text ?? "",
+  kind: "artist" as const,
+  source: baseSource,
+});
+
+describe("makeNugget headline derivation", () => {
+  it("passes through a provided headline unchanged", () => {
+    const n = make({ headline: "A Great Fact", text: "Some body text." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("A Great Fact");
+  });
+
+  it("derives headline from the first sentence when headline is empty", () => {
+    const n = make({ headline: "", text: "He played guitar on the track. The album was released later." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("He played guitar on the track");
+  });
+
+  it("splits on newline-separated sentences (not just space)", () => {
+    const n = make({ headline: "", text: "He played guitar.\nThe album dropped in 1975." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("He played guitar");
+  });
+
+  it("falls back to truncated text when first sentence is too short (≤ 10 chars)", () => {
+    const longTail = "A".repeat(120);
+    const n = make({ headline: "", text: `Hi. ${longTail}` });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe(`Hi. ${longTail}`.slice(0, 77) + "...");
+  });
+
+  it("truncates long first sentences with ellipsis", () => {
+    const longSentence = "A".repeat(100) + ". Second sentence.";
+    const n = make({ headline: "", text: longSentence });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("A".repeat(77) + "...");
+    expect(result.headline.length).toBe(80);
+  });
+
+  it("truncates short-first-sentence fallback consistently with ellipsis", () => {
+    const longTail = "B".repeat(100);
+    const n = make({ headline: "", text: `Ok. ${longTail}` });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline.endsWith("...")).toBe(true);
+    expect(result.headline.length).toBe(80);
+  });
+
+  it("derives headline when server sends whitespace-only headline + valid text", () => {
+    const n = make({ headline: "   ", text: "He played guitar on the track. More text." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("He played guitar on the track");
+  });
+
+  it("handles ! and ? sentence endings", () => {
+    const exclaim = make({ headline: "", text: "What a solo! This is the key part." });
+    expect(makeNugget(exclaim, "nug-1", "src-1", "track-1", 60).headline).toBe("What a solo");
+
+    const question = make({ headline: "", text: "Did you hear that riff? It changed rock music." });
+    expect(makeNugget(question, "nug-2", "src-2", "track-1", 60).headline).toBe("Did you hear that riff");
+  });
+
+  it("strips trailing punctuation from single-sentence text", () => {
+    const n = make({ headline: "", text: "Only sentence." });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("Only sentence");
+  });
+
+  it("uses 'Music Fact' placeholder when both headline and text are empty", () => {
+    const n = make({ headline: "", text: "" });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("Music Fact");
+  });
+
+  it("uses placeholder when both fields are whitespace-only", () => {
+    const n = make({ headline: "   ", text: "\n\t " });
+    const result = makeNugget(n, "nug-1", "src-1", "track-1", 60);
+    expect(result.headline).toBe("Music Fact");
+  });
+
+  it("preserves other nugget fields", () => {
+    const n = make({ headline: "Hello", text: "Body." });
+    const result = makeNugget(n, "nug-42", "src-42", "track-99", 123);
+    expect(result.id).toBe("nug-42");
+    expect(result.sourceId).toBe("src-42");
+    expect(result.trackId).toBe("track-99");
+    expect(result.timestampSec).toBe(123);
+    expect(result.text).toBe("Body.");
+    expect(result.kind).toBe("artist");
+  });
+});

--- a/src/test/resolveStreamingService.test.ts
+++ b/src/test/resolveStreamingService.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveStreamingService } from "@/hooks/useMusicNerdState";
+
+// Regression: useMusicNerdState previously force-set streamingService="Spotify"
+// whenever dbProfile.spotifyTopArtists existed, even for Apple Music users.
+// This silently downgraded Apple Music users whose row still had legacy
+// Spotify taste data. The new logic prefers the explicit service when set.
+
+describe("resolveStreamingService", () => {
+  it("returns the explicit service when provided (happy path)", () => {
+    expect(resolveStreamingService("Spotify", 20)).toBe("Spotify");
+    expect(resolveStreamingService("Apple Music", 20)).toBe("Apple Music");
+    expect(resolveStreamingService("YouTube Music", 20)).toBe("YouTube Music");
+  });
+
+  it("preserves Apple Music even when spotifyTopArtists is populated (the bug fix)", () => {
+    // Scenario: user first connected Spotify, later switched to Apple Music.
+    // Their DB row still has spotify_taste. The old logic clobbered service
+    // back to "Spotify" on the next DB load — this test locks that invariant.
+    expect(resolveStreamingService("Apple Music", 20)).toBe("Apple Music");
+  });
+
+  it("falls back to Spotify when service is unset but spotifyTopArtists is populated", () => {
+    // Legacy rows from before streaming_service was persisted
+    expect(resolveStreamingService(undefined, 15)).toBe("Spotify");
+    expect(resolveStreamingService("", 15)).toBe("Spotify");
+  });
+
+  it("returns empty string when service is unset and no spotifyTopArtists", () => {
+    expect(resolveStreamingService(undefined, 0)).toBe("");
+    expect(resolveStreamingService("", 0)).toBe("");
+  });
+
+  it("empty string service with populated artists still falls back to Spotify", () => {
+    expect(resolveStreamingService("", 5)).toBe("Spotify");
+  });
+
+  it("doesn't downgrade YouTube Music or future services to Spotify even with artists", () => {
+    expect(resolveStreamingService("YouTube Music", 100)).toBe("YouTube Music");
+  });
+});

--- a/src/test/useAppleMusicToken.test.ts
+++ b/src/test/useAppleMusicToken.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Mock supabase client before importing the hook so the mocked function
+// is in place when useAppleMusicToken's module-level imports resolve.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+import { useAppleMusicToken, saveAppleMusicToken, fetchAppleDeveloperToken } from "@/hooks/useAppleMusicToken";
+import { supabase } from "@/integrations/supabase/client";
+
+const STORAGE_KEY = "apple_music_token";
+
+describe("saveAppleMusicToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists both tokens to localStorage", () => {
+    saveAppleMusicToken("user-token", "dev-token");
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const stored = JSON.parse(raw!);
+    expect(stored.musicUserToken).toBe("user-token");
+    expect(stored.developerToken).toBe("dev-token");
+    expect(stored.devTokenExpiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("sets expiry ~30 days in the future", () => {
+    const before = Date.now();
+    saveAppleMusicToken("u", "d");
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+    expect(stored.devTokenExpiresAt).toBeGreaterThanOrEqual(before + thirtyDays - 1000);
+    expect(stored.devTokenExpiresAt).toBeLessThanOrEqual(before + thirtyDays + 1000);
+  });
+});
+
+describe("useAppleMusicToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("reports no token when localStorage is empty", () => {
+    const { result } = renderHook(() => useAppleMusicToken());
+    expect(result.current.hasMusicToken).toBe(false);
+    expect(result.current.getMusicUserToken()).toBeNull();
+  });
+
+  it("reports token when present in localStorage", () => {
+    saveAppleMusicToken("user-token-abc", "dev-token-xyz");
+    const { result } = renderHook(() => useAppleMusicToken());
+    expect(result.current.hasMusicToken).toBe(true);
+    expect(result.current.getMusicUserToken()).toBe("user-token-abc");
+  });
+
+  it("clearToken removes the stored token and updates state", () => {
+    saveAppleMusicToken("u", "d");
+    const { result } = renderHook(() => useAppleMusicToken());
+    expect(result.current.hasMusicToken).toBe(true);
+
+    act(() => {
+      result.current.clearToken();
+    });
+
+    expect(result.current.hasMusicToken).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("getDeveloperToken returns cached token when still fresh", async () => {
+    saveAppleMusicToken("u", "cached-dev-token");
+    const { result } = renderHook(() => useAppleMusicToken());
+
+    const token = await result.current.getDeveloperToken();
+    expect(token).toBe("cached-dev-token");
+    // Should NOT have called the edge function
+    expect(supabase.functions.invoke).not.toHaveBeenCalled();
+  });
+
+  it("getDeveloperToken refetches when token is expired", async () => {
+    // Write a stale token directly (expiresAt in the past)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      musicUserToken: "u",
+      developerToken: "stale-dev-token",
+      devTokenExpiresAt: Date.now() - 1000,
+    }));
+
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: { token: "fresh-dev-token" },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAppleMusicToken());
+    const token = await result.current.getDeveloperToken();
+
+    expect(supabase.functions.invoke).toHaveBeenCalledWith("apple-dev-token");
+    expect(token).toBe("fresh-dev-token");
+
+    // The stored token should have been updated
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.developerToken).toBe("fresh-dev-token");
+    expect(stored.musicUserToken).toBe("u"); // MUT preserved
+  });
+});
+
+describe("fetchAppleDeveloperToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns token on success", async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: { token: "jwt-token" },
+      error: null,
+    });
+
+    const token = await fetchAppleDeveloperToken();
+    expect(token).toBe("jwt-token");
+  });
+
+  it("returns null on edge function error", async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: null,
+      error: { message: "server error" },
+    });
+
+    const token = await fetchAppleDeveloperToken();
+    expect(token).toBeNull();
+  });
+
+  it("returns null on network exception", async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network"));
+
+    const token = await fetchAppleDeveloperToken();
+    expect(token).toBeNull();
+  });
+});

--- a/src/test/useUserProfile.test.ts
+++ b/src/test/useUserProfile.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Mock dependencies before the hook module is imported so the mocks
+// are in place when useUserProfile's top-level imports resolve.
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: null, session: null, loading: false, isGuest: true }),
+}));
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    })),
+  },
+}));
+
+import { useUserProfile } from "@/hooks/useMusicNerdState";
+import type { UserProfile } from "@/mock/types";
+
+const PROFILE_KEY = "musicnerd_profile";
+
+// Regression: the Apple Music fast path broke because every useUserProfile()
+// call created its own independent useState slot. Connect.tsx saved a profile,
+// but PlayerProvider's useUserProfile never saw the change — its state stayed
+// null, the engine init effect never fired, and Apple Music playback died.
+// These tests lock the cross-instance sync via the custom-event pattern.
+
+describe("useUserProfile cross-instance sync", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("syncs profile across two hook instances when one calls saveProfile", async () => {
+    const { result: a } = renderHook(() => useUserProfile());
+    const { result: b } = renderHook(() => useUserProfile());
+
+    expect(a.current.profile).toBeNull();
+    expect(b.current.profile).toBeNull();
+
+    const newProfile: UserProfile = {
+      streamingService: "Apple Music",
+      calculatedTier: "nerd",
+    };
+
+    await act(async () => {
+      await a.current.saveProfile(newProfile);
+    });
+
+    // Both instances should now report the new profile
+    expect(a.current.profile?.streamingService).toBe("Apple Music");
+    expect(b.current.profile?.streamingService).toBe("Apple Music");
+    expect(a.current.profile?.calculatedTier).toBe("nerd");
+    expect(b.current.profile?.calculatedTier).toBe("nerd");
+  });
+
+  it("syncs clearProfile across two hook instances", async () => {
+    // Seed both instances with a profile
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Spotify",
+      calculatedTier: "casual",
+    }));
+
+    const { result: a } = renderHook(() => useUserProfile());
+    const { result: b } = renderHook(() => useUserProfile());
+
+    expect(a.current.profile?.streamingService).toBe("Spotify");
+    expect(b.current.profile?.streamingService).toBe("Spotify");
+
+    await act(async () => {
+      a.current.clearProfile();
+    });
+
+    expect(a.current.profile).toBeNull();
+    expect(b.current.profile).toBeNull();
+    expect(localStorage.getItem(PROFILE_KEY)).toBeNull();
+  });
+
+  it("changing streamingService propagates to a second instance", async () => {
+    // Starts as Spotify
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Spotify",
+      calculatedTier: "casual",
+    }));
+
+    const { result: a } = renderHook(() => useUserProfile());
+    const { result: b } = renderHook(() => useUserProfile());
+
+    // Second instance also sees the initial value
+    expect(b.current.profile?.streamingService).toBe("Spotify");
+
+    // First instance switches the user to Apple Music
+    await act(async () => {
+      await a.current.saveProfile({
+        streamingService: "Apple Music",
+        calculatedTier: "casual",
+      });
+    });
+
+    // The change must propagate — this is the exact scenario that broke
+    // Apple Music playback: PlayerProvider needs to see the new service
+    // to create the correct engine.
+    expect(b.current.profile?.streamingService).toBe("Apple Music");
+  });
+});

--- a/src/types/musickit.d.ts
+++ b/src/types/musickit.d.ts
@@ -1,0 +1,125 @@
+// MusicKit JS v3 type stubs.
+// Covers the subset of APIs used by AppleMusicPlaybackEngine and useAppleMusicAuth.
+// Full reference: https://js-cdn.music.apple.com/musickit/v3/docs/
+
+declare namespace MusicKit {
+  interface ConfigureOptions {
+    developerToken: string;
+    app: {
+      name: string;
+      build?: string;
+    };
+    storefrontId?: string;
+    suppressErrorDialog?: boolean;
+  }
+
+  /** Playback state values per MusicKit v3 spec. Declared as a runtime
+   *  object (not a TS enum) so ambient emit semantics stay predictable
+   *  across bundlers. The engine reads window.MusicKit.PlaybackStates at
+   *  runtime and compares numeric values. */
+  const PlaybackStates: {
+    readonly none: 0;
+    readonly loading: 1;
+    readonly playing: 2;
+    readonly paused: 3;
+    readonly stopped: 4;
+    readonly ended: 5;
+    readonly seeking: 6;
+    readonly waiting: 8;
+    readonly stalled: 9;
+    readonly completed: 10;
+  };
+  type PlaybackStates = typeof PlaybackStates[keyof typeof PlaybackStates];
+
+  interface Artwork {
+    url?: string;         // Contains {w}x{h} template placeholders
+    width?: number;
+    height?: number;
+    bgColor?: string;
+  }
+
+  interface MediaItem {
+    id: string;
+    type: string;         // "song", "album", etc.
+    attributes?: {
+      name?: string;
+      artistName?: string;
+      albumName?: string;
+      artwork?: Artwork;
+      durationInMillis?: number;
+      url?: string;
+    };
+  }
+
+  interface SetQueueOptions {
+    song?: string;        // Catalog song ID
+    songs?: string[];
+    album?: string;
+    playlist?: string;
+    startWith?: number;
+    startPlaying?: boolean;
+  }
+
+  interface PlaybackTimeEvent {
+    currentPlaybackDuration: number;  // seconds
+    currentPlaybackTime: number;      // seconds
+    currentPlaybackTimeRemaining: number;
+  }
+
+  interface PlaybackStateEvent {
+    state: PlaybackStates;
+    oldState?: PlaybackStates;
+  }
+
+  interface MediaItemEvent {
+    oldItem?: MediaItem;
+    item?: MediaItem;
+  }
+
+  type EventCallback<T = unknown> = (event: T) => void;
+
+  interface MusicKitInstance {
+    readonly developerToken: string;
+    readonly musicUserToken: string;
+    readonly isAuthorized: boolean;
+    readonly storefrontCountryCode: string;
+    readonly nowPlayingItem: MediaItem | null;
+    readonly currentPlaybackTime: number;
+    readonly currentPlaybackDuration: number;
+    readonly currentPlaybackTimeRemaining: number;
+    readonly playbackState: PlaybackStates;
+
+    // Auth
+    authorize(): Promise<string>;   // Returns Music User Token
+    unauthorize(): Promise<void>;
+
+    // Playback control
+    play(): Promise<void>;
+    pause(): void;
+    stop(): void;
+    seekToTime(time: number): Promise<void>;
+    skipToNextItem(): Promise<void>;
+    skipToPreviousItem(): Promise<void>;
+
+    // Queue
+    setQueue(options: SetQueueOptions): Promise<void>;
+
+    // Events
+    addEventListener(event: "playbackStateDidChange", cb: EventCallback<PlaybackStateEvent>): void;
+    addEventListener(event: "playbackTimeDidChange", cb: EventCallback<PlaybackTimeEvent>): void;
+    addEventListener(event: "playbackDurationDidChange", cb: EventCallback<{ duration: number }>): void;
+    addEventListener(event: "mediaItemDidChange", cb: EventCallback<MediaItemEvent>): void;
+    addEventListener(event: "queueItemsDidChange", cb: EventCallback<MediaItem[]>): void;
+    addEventListener(event: "authorizationStatusDidChange", cb: EventCallback<{ authorizationStatus: number }>): void;
+    addEventListener(event: string, cb: EventCallback): void;
+    removeEventListener(event: string, cb: EventCallback): void;
+  }
+
+  function configure(options: ConfigureOptions): Promise<MusicKitInstance>;
+  function getInstance(): MusicKitInstance;
+}
+
+interface Window {
+  MusicKit?: typeof MusicKit;
+  musicKitLoaded?: boolean;
+}

--- a/supabase/functions/_shared/apple-token.ts
+++ b/supabase/functions/_shared/apple-token.ts
@@ -1,0 +1,98 @@
+// Shared Apple Music Developer Token generation.
+// Import as: import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
+//
+// Generates an ES256-signed JWT using the Apple Music private key (.p8 file).
+// Max JWT lifetime is 180 days per Apple's requirements. Cached in-memory with
+// 1-day buffer so we regenerate well before expiry. Each Deno isolate caches
+// independently — cold starts re-generate (fast local CPU operation, no network).
+//
+// Required secrets:
+//   APPLE_MUSIC_KEY_ID     — 10-char Key ID from Apple Developer portal
+//   APPLE_MUSIC_TEAM_ID    — 10-char Team ID
+//   APPLE_MUSIC_PRIVATE_KEY — Contents of the .p8 file (PEM format)
+//
+// Key rotation: if APPLE_MUSIC_PRIVATE_KEY is rotated (e.g. due to compromise),
+// warm Deno isolates will continue serving the old cached JWT until they cold-
+// start. To force an immediate rotation across all isolates, redeploy the
+// edge function after setting the new secret — that replaces all workers.
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+const MAX_LIFETIME_SEC = 180 * 24 * 60 * 60;  // 180 days (Apple's max)
+const BUFFER_SEC = 24 * 60 * 60;              // 1-day buffer
+
+/** Get an Apple Developer Token (ES256 JWT). Cached in-memory, regenerated well before expiry. */
+export async function getAppleDeveloperToken(): Promise<string> {
+  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
+
+  const keyId = Deno.env.get("APPLE_MUSIC_KEY_ID");
+  const teamId = Deno.env.get("APPLE_MUSIC_TEAM_ID");
+  const privateKeyPem = Deno.env.get("APPLE_MUSIC_PRIVATE_KEY");
+
+  if (!keyId || !teamId || !privateKeyPem) {
+    throw new Error("Missing Apple Music credentials (APPLE_MUSIC_KEY_ID, APPLE_MUSIC_TEAM_ID, APPLE_MUSIC_PRIVATE_KEY)");
+  }
+
+  const cryptoKey = await importPrivateKey(privateKeyPem);
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "ES256", kid: keyId, typ: "JWT" };
+  const payload = { iss: teamId, iat: now, exp: now + MAX_LIFETIME_SEC };
+
+  const headerB64 = base64UrlEncode(new TextEncoder().encode(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  );
+
+  // Web Crypto outputs ECDSA signatures in IEEE P1363 format (raw r||s),
+  // which is exactly what JWT ES256 requires.
+  const signatureB64 = base64UrlEncode(new Uint8Array(signature));
+  const token = `${signingInput}.${signatureB64}`;
+
+  cachedToken = token;
+  tokenExpiresAt = Date.now() + (MAX_LIFETIME_SEC - BUFFER_SEC) * 1000;
+  return token;
+}
+
+/** Clear cached token (for testing or forced refresh). */
+export function clearAppleDeveloperToken(): void {
+  cachedToken = null;
+  tokenExpiresAt = 0;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  // Strip PEM headers/footers and whitespace, decode base64 to DER bytes.
+  // Global regex so multi-line or duplicated markers are handled correctly.
+  // Apple provides PKCS8-format keys (-----BEGIN PRIVATE KEY-----); we reject
+  // EC-specific PEM formats early with a clear error so users know to re-export.
+  if (pem.includes("-----BEGIN EC PRIVATE KEY-----")) {
+    throw new Error("Apple Music private key must be in PKCS8 format, not EC format");
+  }
+  const pemBody = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s/g, "");
+  const binary = Uint8Array.from(atob(pemBody), (c) => c.charCodeAt(0));
+
+  return await crypto.subtle.importKey(
+    "pkcs8",
+    binary,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}

--- a/supabase/functions/apple-dev-token/index.ts
+++ b/supabase/functions/apple-dev-token/index.ts
@@ -1,0 +1,71 @@
+// Serves an Apple Music Developer Token (ES256 JWT) to authenticated clients.
+// The client passes this to MusicKit.configure() before prompting the user
+// to authorize (which then returns a Music User Token for library/history access).
+//
+// Requires a valid Supabase user session — prevents anonymous abuse of the
+// Apple Music API quota by third parties scraping the endpoint.
+//
+// Called by useAppleMusicAuth on the client before initiateAppleMusicAuth().
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
+
+// Wildcard origin is safe here — access is gated by the Supabase JWT
+// validation below, so no unauthenticated cross-origin caller can obtain
+// a token. Matches the CORS pattern used across the repo's edge functions.
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  // Require a valid Supabase session — the client library includes the user's
+  // JWT automatically via supabase.functions.invoke.
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error("Supabase environment not configured");
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey);
+    const { data: userData, error: userError } = await supabase.auth.getUser(
+      authHeader.replace(/^Bearer\s+/i, "")
+    );
+    if (userError || !userData?.user) {
+      return new Response(
+        JSON.stringify({ error: "Unauthorized" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const token = await getAppleDeveloperToken();
+    return new Response(
+      JSON.stringify({ token }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    // Log the full error server-side but return a generic message to the client
+    // so we don't leak internal config, key material, or env var names.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[apple-dev-token] Failed to generate token:", message);
+    return new Response(
+      JSON.stringify({ error: "Service temporarily unavailable" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
Promotes the Apple Music rollout, the empty-headline guard, and the PR #45 code-review follow-ups from `staging` to `main`.

Bundled PRs:
- **#39** feat: Apple Music auth + playback engine
- **#40** feat: Apple Music fast path — onboarding + demo playback
- **#41** fix: sync useUserProfile state across hook instances (Apple Music playback)
- **#42** fix: smooth Apple Music progress bar + preview diagnostics
- **#43** fix: client-side headline guard for empty server headlines
- **#46** fix: demo tracks playable on both Spotify and Apple Music + PR #45 review items 2-4 (clearToken same-tab sync, dev-only subscription logging, actionable Apple Music auth error)

## Test plan
- [ ] Spotify playback path unaffected (PKCE OAuth, Web Playback SDK, nugget timing)
- [ ] Apple Music sign-in completes and plays a demo track end-to-end
- [ ] All 5 Browse demo tiles play under **both** Spotify and Apple Music (regression: previously only Around the World worked for Apple users)
- [ ] Apple Music progress bar advances smoothly (no jitter after seek)
- [ ] Switching between Spotify and Apple accounts preserves useUserProfile state across hook instances
- [ ] Nuggets with empty server headlines render a derived headline (not a blank card)
- [ ] Clicking "Connect Apple Music" before signing in shows "Sign in to MusicNerd before connecting Apple Music" (not the generic error loop)
- [ ] `logSubscriptionStatus` does not fire in production builds (verify: no `/v1/me/storefront` call in prod network panel)
- [ ] `clearToken()` flips sibling `useAppleMusicToken` consumers to `hasMusicToken=false` same-tab
- [ ] `npm test` passes (129 tests)
- [ ] `npm run build` succeeds and Vercel preview deploys clean