### PR TITLE
fix: mobile headline visibility + progressive nugget streaming

### DIFF
--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -19,6 +19,10 @@ interface ImmersiveNuggetViewProps {
   onClose: () => void;
   onPrev?: () => void;
   onNext?: () => void;
+  // When true, streamed nuggets are unlocked immediately on arrival instead of
+  // waiting for playback to reach each timestampSec — parity with desktop's
+  // fresh-SSE bypass so the first headline lands the moment the stream emits it.
+  isFresh?: boolean;
 }
 
 // Module-level so it persists across unmount/remount cycles (e.g. navigating
@@ -44,6 +48,7 @@ export default function ImmersiveNuggetView({
   onPrev,
   onNext,
   spotifyAlbumArt,
+  isFresh = false,
 }: ImmersiveNuggetViewProps) {
   const { isPlaying, currentTime, duration, toggle, seek } = usePlayer();
   const mountedRef = useRef(true);
@@ -92,10 +97,22 @@ export default function ImmersiveNuggetView({
   }, [trackTitle, artist]);
 
   // ── Unlock nuggets ─────────────────────────────────────────────────
-  // Only runs when currentTime crosses the next nugget's timestamp,
-  // not on every ~4 Hz playback tick (~720 skipped invocations per track).
+  // Fresh SSE: unlock every streamed nugget immediately so swipes work
+  // while the stream is still arriving (parity with desktop queue behavior).
+  // Cached: only unlock when currentTime crosses each timestamp, not on every
+  // ~4 Hz playback tick (~720 skipped invocations per track).
   useEffect(() => {
     if (nuggets.length === 0) return;
+
+    if (isFresh) {
+      setUnlockedIds((prev) => {
+        if (prev.size === nuggets.length) return prev;
+        return new Set(nuggets.map((n) => n.id));
+      });
+      nextUnlockTimeRef.current = Infinity;
+      return;
+    }
+
     if (currentTime < nextUnlockTimeRef.current) return;
 
     setUnlockedIds((prev) => {
@@ -115,7 +132,7 @@ export default function ImmersiveNuggetView({
       .filter((n) => n.timestampSec > currentTime)
       .sort((a, b) => a.timestampSec - b.timestampSec);
     nextUnlockTimeRef.current = upcoming.length > 0 ? upcoming[0].timestampSec : Infinity;
-  }, [currentTime, nuggets]);
+  }, [currentTime, nuggets, isFresh]);
 
   // ── Auto-show new nuggets ──────────────────────────────────────────
   useEffect(() => {
@@ -250,7 +267,7 @@ export default function ImmersiveNuggetView({
             <img
               src={imgUrl}
               alt=""
-              className={`absolute inset-0 w-full h-full object-cover ${!isNuggetImage ? "scale-110 blur-sm" : ""}`}
+              className="absolute inset-0 w-full h-full object-cover"
               onError={() => {
                 if (isNuggetImage && activeNugget?.imageUrl) {
                   setFailedImages((prev) => new Set(prev).add(activeNugget.imageUrl!));
@@ -261,35 +278,36 @@ export default function ImmersiveNuggetView({
           <div className="absolute inset-0" style={{
             background: "linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.6) 25%, rgba(0,0,0,0.15) 55%, transparent 80%)",
           }} />
-          <div className="absolute bottom-0 inset-x-0 px-5 pb-4 z-20">
-            <span className="text-[10px] uppercase tracking-[0.2em] text-white/60 mb-2 block" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.8)" }}>
-              {activeNugget ? (KIND_LABELS[activeNugget.kind] || activeNugget.kind) : ""}
-            </span>
-            {activeNugget && (
-              isTypewriterDone ? (
-                <h2 className="text-xl font-bold leading-tight text-white" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}>
-                  {activeNugget.headline || activeNugget.text}
-                </h2>
-              ) : (
-                <TypewriterText
-                  text={activeNugget.headline || activeNugget.text}
-                  speed={35}
-                  paused={false}
-                  onComplete={handleTypewriterComplete}
-                  as="h2"
-                  className="text-xl font-bold leading-tight text-white"
-                  style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}
-                />
-              )
-            )}
-          </div>
         </div>
 
-        {/* Body scrolls over the sticky image. Solid black bg-black ensures
-            no gap is visible when scrolling past the gradient overlap zone. */}
-        <div className="px-5 pb-5 -mt-32 relative z-10 pt-36 bg-black" style={{
-          backgroundImage: "linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 20%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 60%, rgb(0,0,0) 100%)",
+        {/* Body overlaps the bottom of the sticky image just enough to show
+            the headline on initial view — the paragraph stays below the fold
+            until the user scrolls. Headline sits at the top of this scrolling
+            block so it travels up with the paragraph when scrolling. No
+            bg-black — the transparent gradient lets the hero show through. */}
+        <div className="px-5 pb-5 -mt-36 relative z-10 pt-16" style={{
+          backgroundImage: "linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.55) 25%, rgba(0,0,0,0.85) 50%, rgb(0,0,0) 75%)",
         }}>
+          <span className="text-[10px] uppercase tracking-[0.2em] text-white/60 mb-2 block" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.8)" }}>
+            {activeNugget ? (KIND_LABELS[activeNugget.kind] || activeNugget.kind) : ""}
+          </span>
+          {activeNugget && (
+            isTypewriterDone ? (
+              <h2 className="text-xl font-bold leading-tight text-white mb-4" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}>
+                {activeNugget.headline || activeNugget.text}
+              </h2>
+            ) : (
+              <TypewriterText
+                text={activeNugget.headline || activeNugget.text}
+                speed={35}
+                paused={false}
+                onComplete={handleTypewriterComplete}
+                as="h2"
+                className="text-xl font-bold leading-tight text-white mb-4 block"
+                style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}
+              />
+            )
+          )}
           <p className="text-sm leading-relaxed text-white/60 mb-4">
             {activeNugget?.text}
           </p>

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1699,6 +1699,7 @@ export default function Listen() {
               onPrev={handlePrev}
               onNext={handleNext}
               spotifyAlbumArt={spotifyStateTrack?.albumArtUrl}
+              isFresh={!aiFromCache}
             />
           </Suspense>
         )}

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -2881,9 +2881,15 @@ Return ONLY valid JSON:
           (async () => {
             try {
               // Pipeline: resolve image → assemble → validate → stream.
-              // Sequential to prevent duplicate usedImageUrls. Skipped nuggets
-              // (hallucinated sources) don't get streamed, so we track a separate
-              // streamedIndex for contiguous client-side indices.
+              // Wikipedia lookups fire in parallel so late nuggets don't wait
+              // behind early ones; dedup + assemble + stream still happen
+              // sequentially to keep usedImageUrls correct and preserve order.
+              const imageLookups = rawNuggets.map((n) =>
+                !n._resolvedImageUrl && isValidImageQuery(n.imageSearchQuery)
+                  ? resolveNuggetImage(n.imageSearchQuery!).catch(() => null)
+                  : null
+              );
+
               let streamedIndex = 0;
               const streamedNuggets: any[] = []; // for cache write consistency
 
@@ -2891,9 +2897,9 @@ Return ONLY valid JSON:
                 const n = rawNuggets[i];
 
                 // ── Image resolution ──
-                if (!n._resolvedImageUrl && isValidImageQuery(n.imageSearchQuery)) {
+                if (!n._resolvedImageUrl && imageLookups[i]) {
                   try {
-                    const wikiResult = await resolveNuggetImage(n.imageSearchQuery!);
+                    const wikiResult = await imageLookups[i];
                     if (wikiResult && !usedImageUrls.has(wikiResult.url)) {
                       n._resolvedImageUrl = wikiResult.url;
                       n._resolvedImageTitle = wikiResult.title;


### PR DESCRIPTION
## Summary

Fixes two related nugget-pipeline bugs surfaced on the Listen page:

- **Mobile headlines never appeared.** The ImmersiveNuggetView put the kind label + headline at the bottom of a viewport-tall sticky div, where the body's `-mt-32 bg-black` layer covered it on every scroll. Moved the headline to the top of the scrolling body so it travels with the paragraph, tightened the overlap so only the headline peeks initially, and dropped the body's solid `bg-black` so the crossfade gradient actually reveals the hero image. Also removed the blur+scale on fallback cover art so it renders sharp.
- **Mobile unlock gate was cache-only.** Added `isFresh` prop (wired from Listen via `!aiFromCache`) that unlocks streamed nuggets immediately on arrival, parity with desktop's fresh-SSE bypass.
- **Desktop felt like it waited for all 3 nuggets before showing the first.** Server was awaiting Wikipedia image lookups sequentially per-nugget; now kicks them off in parallel before the streaming loop so later nuggets don't wait behind earlier ones. Dedup + assemble + stream-order still sequential.

## Test plan

- [ ] `npm test` — all 193 passing locally
- [ ] `npm run build` — clean
- [ ] Mobile Safari on a seed track (KIKI): confirm headline + kind label peek at the bottom of the hero on load, paragraph hidden until scroll, image renders sharp
- [ ] Scroll up on mobile: headline + paragraph move together over the pinned image with a smooth gradient fade
- [ ] Desktop fresh uncached track: confirm first NuggetCard renders as soon as first SSE event lands (not after all 3)
- [ ] Cached tracks still unlock at playback timestamps (no regression)