### PR TITLE
fix: unblock Apple Music connect by dropping the false session gate

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tvdb": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=ofuayztvadxtacmsevxk&read_only=true"
+    }
+  }
+}

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -9,7 +9,6 @@ import spotifyLogo from "@/assets/spotify-logo.png";
 import { initiateSpotifyAuth } from "@/hooks/useSpotifyAuth";
 import { initiateAppleMusicAuth, fetchAppleMusicTaste } from "@/hooks/useAppleMusicAuth";
 import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
-import { supabase } from "@/integrations/supabase/client";
 
 type Tier = "casual" | "curious" | "nerd";
 
@@ -103,15 +102,13 @@ export default function Connect() {
     setAppleMusicConnecting(true);
     setAppleMusicError(null);
     try {
-      // The apple-dev-token edge function requires a Supabase session and
-      // returns 401 otherwise. Pre-flight the check so we surface an
-      // actionable message instead of a generic "couldn't connect" loop.
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) {
-        setAppleMusicError("Sign in to MusicNerd before connecting Apple Music.");
-        return;
-      }
-
+      // No Supabase session required: the deployed apple-dev-token edge
+      // function authenticates on the anon key alone (no in-function
+      // user check, no rows in auth.users). The earlier pre-flight gate
+      // here was based on a documented-but-not-enforced JWT requirement
+      // and blocked all Apple Music sign-ins after a real logout cleared
+      // the leftover Lovable broker session that nobody had explicitly
+      // provisioned.
       const musicUserToken = await initiateAppleMusicAuth();
       if (musicUserToken) {
         setAppleMusicConnected(true);

--- a/supabase/functions/spotify-taste/index.ts
+++ b/supabase/functions/spotify-taste/index.ts
@@ -43,7 +43,21 @@ serve(async (req) => {
     ]);
 
     if (!artistsMediumRes.ok) {
-      throw new Error(`Spotify API error: ${artistsMediumRes.status}`);
+      // Capture the actual Spotify response body + status so we can see
+      // *why* the call failed (401 expired token vs 403 missing scope vs
+      // dev-mode deprecation). Without this, the client sees a generic 500.
+      const body = await artistsMediumRes.text().catch(() => "<unreadable>");
+      console.error(
+        `[spotify-taste] /me/top/artists failed: status=${artistsMediumRes.status} body=${body.slice(0, 500)}`,
+      );
+      return new Response(
+        JSON.stringify({
+          error: "Spotify API error",
+          spotifyStatus: artistsMediumRes.status,
+          spotifyBody: body.slice(0, 500),
+        }),
+        { status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
     }
 
     const [artistsMedium, artistsShort, tracksData, profileData] = await Promise.all([


### PR DESCRIPTION
## Summary

The "Sign in to MusicNerd before connecting Apple Music" error you saw after the logout fix was a phantom check. The deployed \`apple-dev-token\` edge function does not actually require a Supabase session, the in-app gate that pretended it did was the only thing blocking Apple Music after a real logout, and there are zero rows in \`auth.users\` because nobody has ever signed in to this Supabase project. All Apple Music testing has been working anonymously the entire time.

## What changed
- **\`Connect.tsx\`** — removes the \`supabase.auth.getSession()\` pre-flight gate in \`handleConnectAppleMusic\`. Apple Music connect succeeds for any user, with or without a Supabase session, matching the actual deployed backend.
- **\`Connect.tsx\`** — drops the now-unused \`supabase\` client import.
- **\`supabase/functions/spotify-taste/index.ts\`** — the diagnostic patch from earlier in this session (already deployed as version 13). Keeps the repo in sync with prod.
- **\`.mcp.json\`** — tvdb MCP server config (project_ref + read_only flag, no secrets).

## Why this is the right fix right now
Verified empirically against \`ofuayztvadxtacmsevxk\` via MCP:

\`\`\`
auth.users         → 0 rows
auth.identities    → 0 rows
auth.sessions      → 0 rows
auth.refresh_tokens → 0 rows
public.profiles    → 0 rows
public.nugget_history → 0 rows
\`\`\`

The contractor wired up two parallel "auth" worlds (a custom Spotify PKCE flow that bypasses Supabase entirely, and a Lovable broker integration that's exported but never called) and then documented an apple-dev-token JWT requirement that the deployed function doesn't actually enforce. The result is a codebase where \`auth.users\` has never had a row and the only thing preventing anonymous Apple Music sign-in was the client-side gate this PR removes.

This is option 1 from the design discussion: the smallest fix to unblock testing tonight. It does not address the bigger question of whether MNTv should have real user accounts, and it doesn't migrate the speculative auth wiring (lovable integration, AuthContext, useUserProfile DB sync) that's currently dead code. Those decisions can come later once we know whether you want accounts at all.

## Test plan
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 185 tests pass
- [ ] Manually: sign out from Browse → click Apple Music connect on Connect → Apple authorize popup should fire (no error banner)
- [ ] Manually: full Apple Music end-to-end after sign-out should work the same as it did before the logout fix landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)