### PR TITLE
feat: progressive per-nugget streaming + UI pacing

### DIFF
--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -134,19 +134,43 @@ export default function ImmersiveNuggetView({
     nextUnlockTimeRef.current = upcoming.length > 0 ? upcoming[0].timestampSec : Infinity;
   }, [currentTime, nuggets, isFresh]);
 
+  // Track when the current nugget was first shown — used by auto-show
+  // to enforce minimum read time before auto-advancing.
+  const nuggetShownAtRef = useRef(Date.now());
+
   // ── Auto-show new nuggets ──────────────────────────────────────────
+  // Enforces a minimum display time (10 s) so freshly-streamed nuggets
+  // don't yank the user away mid-read. If the timer hasn't elapsed the
+  // swipe dots still update — user can swipe manually.
+  const MIN_DISPLAY_MS = 10_000;
   useEffect(() => {
     const count = unlockedIds.size;
     if (count > prevUnlockedCountRef.current && count > 0) {
       const arr = nuggets.filter((n) => unlockedIds.has(n.id));
       const idx = nuggets.indexOf(arr[arr.length - 1]);
       if (idx >= 0) {
-        setActiveIndex(idx);
-        // Only auto-show if user hasn't manually dismissed to now-playing
-        if (!userDismissedRef.current) {
-          setNuggetDismissed(false);
+        const elapsed = Date.now() - nuggetShownAtRef.current;
+        if (prevUnlockedCountRef.current === 0 || elapsed >= MIN_DISPLAY_MS) {
+          setActiveIndex(idx);
+          nuggetShownAtRef.current = Date.now();
+          if (!userDismissedRef.current) {
+            setNuggetDismissed(false);
+          }
+          setDeepDiveText(null);
+        } else {
+          const remaining = MIN_DISPLAY_MS - elapsed;
+          const timer = setTimeout(() => {
+            setActiveIndex(idx);
+            nuggetShownAtRef.current = Date.now();
+            if (!userDismissedRef.current) {
+              setNuggetDismissed(false);
+            }
+            setDeepDiveText(null);
+          }, remaining);
+          // Don't update prevUnlockedCountRef yet — the timer handles it
+          prevUnlockedCountRef.current = count;
+          return () => clearTimeout(timer);
         }
-        setDeepDiveText(null);
       }
     }
     prevUnlockedCountRef.current = count;
@@ -291,9 +315,10 @@ export default function ImmersiveNuggetView({
           <span className="text-[10px] uppercase tracking-[0.2em] text-white/60 mb-2 block" style={{ textShadow: "0 1px 4px rgba(0,0,0,0.8)" }}>
             {activeNugget ? (KIND_LABELS[activeNugget.kind] || activeNugget.kind) : ""}
           </span>
+          <div className="min-h-[3.5rem] mb-4">
           {activeNugget && (
             isTypewriterDone ? (
-              <h2 className="text-xl font-bold leading-tight text-white mb-4" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}>
+              <h2 className="text-xl font-bold leading-tight text-white" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}>
                 {activeNugget.headline || activeNugget.text}
               </h2>
             ) : (
@@ -303,11 +328,12 @@ export default function ImmersiveNuggetView({
                 paused={false}
                 onComplete={handleTypewriterComplete}
                 as="h2"
-                className="text-xl font-bold leading-tight text-white mb-4 block"
+                className="text-xl font-bold leading-tight text-white block"
                 style={{ textShadow: "0 2px 8px rgba(0,0,0,0.9), 0 0 20px rgba(0,0,0,0.5)" }}
               />
             )
           )}
+          </div>
           <p className="text-sm leading-relaxed text-white/60 mb-4">
             {activeNugget?.text}
           </p>

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -31,6 +31,11 @@ interface ImmersiveNuggetViewProps {
 let deepDiveSessionCount = 0;
 const MAX_DEEP_DIVES_PER_SESSION = 10;
 
+// Minimum time a nugget stays on-screen before auto-advance can swap it out.
+// Tuning knob for the streaming pacing — keeps freshly-streamed nuggets
+// readable without yanking the user mid-sentence.
+const MIN_DISPLAY_MS = 10_000;
+
 const KIND_LABELS: Record<string, string> = {
   artist: "The Artist",
   track: "The Track",
@@ -93,6 +98,11 @@ export default function ImmersiveNuggetView({
       userDismissedRef.current = false;
       initialUnlockDoneRef.current = false;
       nextUnlockTimeRef.current = 0;
+      pendingQueueRef.current = [];
+      if (advanceTimerRef.current) {
+        clearTimeout(advanceTimerRef.current);
+        advanceTimerRef.current = null;
+      }
     }
   }, [trackTitle, artist]);
 
@@ -139,42 +149,65 @@ export default function ImmersiveNuggetView({
   const nuggetShownAtRef = useRef(Date.now());
 
   // ── Auto-show new nuggets ──────────────────────────────────────────
-  // Enforces a minimum display time (10 s) so freshly-streamed nuggets
-  // don't yank the user away mid-read. If the timer hasn't elapsed the
-  // swipe dots still update — user can swipe manually.
-  const MIN_DISPLAY_MS = 10_000;
-  useEffect(() => {
-    const count = unlockedIds.size;
-    if (count > prevUnlockedCountRef.current && count > 0) {
-      const arr = nuggets.filter((n) => unlockedIds.has(n.id));
-      const idx = nuggets.indexOf(arr[arr.length - 1]);
-      if (idx >= 0) {
-        const elapsed = Date.now() - nuggetShownAtRef.current;
-        if (prevUnlockedCountRef.current === 0 || elapsed >= MIN_DISPLAY_MS) {
-          setActiveIndex(idx);
-          nuggetShownAtRef.current = Date.now();
-          if (!userDismissedRef.current) {
-            setNuggetDismissed(false);
-          }
-          setDeepDiveText(null);
-        } else {
-          const remaining = MIN_DISPLAY_MS - elapsed;
-          const timer = setTimeout(() => {
-            setActiveIndex(idx);
-            nuggetShownAtRef.current = Date.now();
-            if (!userDismissedRef.current) {
-              setNuggetDismissed(false);
-            }
-            setDeepDiveText(null);
-          }, remaining);
-          // Don't update prevUnlockedCountRef yet — the timer handles it
-          prevUnlockedCountRef.current = count;
-          return () => clearTimeout(timer);
-        }
+  // Proper queue: when multiple nuggets arrive within MIN_DISPLAY_MS, each
+  // one is shown in turn rather than the older one being silently replaced.
+  // A React effect-cleanup-based timer would cancel the pending nugget
+  // whenever unlockedIds changed again, dropping intermediate entries.
+  const pendingQueueRef = useRef<number[]>([]);
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showNugget = useCallback((idx: number) => {
+    setActiveIndex(idx);
+    nuggetShownAtRef.current = Date.now();
+    if (!userDismissedRef.current) setNuggetDismissed(false);
+    setDeepDiveText(null);
+  }, []);
+
+  const scheduleNextFromQueue = useCallback(() => {
+    if (advanceTimerRef.current) return;
+    if (pendingQueueRef.current.length === 0) return;
+    const elapsed = Date.now() - nuggetShownAtRef.current;
+    const wait = Math.max(0, MIN_DISPLAY_MS - elapsed);
+    advanceTimerRef.current = setTimeout(() => {
+      advanceTimerRef.current = null;
+      const next = pendingQueueRef.current.shift();
+      if (next !== undefined) {
+        showNugget(next);
+        scheduleNextFromQueue();
       }
+    }, wait);
+  }, [showNugget]);
+
+  useEffect(() => {
+    // Compute the ordered list of unlocked indices (stable by array position).
+    const unlockedIndices: number[] = [];
+    for (let i = 0; i < nuggets.length; i++) {
+      if (unlockedIds.has(nuggets[i].id)) unlockedIndices.push(i);
     }
-    prevUnlockedCountRef.current = count;
-  }, [unlockedIds, nuggets]);
+    const newCount = unlockedIndices.length;
+    const oldCount = prevUnlockedCountRef.current;
+    if (newCount <= oldCount) {
+      prevUnlockedCountRef.current = newCount;
+      return;
+    }
+
+    const newlyAdded = unlockedIndices.slice(oldCount);
+    prevUnlockedCountRef.current = newCount;
+
+    if (oldCount === 0) {
+      // First unlock: show the first immediately, queue the rest.
+      const [first, ...rest] = newlyAdded;
+      showNugget(first);
+      pendingQueueRef.current.push(...rest);
+    } else {
+      pendingQueueRef.current.push(...newlyAdded);
+    }
+    scheduleNextFromQueue();
+  }, [unlockedIds, nuggets, showNugget, scheduleNextFromQueue]);
+
+  useEffect(() => () => {
+    if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
+  }, []);
 
   // ── Initial unlock ─────────────────────────────────────────────────
   // Runs once when nuggets first arrive. Uses currentTimeRef to avoid

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -149,7 +149,7 @@ export default function ImmersiveNuggetView({
     setDeepDiveText(null);
   }, []);
 
-  useNuggetPacer({
+  const { cancelPending: cancelPacerQueue } = useNuggetPacer({
     nuggets,
     unlockedIds,
     trackKey,
@@ -204,11 +204,14 @@ export default function ImmersiveNuggetView({
 
   // ── Handlers ───────────────────────────────────────────────────────
   const handleSwipe = useCallback((newIndex: number) => {
+    // User took manual control — stop the pacer so a pending auto-advance
+    // (or a nugget that arrives later) can't yank them off this card.
+    cancelPacerQueue();
     setActiveIndex(newIndex);
     setNuggetDismissed(false);
     setDeepDiveText(null);
     setDeepDiveFollowUp(null);
-  }, []);
+  }, [cancelPacerQueue]);
 
   const handleTypewriterComplete = useCallback(() => {
     if (activeNugget) setTypewriterDoneIds((prev) => new Set(prev).add(activeNugget.id));

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -8,6 +8,7 @@ import MusicNerdLogo from "@/components/MusicNerdLogo";
 import TypewriterText from "./TypewriterText";
 import SwipeableNuggetStack from "./SwipeableNuggetStack";
 import MiniPlayer from "./MiniPlayer";
+import { useNuggetPacer } from "./useNuggetPacer";
 
 interface ImmersiveNuggetViewProps {
   nuggets: Nugget[];
@@ -75,17 +76,18 @@ export default function ImmersiveNuggetView({
   // Next nugget timestamp to unlock — avoids running the unlock effect on
   // every ~4 Hz playback tick (only runs when currentTime crosses this threshold).
   const nextUnlockTimeRef = useRef(0);
-  const prevUnlockedCountRef = useRef(0);
   const prevTrackKeyRef = useRef(`${trackTitle}::${artist}`);
   const currentTimeRef = useRef(currentTime);
   useEffect(() => { currentTimeRef.current = currentTime; }, [currentTime]);
   const initialUnlockDoneRef = useRef(false);
+  const trackKey = `${trackTitle}::${artist}`;
 
   // ── Reset on track change ──────────────────────────────────────────
+  // Pacer state (queue, timer, prevUnlockedCount) is reset by useNuggetPacer
+  // when trackKey changes — not duplicated here.
   useEffect(() => {
-    const key = `${trackTitle}::${artist}`;
-    if (key !== prevTrackKeyRef.current) {
-      prevTrackKeyRef.current = key;
+    if (trackKey !== prevTrackKeyRef.current) {
+      prevTrackKeyRef.current = trackKey;
       setUnlockedIds(new Set());
       setActiveIndex(0);
       setNuggetDismissed(false);
@@ -93,18 +95,12 @@ export default function ImmersiveNuggetView({
       setDeepDiveFollowUp(null);
       setDeepDiveLoading(false);
       deepDiveLoadingRef.current = false;
-      prevUnlockedCountRef.current = 0;
       setTypewriterDoneIds(new Set());
       userDismissedRef.current = false;
       initialUnlockDoneRef.current = false;
       nextUnlockTimeRef.current = 0;
-      pendingQueueRef.current = [];
-      if (advanceTimerRef.current) {
-        clearTimeout(advanceTimerRef.current);
-        advanceTimerRef.current = null;
-      }
     }
-  }, [trackTitle, artist]);
+  }, [trackKey]);
 
   // ── Unlock nuggets ─────────────────────────────────────────────────
   // Fresh SSE: unlock every streamed nugget immediately so swipes work
@@ -144,70 +140,22 @@ export default function ImmersiveNuggetView({
     nextUnlockTimeRef.current = upcoming.length > 0 ? upcoming[0].timestampSec : Infinity;
   }, [currentTime, nuggets, isFresh]);
 
-  // Track when the current nugget was first shown — used by auto-show
-  // to enforce minimum read time before auto-advancing.
-  const nuggetShownAtRef = useRef(Date.now());
-
-  // ── Auto-show new nuggets ──────────────────────────────────────────
-  // Proper queue: when multiple nuggets arrive within MIN_DISPLAY_MS, each
-  // one is shown in turn rather than the older one being silently replaced.
-  // A React effect-cleanup-based timer would cancel the pending nugget
-  // whenever unlockedIds changed again, dropping intermediate entries.
-  const pendingQueueRef = useRef<number[]>([]);
-  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
+  // ── Auto-show new nuggets (via pacer hook) ─────────────────────────
+  // See useNuggetPacer for queueing behavior. The hook calls showNugget
+  // one index at a time, with at least MIN_DISPLAY_MS between calls.
   const showNugget = useCallback((idx: number) => {
     setActiveIndex(idx);
-    nuggetShownAtRef.current = Date.now();
     if (!userDismissedRef.current) setNuggetDismissed(false);
     setDeepDiveText(null);
   }, []);
 
-  const scheduleNextFromQueue = useCallback(() => {
-    if (advanceTimerRef.current) return;
-    if (pendingQueueRef.current.length === 0) return;
-    const elapsed = Date.now() - nuggetShownAtRef.current;
-    const wait = Math.max(0, MIN_DISPLAY_MS - elapsed);
-    advanceTimerRef.current = setTimeout(() => {
-      advanceTimerRef.current = null;
-      const next = pendingQueueRef.current.shift();
-      if (next !== undefined) {
-        showNugget(next);
-        scheduleNextFromQueue();
-      }
-    }, wait);
-  }, [showNugget]);
-
-  useEffect(() => {
-    // Compute the ordered list of unlocked indices (stable by array position).
-    const unlockedIndices: number[] = [];
-    for (let i = 0; i < nuggets.length; i++) {
-      if (unlockedIds.has(nuggets[i].id)) unlockedIndices.push(i);
-    }
-    const newCount = unlockedIndices.length;
-    const oldCount = prevUnlockedCountRef.current;
-    if (newCount <= oldCount) {
-      prevUnlockedCountRef.current = newCount;
-      return;
-    }
-
-    const newlyAdded = unlockedIndices.slice(oldCount);
-    prevUnlockedCountRef.current = newCount;
-
-    if (oldCount === 0) {
-      // First unlock: show the first immediately, queue the rest.
-      const [first, ...rest] = newlyAdded;
-      showNugget(first);
-      pendingQueueRef.current.push(...rest);
-    } else {
-      pendingQueueRef.current.push(...newlyAdded);
-    }
-    scheduleNextFromQueue();
-  }, [unlockedIds, nuggets, showNugget, scheduleNextFromQueue]);
-
-  useEffect(() => () => {
-    if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
-  }, []);
+  useNuggetPacer({
+    nuggets,
+    unlockedIds,
+    trackKey,
+    onShow: showNugget,
+    minDisplayMs: MIN_DISPLAY_MS,
+  });
 
   // ── Initial unlock ─────────────────────────────────────────────────
   // Runs once when nuggets first arrive. Uses currentTimeRef to avoid

--- a/src/components/immersive/useNuggetPacer.ts
+++ b/src/components/immersive/useNuggetPacer.ts
@@ -131,7 +131,11 @@ export function useNuggetPacer<T extends NuggetIdentity>({
       pendingQueueRef.current.push(...newlyAdded);
     }
     scheduleNext();
-  }, [unlockedIds, nuggets, minDisplayMs]);
+    // minDisplayMs intentionally omitted — it's consumed via minDisplayMsRef
+    // inside scheduleNext, and a dedicated ref-sync effect keeps that ref
+    // up to date. Listing minDisplayMs here would trigger a full unlockedIds
+    // pass on every change for no behavioral gain.
+  }, [unlockedIds, nuggets]);
 
   useEffect(() => () => clearAdvanceTimer(), []);
 

--- a/src/components/immersive/useNuggetPacer.ts
+++ b/src/components/immersive/useNuggetPacer.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from "react";
+
+interface NuggetIdentity {
+  id: string;
+}
+
+interface UseNuggetPacerOptions<T extends NuggetIdentity> {
+  nuggets: T[];
+  unlockedIds: Set<string>;
+  trackKey: string;
+  onShow: (index: number) => void;
+  minDisplayMs?: number;
+}
+
+// Paces nugget reveal for the immersive view. Newly-unlocked nuggets are
+// queued and dispatched via onShow one at a time, with at least
+// minDisplayMs between dispatches, so fast-arriving streams don't yank
+// the reader mid-sentence or silently drop intermediate entries.
+//
+// The track-change reset is authoritative: when trackKey flips, the queue,
+// pending timer, and prevUnlockedCount are all cleared before the next
+// unlockedIds tick runs, so stale state from the previous track can't leak
+// in.
+export function useNuggetPacer<T extends NuggetIdentity>({
+  nuggets,
+  unlockedIds,
+  trackKey,
+  onShow,
+  minDisplayMs = 10_000,
+}: UseNuggetPacerOptions<T>) {
+  const pendingQueueRef = useRef<number[]>([]);
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nuggetShownAtRef = useRef(0);
+  const prevUnlockedCountRef = useRef(0);
+  const prevTrackKeyRef = useRef(trackKey);
+
+  // Keep onShow in a ref so the effect doesn't re-run each render as the
+  // parent recreates the callback.
+  const onShowRef = useRef(onShow);
+  useEffect(() => {
+    onShowRef.current = onShow;
+  }, [onShow]);
+
+  const clearAdvanceTimer = () => {
+    if (advanceTimerRef.current) {
+      clearTimeout(advanceTimerRef.current);
+      advanceTimerRef.current = null;
+    }
+  };
+
+  const scheduleNext = () => {
+    if (advanceTimerRef.current) return;
+    if (pendingQueueRef.current.length === 0) return;
+    const elapsed = Date.now() - nuggetShownAtRef.current;
+    const wait = Math.max(0, minDisplayMs - elapsed);
+    advanceTimerRef.current = setTimeout(() => {
+      advanceTimerRef.current = null;
+      const next = pendingQueueRef.current.shift();
+      if (next !== undefined) {
+        nuggetShownAtRef.current = Date.now();
+        onShowRef.current(next);
+        scheduleNext();
+      }
+    }, wait);
+  };
+
+  // Track change: reset before any unlockedIds effect runs for the new track.
+  useEffect(() => {
+    if (trackKey !== prevTrackKeyRef.current) {
+      prevTrackKeyRef.current = trackKey;
+      pendingQueueRef.current = [];
+      clearAdvanceTimer();
+      prevUnlockedCountRef.current = 0;
+      nuggetShownAtRef.current = 0;
+    }
+  }, [trackKey]);
+
+  useEffect(() => {
+    const unlockedIndices: number[] = [];
+    for (let i = 0; i < nuggets.length; i++) {
+      if (unlockedIds.has(nuggets[i].id)) unlockedIndices.push(i);
+    }
+    const newCount = unlockedIndices.length;
+    const oldCount = prevUnlockedCountRef.current;
+    if (newCount <= oldCount) {
+      // Defensive: if nuggets ever shrink mid-track we just sync the counter.
+      // Track-change reset is the authoritative zeroing path.
+      prevUnlockedCountRef.current = newCount;
+      return;
+    }
+
+    const newlyAdded = unlockedIndices.slice(oldCount);
+    prevUnlockedCountRef.current = newCount;
+
+    if (oldCount === 0) {
+      const [first, ...rest] = newlyAdded;
+      nuggetShownAtRef.current = Date.now();
+      onShowRef.current(first);
+      pendingQueueRef.current.push(...rest);
+    } else {
+      pendingQueueRef.current.push(...newlyAdded);
+    }
+    scheduleNext();
+  }, [unlockedIds, nuggets, minDisplayMs]);
+
+  useEffect(() => () => clearAdvanceTimer(), []);
+}

--- a/src/components/immersive/useNuggetPacer.ts
+++ b/src/components/immersive/useNuggetPacer.ts
@@ -40,11 +40,16 @@ export function useNuggetPacer<T extends NuggetIdentity>({
   const userTookOverRef = useRef(false);
 
   // Keep onShow in a ref so the effect doesn't re-run each render as the
-  // parent recreates the callback.
+  // parent recreates the callback. Same treatment for minDisplayMs so a
+  // timer scheduled on an old closure still honors the latest value.
   const onShowRef = useRef(onShow);
   useEffect(() => {
     onShowRef.current = onShow;
   }, [onShow]);
+  const minDisplayMsRef = useRef(minDisplayMs);
+  useEffect(() => {
+    minDisplayMsRef.current = minDisplayMs;
+  }, [minDisplayMs]);
 
   const clearAdvanceTimer = () => {
     if (advanceTimerRef.current) {
@@ -58,7 +63,7 @@ export function useNuggetPacer<T extends NuggetIdentity>({
     if (advanceTimerRef.current) return;
     if (pendingQueueRef.current.length === 0) return;
     const elapsed = Date.now() - nuggetShownAtRef.current;
-    const wait = Math.max(0, minDisplayMs - elapsed);
+    const wait = Math.max(0, minDisplayMsRef.current - elapsed);
     advanceTimerRef.current = setTimeout(() => {
       advanceTimerRef.current = null;
       if (userTookOverRef.current) return;

--- a/src/components/immersive/useNuggetPacer.ts
+++ b/src/components/immersive/useNuggetPacer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 interface NuggetIdentity {
   id: string;
@@ -18,9 +18,13 @@ interface UseNuggetPacerOptions<T extends NuggetIdentity> {
 // the reader mid-sentence or silently drop intermediate entries.
 //
 // The track-change reset is authoritative: when trackKey flips, the queue,
-// pending timer, and prevUnlockedCount are all cleared before the next
-// unlockedIds tick runs, so stale state from the previous track can't leak
-// in.
+// pending timer, prevUnlockedCount, and user-takeover flag are all cleared
+// before the next unlockedIds tick runs.
+//
+// cancelPending() hands control back to the user (e.g. on a manual swipe):
+// the pending queue and timer are cleared, and the pacer stops auto-advancing
+// for the rest of the track so arrivals that land after the swipe don't yank
+// the reader off the nugget they chose.
 export function useNuggetPacer<T extends NuggetIdentity>({
   nuggets,
   unlockedIds,
@@ -33,6 +37,7 @@ export function useNuggetPacer<T extends NuggetIdentity>({
   const nuggetShownAtRef = useRef(0);
   const prevUnlockedCountRef = useRef(0);
   const prevTrackKeyRef = useRef(trackKey);
+  const userTookOverRef = useRef(false);
 
   // Keep onShow in a ref so the effect doesn't re-run each render as the
   // parent recreates the callback.
@@ -49,12 +54,14 @@ export function useNuggetPacer<T extends NuggetIdentity>({
   };
 
   const scheduleNext = () => {
+    if (userTookOverRef.current) return;
     if (advanceTimerRef.current) return;
     if (pendingQueueRef.current.length === 0) return;
     const elapsed = Date.now() - nuggetShownAtRef.current;
     const wait = Math.max(0, minDisplayMs - elapsed);
     advanceTimerRef.current = setTimeout(() => {
       advanceTimerRef.current = null;
+      if (userTookOverRef.current) return;
       const next = pendingQueueRef.current.shift();
       if (next !== undefined) {
         nuggetShownAtRef.current = Date.now();
@@ -64,6 +71,18 @@ export function useNuggetPacer<T extends NuggetIdentity>({
     }, wait);
   };
 
+  // Stable reference so callers can list this in useCallback deps without
+  // causing a new identity every render. The body only reads refs, which
+  // are themselves stable, so an empty dep list is safe.
+  const cancelPending = useCallback(() => {
+    pendingQueueRef.current = [];
+    if (advanceTimerRef.current) {
+      clearTimeout(advanceTimerRef.current);
+      advanceTimerRef.current = null;
+    }
+    userTookOverRef.current = true;
+  }, []);
+
   // Track change: reset before any unlockedIds effect runs for the new track.
   useEffect(() => {
     if (trackKey !== prevTrackKeyRef.current) {
@@ -72,6 +91,7 @@ export function useNuggetPacer<T extends NuggetIdentity>({
       clearAdvanceTimer();
       prevUnlockedCountRef.current = 0;
       nuggetShownAtRef.current = 0;
+      userTookOverRef.current = false;
     }
   }, [trackKey]);
 
@@ -92,6 +112,11 @@ export function useNuggetPacer<T extends NuggetIdentity>({
     const newlyAdded = unlockedIndices.slice(oldCount);
     prevUnlockedCountRef.current = newCount;
 
+    // After a manual swipe we don't auto-advance for the rest of the track,
+    // but we still update prevUnlockedCount so a future track-change reset
+    // starts fresh.
+    if (userTookOverRef.current) return;
+
     if (oldCount === 0) {
       const [first, ...rest] = newlyAdded;
       nuggetShownAtRef.current = Date.now();
@@ -104,4 +129,6 @@ export function useNuggetPacer<T extends NuggetIdentity>({
   }, [unlockedIds, nuggets, minDisplayMs]);
 
   useEffect(() => () => clearAdvanceTimer(), []);
+
+  return { cancelPending };
 }

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -467,36 +467,46 @@ export function useAINuggets(
           for (const event of events) {
             const dataLine = event.split("\n").find((l) => l.startsWith("data: "));
             if (!dataLine) continue;
+            let payload: any;
             try {
-              const payload = JSON.parse(dataLine.slice(6));
-              if (payload.type === "nugget") {
-                aiNuggets.push(payload.nugget);
-                const n = payload.nugget as AINuggetData;
-                const { sourceId, nuggetId } = makeIds(trackId, currentListenCount, payload.index);
-                const source = makeSource(sourceId, n.source);
-                // Use provisional timestamp during streaming; recalculated after done
-                const ts = makeTimestamp(payload.index, payload.totalExpected || aiNuggets.length, durationSec);
-                const nugget = makeNugget(n, nuggetId, sourceId, trackId, ts);
+              payload = JSON.parse(dataLine.slice(6));
+            } catch (e) {
+              console.warn("[SSE] Malformed event:", dataLine, e);
+              continue;
+            }
+            if (payload.type === "nugget") {
+              aiNuggets.push(payload.nugget);
+              const n = payload.nugget as AINuggetData;
+              const { sourceId, nuggetId } = makeIds(trackId, currentListenCount, payload.index);
+              const source = makeSource(sourceId, n.source);
+              // Use provisional timestamp during streaming; recalculated after done
+              const ts = makeTimestamp(payload.index, payload.totalExpected || aiNuggets.length, durationSec);
+              const nugget = makeNugget(n, nuggetId, sourceId, trackId, ts);
 
-                setSources((prev) => new Map(prev).set(sourceId, source));
-                setNuggets((prev) => [...prev, nugget]);
-                if (import.meta.env.DEV) console.log(`[SSE] Received nugget ${payload.index}: "${n.headline?.slice(0, 40)}"`);
+              setSources((prev) => new Map(prev).set(sourceId, source));
+              setNuggets((prev) => [...prev, nugget]);
+              if (import.meta.env.DEV) console.log(`[SSE] Received nugget ${payload.index}: "${n.headline?.slice(0, 40)}"`);
 
-              } else if (payload.type === "done") {
-                aiArtistSummary = payload.artistSummary || "";
-                aiExternalLinks = payload.externalLinks || [];
-                aiNoTrackData = !!payload.noTrackData;
-                setArtistSummary(aiArtistSummary);
+            } else if (payload.type === "done") {
+              aiArtistSummary = payload.artistSummary || "";
+              aiExternalLinks = payload.externalLinks || [];
+              aiNoTrackData = !!payload.noTrackData;
+              setArtistSummary(aiArtistSummary);
 
-                // Recalculate all timestamps now that we know the true total count
-                const totalCount = aiNuggets.length;
-                setNuggets((prev) => prev.map((nugget, i) => ({
-                  ...nugget,
-                  timestampSec: makeTimestamp(i, totalCount, durationSec),
-                })));
-                if (import.meta.env.DEV) console.log(`[SSE] All ${totalCount} nuggets received — timestamps recalculated`);
-              }
-            } catch (e) { console.warn("[SSE] Malformed event:", dataLine, e); }
+              // Recalculate all timestamps now that we know the true total count
+              const totalCount = aiNuggets.length;
+              setNuggets((prev) => prev.map((nugget, i) => ({
+                ...nugget,
+                timestampSec: makeTimestamp(i, totalCount, durationSec),
+              })));
+              if (import.meta.env.DEV) console.log(`[SSE] All ${totalCount} nuggets received — timestamps recalculated`);
+
+            } else if (payload.type === "error") {
+              // Server signals all Writer attempts failed — propagate so we
+              // hit the catch block without touching the success path
+              // (cache writes, history updates).
+              throw new Error(payload.message || "SSE server reported error");
+            }
           }
         }
 
@@ -504,12 +514,12 @@ export function useAINuggets(
         // Write to cache + history, then return
         if (cancelledRef.current) return;
 
-        // Defensive: if all server-side Gemini retries failed, the stream
-        // closes with zero nuggets. Treat that as an error so the catch
-        // block clears the "generating" sentinel and the next listen retries,
-        // rather than caching an empty result and starving future listeners.
+        // Defensive: the server should have sent an explicit "error" event
+        // when no nuggets were generated. This guard catches any lingering
+        // paths (e.g. stream closed without a terminal event) and prevents
+        // caching an empty result.
         if (aiNuggets.length === 0) {
-          throw new Error("SSE stream returned no nuggets");
+          throw new Error("SSE stream closed with no nuggets");
         }
 
         // Enrich SSE nuggets with Spotify fallback images (server resolves

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -504,6 +504,14 @@ export function useAINuggets(
         // Write to cache + history, then return
         if (cancelledRef.current) return;
 
+        // Defensive: if all server-side Gemini retries failed, the stream
+        // closes with zero nuggets. Treat that as an error so the catch
+        // block clears the "generating" sentinel and the next listen retries,
+        // rather than caching an empty result and starving future listeners.
+        if (aiNuggets.length === 0) {
+          throw new Error("SSE stream returned no nuggets");
+        }
+
         // Enrich SSE nuggets with Spotify fallback images (server resolves
         // Wikipedia/Exa but may miss lesser-known artists — same logic as
         // the JSON path's image-assignment block).

--- a/src/test/useNuggetPacer.test.ts
+++ b/src/test/useNuggetPacer.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNuggetPacer } from "@/components/immersive/useNuggetPacer";
+
+const mkNugget = (id: string) => ({ id });
+
+describe("useNuggetPacer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the first unlocked nugget immediately", () => {
+    const onShow = vi.fn();
+    const nuggets = [mkNugget("a"), mkNugget("b"), mkNugget("c")];
+
+    renderHook(({ unlockedIds }) =>
+      useNuggetPacer({
+        nuggets,
+        unlockedIds,
+        trackKey: "t1",
+        onShow,
+        minDisplayMs: 10_000,
+      }),
+      { initialProps: { unlockedIds: new Set(["a"]) } }
+    );
+
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onShow).toHaveBeenCalledWith(0);
+  });
+
+  it("queues subsequent nuggets and dispatches them spaced by minDisplayMs", () => {
+    const onShow = vi.fn();
+    const nuggets = [mkNugget("a"), mkNugget("b"), mkNugget("c")];
+
+    const { rerender } = renderHook(
+      ({ unlockedIds }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey: "t1",
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      { initialProps: { unlockedIds: new Set<string>(["a"]) } }
+    );
+
+    // First nugget shown immediately.
+    expect(onShow).toHaveBeenLastCalledWith(0);
+    expect(onShow).toHaveBeenCalledTimes(1);
+
+    // Second and third arrive before the min display window — both should be
+    // queued (neither immediately replaces "a").
+    act(() => {
+      rerender({ unlockedIds: new Set(["a", "b"]) });
+    });
+    act(() => {
+      rerender({ unlockedIds: new Set(["a", "b", "c"]) });
+    });
+    expect(onShow).toHaveBeenCalledTimes(1);
+
+    // After 10s, nugget "b" (index 1) dispatches.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onShow).toHaveBeenCalledTimes(2);
+    expect(onShow).toHaveBeenLastCalledWith(1);
+
+    // Another 10s later, nugget "c" (index 2) dispatches — no drop.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onShow).toHaveBeenCalledTimes(3);
+    expect(onShow).toHaveBeenLastCalledWith(2);
+  });
+
+  it("dispatches every nugget in order even when they arrive faster than minDisplayMs", () => {
+    const onShow = vi.fn();
+    const nuggets = [mkNugget("a"), mkNugget("b"), mkNugget("c")];
+
+    const { rerender } = renderHook(
+      ({ unlockedIds }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey: "t1",
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      { initialProps: { unlockedIds: new Set<string>(["a"]) } }
+    );
+
+    // 3s later, "b" arrives.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+      rerender({ unlockedIds: new Set(["a", "b"]) });
+    });
+    // 3s later (6s total since "a"), "c" arrives.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+      rerender({ unlockedIds: new Set(["a", "b", "c"]) });
+    });
+
+    expect(onShow.mock.calls.map((c) => c[0])).toEqual([0]);
+
+    // At t=10s since "a", "b" should dispatch.
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(onShow.mock.calls.map((c) => c[0])).toEqual([0, 1]);
+
+    // At t=10s since "b", "c" should dispatch.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onShow.mock.calls.map((c) => c[0])).toEqual([0, 1, 2]);
+  });
+
+  it("advances immediately when a new nugget arrives after the min display window", () => {
+    const onShow = vi.fn();
+    const nuggets = [mkNugget("a"), mkNugget("b")];
+
+    const { rerender } = renderHook(
+      ({ unlockedIds }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey: "t1",
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      { initialProps: { unlockedIds: new Set<string>(["a"]) } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(12_000);
+      rerender({ unlockedIds: new Set(["a", "b"]) });
+    });
+    // Scheduler sets wait = max(0, minDisplay - elapsed) = 0, so the timer
+    // fires on the next tick rather than synchronously. Flush it.
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(onShow.mock.calls.map((c) => c[0])).toEqual([0, 1]);
+  });
+
+  it("clears the queue and resets state on track change", () => {
+    const onShow = vi.fn();
+    const nuggetsT1 = [mkNugget("a"), mkNugget("b"), mkNugget("c")];
+    const nuggetsT2 = [mkNugget("x"), mkNugget("y")];
+
+    const { rerender } = renderHook(
+      ({ unlockedIds, trackKey, nuggets }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey,
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      {
+        initialProps: {
+          unlockedIds: new Set<string>(["a", "b"]),
+          trackKey: "t1",
+          nuggets: nuggetsT1,
+        },
+      }
+    );
+    // First call shows index 0 immediately; index 1 is queued.
+    expect(onShow.mock.calls.map((c) => c[0])).toEqual([0]);
+    onShow.mockClear();
+
+    // Switch track. The queued dispatch for nugget "b" must not leak.
+    act(() => {
+      rerender({
+        unlockedIds: new Set<string>([]),
+        trackKey: "t2",
+        nuggets: nuggetsT2,
+      });
+    });
+    // Advance past the old scheduled wait — should NOT fire the stale "b".
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onShow).not.toHaveBeenCalled();
+
+    // New track's first nugget unlocks and shows immediately.
+    act(() => {
+      rerender({
+        unlockedIds: new Set(["x"]),
+        trackKey: "t2",
+        nuggets: nuggetsT2,
+      });
+    });
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onShow).toHaveBeenCalledWith(0);
+  });
+
+  it("cleans up the pending timer on unmount", () => {
+    const onShow = vi.fn();
+    const nuggets = [mkNugget("a"), mkNugget("b")];
+
+    const { rerender, unmount } = renderHook(
+      ({ unlockedIds }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey: "t1",
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      { initialProps: { unlockedIds: new Set<string>(["a"]) } }
+    );
+    act(() => {
+      rerender({ unlockedIds: new Set(["a", "b"]) });
+    });
+    onShow.mockClear();
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent on unlockedIds re-renders that don't grow the set", () => {
+    const onShow = vi.fn();
+    const nuggets = [mkNugget("a"), mkNugget("b")];
+
+    const { rerender } = renderHook(
+      ({ unlockedIds }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey: "t1",
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      { initialProps: { unlockedIds: new Set<string>(["a"]) } }
+    );
+    expect(onShow).toHaveBeenCalledTimes(1);
+
+    // Re-render with a new Set instance that has the same contents — should
+    // not re-dispatch.
+    act(() => {
+      rerender({ unlockedIds: new Set(["a"]) });
+    });
+    expect(onShow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/useNuggetPacer.test.ts
+++ b/src/test/useNuggetPacer.test.ts
@@ -294,6 +294,7 @@ describe("useNuggetPacer", () => {
 
     // Switch track and add nuggets — pacer should resume normally for the
     // new track even though the previous track was paused.
+    onShow.mockClear();
     act(() => {
       rerender({
         unlockedIds: new Set(["x"]),
@@ -301,7 +302,8 @@ describe("useNuggetPacer", () => {
         nuggets: nuggetsT2,
       });
     });
-    expect(onShow.mock.calls.filter(([i]) => i === 0).length).toBeGreaterThanOrEqual(1);
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onShow).toHaveBeenCalledWith(0);
 
     onShow.mockClear();
     act(() => {

--- a/src/test/useNuggetPacer.test.ts
+++ b/src/test/useNuggetPacer.test.ts
@@ -226,6 +226,97 @@ describe("useNuggetPacer", () => {
     expect(onShow).not.toHaveBeenCalled();
   });
 
+  it("cancelPending drops queued nuggets and stops auto-advance for the rest of the track", () => {
+    const onShow = vi.fn();
+    const nuggets = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+    const { result, rerender } = renderHook(
+      ({ unlockedIds }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey: "t1",
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      { initialProps: { unlockedIds: new Set<string>(["a", "b"]) } }
+    );
+    // Index 0 shown immediately, index 1 queued.
+    expect(onShow.mock.calls.map((c) => c[0])).toEqual([0]);
+
+    // User swipes — cancel the queue.
+    act(() => {
+      result.current.cancelPending();
+    });
+
+    // Pending advance to "b" should never fire.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onShow).toHaveBeenCalledTimes(1);
+
+    // Nugget "c" arrives — pacer should NOT auto-advance now that the user
+    // has taken over.
+    act(() => {
+      rerender({ unlockedIds: new Set(["a", "b", "c"]) });
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onShow).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelPending's takeover resets on track change", () => {
+    const onShow = vi.fn();
+    const nuggetsT1 = [{ id: "a" }, { id: "b" }];
+    const nuggetsT2 = [{ id: "x" }, { id: "y" }];
+
+    const { result, rerender } = renderHook(
+      ({ unlockedIds, trackKey, nuggets }) =>
+        useNuggetPacer({
+          nuggets,
+          unlockedIds,
+          trackKey,
+          onShow,
+          minDisplayMs: 10_000,
+        }),
+      {
+        initialProps: {
+          unlockedIds: new Set<string>(["a"]),
+          trackKey: "t1",
+          nuggets: nuggetsT1,
+        },
+      }
+    );
+    act(() => {
+      result.current.cancelPending();
+    });
+
+    // Switch track and add nuggets — pacer should resume normally for the
+    // new track even though the previous track was paused.
+    act(() => {
+      rerender({
+        unlockedIds: new Set(["x"]),
+        trackKey: "t2",
+        nuggets: nuggetsT2,
+      });
+    });
+    expect(onShow.mock.calls.filter(([i]) => i === 0).length).toBeGreaterThanOrEqual(1);
+
+    onShow.mockClear();
+    act(() => {
+      rerender({
+        unlockedIds: new Set(["x", "y"]),
+        trackKey: "t2",
+        nuggets: nuggetsT2,
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onShow).toHaveBeenCalledWith(1);
+  });
+
   it("is idempotent on unlockedIds re-renders that don't grow the set", () => {
     const onShow = vi.fn();
     const nuggets = [mkNugget("a"), mkNugget("b")];

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -513,10 +513,51 @@ function isActualImageUrl(url: string): boolean {
   }
 }
 
-// Exa citations are bucketed by nugget: each nugget owns a contiguous
-// window of citIndex values. Keep in sync with the citation-builder.
+// Each nugget owns a contiguous window of Exa citIndex values. Search
+// call sites must derive their citIndexStart from CITATION_GROUP below —
+// not from the literal 10 — so the grouping stays consistent with
+// resolveExaImageForNugget.
 const CITATION_GROUP_SIZE = 10;
+// Number of nuggets streamed per SSE response (artist, track|context, discovery).
 const NUGGET_COUNT = 3;
+const CITATION_GROUP = {
+  ARTIST: 0,
+  TRACK: CITATION_GROUP_SIZE,
+  DISCOVERY: CITATION_GROUP_SIZE * 2,
+} as const;
+
+// Canonical voice + non-negotiable writing rules. Shared by all three Writer
+// prompts (batch-curated, batch-direct, SSE per-nugget). Having one source
+// of truth for the voice/rules prevents silent drift between the paths —
+// previously a tone change would need to be mirrored manually in three
+// places and often wasn't.
+//
+// Path-specific extras (e.g. "Prefer birthplace" for the direct path, where
+// no curated origin is available) are appended as rules 9+ via the `extras`
+// argument.
+function buildWriterNonNegotiables(artist: string, extras: string[] = []): string {
+  const extraBlock = extras.length
+    ? "\n" + extras.map((e, i) => `${9 + i}. ${e}`).join("\n")
+    : "";
+  return `WRITING RULES — NON-NEGOTIABLE:
+1. The listener can HEAR the music. Tell them what they CAN'T know from listening — stories, history, people, places, creative context.
+2. Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.
+3. VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.
+4. If uncertain about a fact, OMIT IT. One confident true sentence beats three hedged guesses.
+5. Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading your headline, you failed.
+   SAME FACT, TWO WAYS:
+   - SUMMARY (bad): "A scrapped Gucci Mane beat became 'HUMBLE.'" → gives away the whole story, nothing left to read
+   - CURIOSITY (good): "HUMBLE. was never meant for Kendrick" → wait, whose beat was it? I need to read more
+   MORE GOOD: "the bedroom demo that almost got deleted" / "they only met because of a wrong phone number" / "a scrapped beat turned ${artist}'s biggest hit into an accident"
+   MORE BAD: "He recorded his first EP in a closet at 16" / "Aaron Doh's Early Digital Footprint Takes Shape" / "The Creative Evolution Behind the Music" / "this artist's creative path"
+   The test: does the headline make you ask "wait, what?" or "tell me more"? If it just states a fact, rewrite it.
+   Use "${artist}" by name in headlines — never say "this artist" or "he"/"she" without naming them.
+   NEVER use title case. NEVER use "[Name]'s [Abstract Noun]".
+6. NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
+   SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.
+7. Do NOT recommend artists who share ANY part of ${artist}'s name.
+8. Do NOT use fabricated publisher names. Use the artist's real website, Bandcamp, Spotify, or a real music publication.${extraBlock}`;
+}
 
 // Picks an unused Exa citation image for a nugget, preferring the nugget's
 // own citation group and falling back to any unused image. Mutates the
@@ -1821,24 +1862,7 @@ ${tasteContext}
 VOICE: ${tierConfig.tone}
 ${tierConfig.assumedKnowledge}
 
-WRITING RULES — NON-NEGOTIABLE:
-1. The listener can HEAR the music. Tell them what they CAN'T know from listening — stories, history, people, places, creative context.
-2. Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.
-3. VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.
-4. If uncertain about a fact, OMIT IT. One confident true sentence beats three hedged guesses.
-5. Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading your headline, you failed.
-   SAME FACT, TWO WAYS:
-   - SUMMARY (bad): "A scrapped Gucci Mane beat became 'HUMBLE.'" → gives away the whole story, nothing left to read
-   - CURIOSITY (good): "HUMBLE. was never meant for Kendrick" → wait, whose beat was it? I need to read more
-   MORE GOOD: "the bedroom demo that almost got deleted" / "they only met because of a wrong phone number" / "a scrapped beat turned ${artist}'s biggest hit into an accident"
-   MORE BAD: "He recorded his first EP in a closet at 16" / "Aaron Doh's Early Digital Footprint Takes Shape" / "The Creative Evolution Behind the Music" / "this artist's creative path"
-   The test: does the headline make you ask "wait, what?" or "tell me more"? If it just states a fact, rewrite it.
-   Use "${artist}" by name in headlines — never say "this artist" or "he"/"she" without naming them.
-   NEVER use title case. NEVER use "[Name]'s [Abstract Noun]".
-6. NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
-   SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.
-7. Do NOT recommend artists who share ANY part of ${artist}'s name.
-8. Do NOT use fabricated publisher names like "General Knowledge" or "Music Analysis". Use the artist's real website, Bandcamp, Spotify, or a real music publication.
+${buildWriterNonNegotiables(artist)}
 
 STRUCTURE — exactly 3 nuggets:
 1. **artist** (kind: "artist"): ${applyCollabBias
@@ -1907,19 +1931,10 @@ ${transcriptContext ? `YOUTUBE TRANSCRIPTS:\n${videoListContext}\n${transcriptCo
 VOICE: ${tierConfig.tone}
 ${tierConfig.assumedKnowledge}
 
-WRITING RULES — NON-NEGOTIABLE:
-1. Tell stories, not descriptions. Never describe what the music sounds like.
-2. Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.
-3. VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.
-4. If uncertain, OMIT IT rather than hedging.
-5. Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading the headline, you failed.
-   Use "${artist}" by name in headlines — never say "this artist" or "he"/"she" without naming them.
-   NEVER use title case. NEVER use "[Name]'s [Abstract Noun]". Never summarize — tease.
-6. NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
-   SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.
-7. NEVER fabricate collaborations with famous people unless verifiable.
-8. Prefer birthplace over current city as the artist's origin.
-9. Do NOT recommend artists sharing ANY part of ${artist}'s name.
+${buildWriterNonNegotiables(artist, [
+  "NEVER fabricate collaborations with famous people unless verifiable.",
+  "Prefer birthplace over current city as the artist's origin.",
+])}
 
 STRUCTURE — exactly 3 nuggets:
 1. **artist** (kind: "artist"): ${applyCollabBias
@@ -2349,7 +2364,7 @@ Return ONLY valid JSON:
 
       // ── Phase 1: Scout — artist search + Spotify in parallel ──────
       console.time("[Timing] Exa Phase 1"); _ts("exaPhase1");
-      const artistSearchPromise = searchExaPages(questions.artistQ, "artist", EXA_API_KEY, 0, [artist]);
+      const artistSearchPromise = searchExaPages(questions.artistQ, "artist", EXA_API_KEY, CITATION_GROUP.ARTIST, [artist]);
 
       const [artistSearchResult, phase1SpotifyInfo] = await Promise.all([
         artistSearchPromise,
@@ -2380,7 +2395,7 @@ Return ONLY valid JSON:
 
         if (!mentionsAlbum && !mentionsTitle && !mentionsKnown) {
           console.log(`[Exa] Name collision detected — Phase 1 results don't mention album "${album}" or any known tracks. Retrying with album filter.`);
-          artistAnswer = await searchExaPages(questions.artistQ, "artist", EXA_API_KEY, 0, [artist, album]);
+          artistAnswer = await searchExaPages(questions.artistQ, "artist", EXA_API_KEY, CITATION_GROUP.ARTIST, [artist, album]);
           nameCollisionDetected = true;
         }
       }
@@ -2404,8 +2419,8 @@ Return ONLY valid JSON:
         // STANDARD: well-known artist — run track + discovery searches in parallel
         console.log(`[Exa] Strategy: STANDARD (${followers.toLocaleString()} followers > 20K)`);
         const [trackResult, discoveryResult] = await Promise.allSettled([
-          searchExaPages(questions.trackQ, "track", EXA_API_KEY, 10, [artist]),
-          searchExaPages(questions.discoveryQ, "discovery", EXA_API_KEY, 20),
+          searchExaPages(questions.trackQ, "track", EXA_API_KEY, CITATION_GROUP.TRACK, [artist]),
+          searchExaPages(questions.discoveryQ, "discovery", EXA_API_KEY, CITATION_GROUP.DISCOVERY),
         ]);
         for (const r of [trackResult, discoveryResult]) {
           if (r.status === "fulfilled" && r.value.answer) {
@@ -2416,7 +2431,7 @@ Return ONLY valid JSON:
       } else if (artistStrictCount >= 2 && trackMentioned) {
         // SEMI-STANDARD: artist has coverage and track is mentioned — track search may find more
         console.log(`[Exa] Strategy: SEMI-STANDARD (${artistStrictCount} strict cites, track "${title}" mentioned in artist results)`);
-        const trackResult = await searchExaPages(questions.trackQ, "track", EXA_API_KEY, 10, [artist]);
+        const trackResult = await searchExaPages(questions.trackQ, "track", EXA_API_KEY, CITATION_GROUP.TRACK, [artist]);
         if (trackResult.answer) {
           answers.push(trackResult);
           totalCost += trackResult.costDollars;
@@ -2428,9 +2443,9 @@ Return ONLY valid JSON:
         console.log(`[Exa] Strategy: ARTIST-HEAVY (${artistStrictCount} strict cites, track "${title}" NOT mentioned)`);
         const broadQuery = buildBroadArtistQuery(artist);
         const broadInclude = nameCollisionDetected && album ? [artist, album] : [artist];
-        // Use citIndex 10-19 (track range) so image grouping treats this as "track" group
-        // More results (8) to maximize coverage for mid-tier artists
-        const broadResult = await searchExaPages(broadQuery, "artist-broad", EXA_API_KEY, 10, broadInclude, undefined, { numResults: 8 });
+        // Use the TRACK citIndex range so image grouping treats this as the track group.
+        // More results (8) to maximize coverage for mid-tier artists.
+        const broadResult = await searchExaPages(broadQuery, "artist-broad", EXA_API_KEY, CITATION_GROUP.TRACK, broadInclude, undefined, { numResults: 8 });
         if (broadResult.answer) {
           answers.push(broadResult);
           totalCost += broadResult.costDollars;
@@ -2448,8 +2463,8 @@ Return ONLY valid JSON:
         const keywordQuery = `"${artist}" musician OR artist OR producer OR rapper OR singer`;
 
         const [broadSettled, keywordSettled] = await Promise.allSettled([
-          searchExaPages(broadQuery, "artist-broad", EXA_API_KEY, 10, sparseInclude, undefined, { numResults: 8 }),
-          searchExaPages(keywordQuery, "artist-keyword", EXA_API_KEY, 20, undefined, undefined, { numResults: 5, searchType: "keyword" }),
+          searchExaPages(broadQuery, "artist-broad", EXA_API_KEY, CITATION_GROUP.TRACK, sparseInclude, undefined, { numResults: 8 }),
+          searchExaPages(keywordQuery, "artist-keyword", EXA_API_KEY, CITATION_GROUP.DISCOVERY, undefined, undefined, { numResults: 5, searchType: "keyword" }),
         ]);
 
         // Strategy A: Broader auto search with more results (catches interview/profile pages)
@@ -2983,16 +2998,9 @@ ${researchSection}
 VOICE: ${tierConfig.tone}
 ${tierConfig.assumedKnowledge}
 
-WRITING RULES — NON-NEGOTIABLE:
-1. Tell stories, not descriptions. Never describe what the music sounds like — the listener can hear it.
-2. Dig like Nardwuar — find the specific detail nobody else would.
-3. VOICE GUARD: Never hedge ("likely", "suggests", "perhaps"). State facts or skip them.
-4. If uncertain, OMIT IT rather than hedging.
-5. Headlines must CREATE A CURIOSITY GAP — tease the story, don't summarize it. Use "${artist}" by name. NEVER use title case.
-6. NO VAGUE FILLER. If a sentence could apply to any artist, it's worthless. Every sentence must be specific to ${artist}.
-   SWAP TEST: if you can replace "${artist}" with any other artist and the sentence still works, DELETE IT.
-7. Do NOT use fabricated publisher names. Use the artist's real website, Bandcamp, Spotify, or a real music publication.
-8. SOURCES: Match facts to [CIT N] citations via "citIndex". Do not invent URLs.
+${buildWriterNonNegotiables(artist)}
+
+SOURCES: Match facts to [CIT N] citations via "citIndex". Do not invent URLs.
 ${nonRepeat}
 
 TASK: Generate exactly ONE "${def.kind}" nugget.
@@ -3041,8 +3049,14 @@ Return ONLY valid JSON:
                     });
                     if (!res.ok) {
                       if (res.status === 429 && attempt < 2) {
-                        console.log(`[SSE] 429 for ${def.kind}, retrying in 2s...`);
-                        await new Promise((resolve) => setTimeout(resolve, 2000));
+                        // Prefer server-provided Retry-After; otherwise exponential backoff (2s, 4s).
+                        const retryAfterHeader = res.headers.get("retry-after");
+                        const retryAfterSec = retryAfterHeader ? parseFloat(retryAfterHeader) : NaN;
+                        const delayMs = Number.isFinite(retryAfterSec) && retryAfterSec > 0
+                          ? Math.min(retryAfterSec * 1000, 10_000)
+                          : 2000 * Math.pow(2, attempt);
+                        console.log(`[SSE] 429 for ${def.kind}, retrying in ${Math.round(delayMs)}ms (attempt ${attempt + 1}/3)`);
+                        await new Promise((resolve) => setTimeout(resolve, delayMs));
                         continue;
                       }
                       throw new Error(`Gemini returned ${res.status} for ${def.kind}`);
@@ -3050,7 +3064,10 @@ Return ONLY valid JSON:
                     const data = await res.json();
                     const text = data.candidates?.[0]?.content?.parts?.[0]?.text || "";
                     if (!text.trim()) {
-                      if (attempt < 2) { await new Promise((resolve) => setTimeout(resolve, 1000)); continue; }
+                      if (attempt < 2) {
+                        await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt)));
+                        continue;
+                      }
                       throw new Error(`Empty Gemini response for ${def.kind}`);
                     }
                     const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
@@ -3117,9 +3134,10 @@ Return ONLY valid JSON:
               }
 
               // ── Done ──
+              // Copy stream-local state back to the outer variables so the
+              // post-IIFE path (cache writes, metrics) sees the same values
+              // the SSE client received.
               artistSummary = sseArtistSummary;
-              // Match batch path: sparse/missing track facts + skipped track search
-              // signal "no track data" so the client can adjust downstream UI.
               noTrackData = !curatedFacts?.trackFacts?.length && trackSearchSkipped;
               rawNuggets = streamedNuggets;
               const doneEvent = `data: ${JSON.stringify({ type: "done", artistSummary: sseArtistSummary, externalLinks: buildExternalLinks(), noTrackData })}\n\n`;
@@ -3179,7 +3197,7 @@ Return ONLY valid JSON:
         rawNuggets[i]._resolvedImageUrl = result.value.url;
         rawNuggets[i]._resolvedImageTitle = result.value.title;
         usedImageUrls.add(result.value.url);
-        console.log(`[Image] Wikipedia fallback for nugget ${i}: ${result.value.url}`);
+        console.log(`[Image] Wikipedia fallback for nugget ${i} ("${rawNuggets[i].imageSearchQuery}"): ${result.value.url}`);
       } else if (!rawNuggets[i]._resolvedImageUrl) {
         console.log(`[Image] No image for nugget ${i} — frontend will use album art`);
       }

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -552,7 +552,7 @@ const WRITER_BASE_RULES = [
   (artist: string) => `NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
    SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.`,
   (artist: string) => `Do NOT recommend artists who share ANY part of ${artist}'s name.`,
-  (_artist: string) => `Do NOT use fabricated publisher names. Use the artist's real website, Bandcamp, Spotify, or a real music publication.`,
+  (_artist: string) => `Do NOT use fabricated publisher names like "General Knowledge" or "Music Analysis". Use the artist's real website, Bandcamp, Spotify, or a real music publication.`,
 ];
 
 function buildWriterNonNegotiables(artist: string, extras: string[] = []): string {
@@ -3125,7 +3125,11 @@ Return ONLY valid JSON:
                 }
 
                 // ── Assemble + validate ──
-                const assembled = assembleNugget(nuggetData, nuggetIndex);
+                // streamedIndex matches the `index` field of the SSE event below,
+                // keeping emitted IDs contiguous even when earlier defs were
+                // skipped. (assembleNugget doesn't read the index today, but any
+                // reader of the emitted nugget should see a coherent position.)
+                const assembled = assembleNugget(nuggetData, streamedIndex);
                 const sourceType = (assembled.source?.type || "").toLowerCase();
                 const publisher = (assembled.source?.publisher || "").toLowerCase();
                 if (

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -2625,7 +2625,13 @@ Return ONLY valid JSON:
     }
     console.timeEnd("[Timing] Gemini (Curator + Writer)"); _te("gemini");
     } else {
-      // SSE path: rawNuggets populated inside the streaming IIFE below
+      // SSE path: rawNuggets populated inside the streaming IIFE below.
+      // groundingChunks stays empty on this path — the per-nugget Writer
+      // calls happen inside the IIFE and the resulting grounding metadata
+      // isn't aggregated here. assembleNugget's realChunks fallback
+      // therefore only resolves against Exa citations on SSE requests;
+      // the Google-search grounding fallback is batch-only. If this
+      // becomes load-bearing, thread chunks out of the IIFE.
       rawNuggets = [];
       groundingChunks = [];
     }
@@ -3042,7 +3048,7 @@ Return ONLY valid JSON:
       "type": "youtube|article|interview",
       "title": "Source title",
       "publisher": "Real publisher name",
-      "citIndex": 0,
+      "citIndex": "<integer — the [CIT N] index of the research item backing this nugget>",
       "quoteSnippet": "Key quote or paraphrase"
     }
   }
@@ -3164,6 +3170,21 @@ Return ONLY valid JSON:
               artistSummary = sseArtistSummary;
               noTrackData = !curatedFacts?.trackFacts?.length && trackSearchSkipped;
               rawNuggets = streamedNuggets;
+
+              // If every Writer call failed, emit an explicit error event
+              // instead of done(nuggets=[]) — saves the client from briefly
+              // entering the "success but empty" path before noticing the
+              // zero-nugget guard, which caused a visible flicker.
+              if (streamedNuggets.length === 0) {
+                const errorEvent = `data: ${JSON.stringify({ type: "error", message: "No nuggets generated — all Writer attempts failed" })}\n\n`;
+                try {
+                  streamController.enqueue(encoder.encode(errorEvent));
+                  streamController.close();
+                } catch { /* stream closed */ }
+                console.warn("[SSE] All Writer calls failed — emitted error event");
+                return;
+              }
+
               const doneEvent = `data: ${JSON.stringify({ type: "done", artistSummary: sseArtistSummary, externalLinks: buildExternalLinks(), noTrackData })}\n\n`;
               try {
                 streamController.enqueue(encoder.encode(doneEvent));

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -2531,10 +2531,18 @@ Return ONLY valid JSON:
     if (isSparseData) {
       console.log(`[SparseData] Only ${exaCitationsStrict.length} strict citations — enabling conservative mode`);
     }
+
+    // Check SSE early — if the client wants SSE, we skip the batch Writer and
+    // generate nuggets one-at-a-time inside the streaming response instead.
+    const wantsSSE = (req.headers.get("accept") || "").includes("text/event-stream");
+
     let rawNuggets: any[];
     let groundingChunks: any[];
     let artistSummary = "";
     let noTrackData = false;
+
+    if (!wantsSSE) {
+    // ── Batch path (non-SSE JSON response) — unchanged ──────────────
     console.time("[Timing] Gemini (Curator + Writer)"); _ts("gemini");
     try {
       const _tracker = { ts: _ts, te: _te };
@@ -2564,6 +2572,11 @@ Return ONLY valid JSON:
       }
     }
     console.timeEnd("[Timing] Gemini (Curator + Writer)"); _te("gemini");
+    } else {
+      // SSE path: rawNuggets populated inside the streaming IIFE below
+      rawNuggets = [];
+      groundingChunks = [];
+    }
     checkTimeout();
 
     console.log(`[Grounding] ${groundingChunks.length} chunks for "${artist} - ${title}":`,
@@ -2864,11 +2877,10 @@ Return ONLY valid JSON:
       return links;
     }
 
-    // ── Check if client wants SSE streaming ──────────────────────────────
-    const wantsSSE = (req.headers.get("accept") || "").includes("text/event-stream");
-
+    // ── SSE: progressive per-nugget generation + streaming ─────────────
+    // wantsSSE was checked earlier — batch Writer was skipped.
     if (wantsSSE) {
-      console.log("[SSE] Streaming nuggets as they resolve");
+      console.log("[SSE] Progressive streaming — generating nuggets one at a time");
       const encoder = new TextEncoder();
       let streamController: ReadableStreamDefaultController<Uint8Array>;
 
@@ -2876,87 +2888,224 @@ Return ONLY valid JSON:
         start(controller) {
           streamController = controller;
 
-          // start() is synchronous per spec — wrap async work in an IIFE
-          // so awaits actually execute (Deno silently discards async start).
           (async () => {
             try {
-              // Pipeline: resolve image → assemble → validate → stream.
-              // Wikipedia lookups fire in parallel so late nuggets don't wait
-              // behind early ones; dedup + assemble + stream still happen
-              // sequentially to keep usedImageUrls correct and preserve order.
-              const imageLookups = rawNuggets.map((n) =>
-                !n._resolvedImageUrl && isValidImageQuery(n.imageSearchQuery)
-                  ? resolveNuggetImage(n.imageSearchQuery!).catch(() => null)
-                  : null
-              );
+              // ── Step 1: Run Curator (same as batch path) ──
+              _ts("curator");
+              let curatedFacts: any = null;
+              if (exaPromptContext) {
+                try {
+                  curatedFacts = await curateResearch(artist, title, album, exaPromptContext, "", GOOGLE_AI_API_KEY, resolvedSpotifyInfo);
+                } catch (e) {
+                  console.warn("[SSE] Curator failed, proceeding with direct path:", e);
+                }
+              }
+              _te("curator");
+
+              // ── Step 2: Build shared research context ──
+              const tierConfig = TIER_CONFIG[tier];
+              const researchBlock = curatedFacts ? [
+                `ARTIST ORIGIN: ${curatedFacts.artistOrigin}`,
+                curatedFacts.artistBio ? `BIO: ${curatedFacts.artistBio}` : "",
+                curatedFacts.artistFacts.length > 0
+                  ? `\nVERIFIED ARTIST FACTS:\n${curatedFacts.artistFacts.map((f: string) => `- ${f}`).join("\n")}`
+                  : "",
+                curatedFacts.trackFacts.length > 0
+                  ? `\nVERIFIED TRACK FACTS ("${title}"):\n${curatedFacts.trackFacts.map((f: string) => `- ${f}`).join("\n")}`
+                  : `\nNo verified facts exist specifically about "${title}".`,
+                curatedFacts.keyCollaborators.length > 0
+                  ? `\nCOLLABORATORS:\n${curatedFacts.keyCollaborators.map((c: string) => `- ${c}`).join("\n")}`
+                  : "",
+              ].filter(Boolean).join("\n") : "";
+
+              const researchSection = researchBlock
+                ? `RESEARCH BRIEF (verified):\n${researchBlock}`
+                : (exaPromptContext ? `RESEARCH MATERIAL (cite by [CIT N] index):\n${exaPromptContext}` : "");
+
+              const prevHeadlines = [...safePreviousNuggets];
+              const generatedHeadlines: string[] = [];
+
+              // ── Step 3: Define the 3 nugget kinds ──
+              const nuggetDefs = [
+                { kind: "artist", focus: tierConfig.artistFocus, listenFor: false, includeArtistSummary: true },
+                { kind: "track", focus: tierConfig.trackFocus, listenFor: true, includeArtistSummary: false },
+                { kind: "discovery", focus: tierConfig.discoveryFocus, listenFor: false, includeArtistSummary: false },
+              ];
 
               let streamedIndex = 0;
-              const streamedNuggets: any[] = []; // for cache write consistency
+              const streamedNuggets: any[] = [];
+              let sseArtistSummary = "";
 
-              for (let i = 0; i < rawNuggets.length; i++) {
-                const n = rawNuggets[i];
+              // ── Step 4: Generate + stream each nugget ──
+              for (const def of nuggetDefs) {
+                _ts(`writer_${def.kind}`);
+                const allPrevHeadlines = [...prevHeadlines, ...generatedHeadlines];
+                const nonRepeat = allPrevHeadlines.length > 0
+                  ? `\nDo NOT repeat or closely rephrase any of these previously shown headlines:\n${allPrevHeadlines.map(h => `- "${h}"`).join("\n")}`
+                  : "";
 
-                // ── Image resolution ──
-                if (!n._resolvedImageUrl && imageLookups[i]) {
-                  try {
-                    const wikiResult = await imageLookups[i];
-                    if (wikiResult && !usedImageUrls.has(wikiResult.url)) {
-                      n._resolvedImageUrl = wikiResult.url;
-                      n._resolvedImageTitle = wikiResult.title;
-                      usedImageUrls.add(wikiResult.url);
-                    }
-                  } catch { /* fall through to Exa fallback */ }
+                const singlePrompt = `You are a music journalist. The listener is PLAYING "${title}" by ${artist}${album ? ` from "${album}"` : ""} RIGHT NOW.
+
+${researchSection}
+
+VOICE: ${tierConfig.tone}
+${tierConfig.assumedKnowledge}
+
+WRITING RULES — NON-NEGOTIABLE:
+1. Tell stories, not descriptions. Never describe what the music sounds like — the listener can hear it.
+2. Dig like Nardwuar — find the specific detail nobody else would.
+3. VOICE GUARD: Never hedge ("likely", "suggests", "perhaps"). State facts or skip them.
+4. If uncertain, OMIT IT rather than hedging.
+5. Headlines must CREATE A CURIOSITY GAP — tease the story, don't summarize it. Use "${artist}" by name. NEVER use title case.
+6. NO VAGUE FILLER. If a sentence could apply to any artist, it's worthless. Every sentence must be specific to ${artist}.
+   SWAP TEST: if you can replace "${artist}" with any other artist and the sentence still works, DELETE IT.
+7. Do NOT use fabricated publisher names. Use the artist's real website, Bandcamp, Spotify, or a real music publication.
+8. SOURCES: Match facts to [CIT N] citations via "citIndex". Do not invent URLs.
+${nonRepeat}
+
+TASK: Generate exactly ONE "${def.kind}" nugget.
+Focus: ${def.focus}
+listenFor: ${def.listenFor}
+${def.kind === "discovery" ? `HONESTY RULE: Only claim a connection you can verify from the research. Do NOT recommend artists sharing any part of ${artist}'s name.` : ""}
+${def.includeArtistSummary ? `\nAlso generate "artistSummary": 2-3 punchy sentences about ${artist}.` : ""}
+
+Return ONLY valid JSON:
+{
+  ${def.includeArtistSummary ? '"artistSummary": "...",' : ""}
+  "nugget": {
+    "headline": "Tease the story — make them need to read more",
+    "text": "2-3 sentences delivering on the headline",
+    "kind": "${def.kind}",
+    "listenFor": ${def.listenFor},
+    "imageSearchQuery": "specific subject for image search OR omit if not needed",
+    "imageCaption": "6-12 word caption",
+    "source": {
+      "type": "youtube|article|interview",
+      "title": "Source title",
+      "publisher": "Real publisher name",
+      "citIndex": 0,
+      "quoteSnippet": "Key quote or paraphrase"
+    }
+  }
+}`;
+
+                const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GOOGLE_AI_API_KEY}`;
+                const effectiveTemp = isSparseData ? Math.min(tierConfig.temperature, 0.75) : tierConfig.temperature;
+                const callBody: any = {
+                  contents: [{ role: "user", parts: [{ text: singlePrompt }] }],
+                  generationConfig: { temperature: effectiveTemp },
+                };
+                if (!exaPromptContext || isSparseData) {
+                  callBody.tools = [{ google_search: {} }];
                 }
-                if (!n._resolvedImageUrl) {
-                  const groupStart = i * 10;
+
+                let nuggetData: any = null;
+                for (let attempt = 0; attempt < 3; attempt++) {
+                  try {
+                    const res = await fetch(geminiUrl, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify(callBody),
+                    });
+                    if (!res.ok) {
+                      if (res.status === 429 && attempt < 2) {
+                        console.log(`[SSE] 429 for ${def.kind}, retrying in 2s...`);
+                        await new Promise(r => setTimeout(r, 2000));
+                        continue;
+                      }
+                      throw new Error(`Gemini returned ${res.status} for ${def.kind}`);
+                    }
+                    const data = await res.json();
+                    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || "";
+                    if (!text.trim()) {
+                      if (attempt < 2) { await new Promise(r => setTimeout(r, 1000)); continue; }
+                      throw new Error(`Empty Gemini response for ${def.kind}`);
+                    }
+                    const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
+                    const parsed = JSON.parse(cleaned);
+                    nuggetData = parsed.nugget || (parsed.nuggets?.[0]);
+                    if (parsed.artistSummary) sseArtistSummary = parsed.artistSummary;
+                    break;
+                  } catch (e) {
+                    if (attempt >= 2) {
+                      console.error(`[SSE] Failed to generate ${def.kind} nugget after 3 attempts:`, e);
+                    }
+                  }
+                }
+                _te(`writer_${def.kind}`);
+
+                if (!nuggetData) {
+                  console.warn(`[SSE] Skipping ${def.kind} — generation failed`);
+                  continue;
+                }
+
+                generatedHeadlines.push(nuggetData.headline || nuggetData.text || "");
+
+                // ── Image: Exa first (instant), Wikipedia fallback ──
+                const nuggetIndex = streamedIndex;
+                if (!nuggetData._resolvedImageUrl) {
+                  const groupStart = nuggetIndex * 10;
                   const groupEnd = groupStart + 10;
-                  let fallbackCit = exaCitationsStrict.find((c) =>
+                  let exaCit = exaCitationsStrict.find((c) =>
                     c.citIndex >= groupStart && c.citIndex < groupEnd &&
                     c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
                   );
-                  if (!fallbackCit) {
-                    fallbackCit = exaCitationsStrict.find((c) =>
+                  if (!exaCit) {
+                    exaCit = exaCitationsStrict.find((c) =>
                       c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
                     );
                   }
-                  if (fallbackCit?.imageUrl) {
-                    n._resolvedImageUrl = fallbackCit.imageUrl;
-                    n._resolvedImageTitle = fallbackCit.title;
-                    usedImageUrls.add(fallbackCit.imageUrl);
+                  if (exaCit?.imageUrl) {
+                    nuggetData._resolvedImageUrl = exaCit.imageUrl;
+                    nuggetData._resolvedImageTitle = exaCit.title;
+                    usedImageUrls.add(exaCit.imageUrl);
                   }
+                }
+                if (!nuggetData._resolvedImageUrl && isValidImageQuery(nuggetData.imageSearchQuery)) {
+                  try {
+                    const wikiResult = await resolveNuggetImage(nuggetData.imageSearchQuery!);
+                    if (wikiResult && !usedImageUrls.has(wikiResult.url)) {
+                      nuggetData._resolvedImageUrl = wikiResult.url;
+                      nuggetData._resolvedImageTitle = wikiResult.title;
+                      usedImageUrls.add(wikiResult.url);
+                    }
+                  } catch { /* stream without image */ }
                 }
 
                 // ── Assemble + validate ──
-                const assembled = assembleNugget(n, i);
+                const assembled = assembleNugget(nuggetData, nuggetIndex);
                 const sourceType = (assembled.source?.type || "").toLowerCase();
                 const publisher = (assembled.source?.publisher || "").toLowerCase();
                 if (
                   sourceType === "internal-data" || sourceType === "internal_data" ||
                   sourceType === "database" || sourceType === "editorial"
                 ) {
-                  console.log(`[SSE] Skipping hallucinated source type nugget ${i}`);
+                  console.log(`[SSE] Skipping hallucinated source type: ${def.kind}`);
                   continue;
                 }
                 if (HALLUCINATED_PUBLISHERS.some(hp => publisher.includes(hp))) {
-                  console.log(`[SSE] Skipping hallucinated publisher nugget ${i}`);
+                  console.log(`[SSE] Skipping hallucinated publisher: ${def.kind}`);
                   continue;
                 }
 
-                // ── Stream with contiguous index ──
+                // ── Stream immediately ──
                 streamedNuggets.push(assembled);
                 const event = `data: ${JSON.stringify({
                   type: "nugget",
                   index: streamedIndex,
                   nugget: assembled,
-                  totalExpected: rawNuggets.length,
+                  totalExpected: 3,
                 })}\n\n`;
                 try { streamController.enqueue(encoder.encode(event)); } catch { /* stream closed */ }
-                console.log(`[SSE] Streamed nugget ${streamedIndex}: "${assembled.headline?.slice(0, 40)}"`);
+                console.log(`[SSE] Streamed ${def.kind} nugget ${streamedIndex}: "${assembled.headline?.slice(0, 40)}"`);
                 streamedIndex++;
               }
 
-              // All done — send done event and close
-              const doneEvent = `data: ${JSON.stringify({ type: "done", artistSummary, externalLinks: buildExternalLinks(), noTrackData })}\n\n`;
+              // ── Done ──
+              artistSummary = sseArtistSummary;
+              noTrackData = false;
+              rawNuggets = streamedNuggets.map((n: any) => n);
+              const doneEvent = `data: ${JSON.stringify({ type: "done", artistSummary: sseArtistSummary, externalLinks: buildExternalLinks(), noTrackData: false })}\n\n`;
               try {
                 streamController.enqueue(encoder.encode(doneEvent));
                 streamController.close();
@@ -2986,6 +3135,32 @@ Return ONLY valid JSON:
 
     // ── Non-SSE path: resolve all images in parallel, return JSON (backward compat) ──
     console.time("[Timing] Wiki image resolution"); _ts("wikiImages");
+    // Exa citation images first (instant — data already in memory)
+    if (exaCitationsStrict.length) {
+      for (let i = 0; i < rawNuggets.length; i++) {
+        if (rawNuggets[i]._resolvedImageUrl) continue;
+        const groupStart = i * 10;
+        const groupEnd = groupStart + 10;
+        let exaCit = exaCitationsStrict.find((c) =>
+          c.citIndex >= groupStart && c.citIndex < groupEnd &&
+          c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
+        );
+        if (!exaCit) {
+          exaCit = exaCitationsStrict.find((c) =>
+            c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
+          );
+        }
+        if (exaCit?.imageUrl) {
+          rawNuggets[i]._resolvedImageUrl = exaCit.imageUrl;
+          rawNuggets[i]._resolvedImageTitle = exaCit.title;
+          usedImageUrls.add(exaCit.imageUrl);
+          const crossGroup = exaCit.citIndex < groupStart || exaCit.citIndex >= groupEnd;
+          console.log(`[Image] Exa${crossGroup ? " (cross-group)" : ""} for nugget ${i}: ${exaCit.imageUrl}`);
+        }
+      }
+    }
+
+    // Wikipedia fallback only for nuggets that still have no image
     const wikiSearchNeeded = rawNuggets.map((n) =>
       !n._resolvedImageUrl && isValidImageQuery(n.imageSearchQuery) ? resolveNuggetImage(n.imageSearchQuery!) : Promise.resolve(null)
     );
@@ -2999,34 +3174,9 @@ Return ONLY valid JSON:
         rawNuggets[i]._resolvedImageUrl = result.value.url;
         rawNuggets[i]._resolvedImageTitle = result.value.title;
         usedImageUrls.add(result.value.url);
-        console.log(`[Image] Wikipedia for nugget ${i} "${rawNuggets[i].imageSearchQuery}" → ${result.value.url}`);
-      }
-    }
-
-    // Third pass: Exa citation fallback
-    if (exaCitationsStrict.length) {
-      for (let i = 0; i < rawNuggets.length; i++) {
-        if (rawNuggets[i]._resolvedImageUrl) continue;
-        const groupStart = i * 10;
-        const groupEnd = groupStart + 10;
-        let fallbackCit = exaCitationsStrict.find((c) =>
-          c.citIndex >= groupStart && c.citIndex < groupEnd &&
-          c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
-        );
-        if (!fallbackCit) {
-          fallbackCit = exaCitationsStrict.find((c) =>
-            c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
-          );
-        }
-        if (fallbackCit?.imageUrl) {
-          rawNuggets[i]._resolvedImageUrl = fallbackCit.imageUrl;
-          rawNuggets[i]._resolvedImageTitle = fallbackCit.title;
-          usedImageUrls.add(fallbackCit.imageUrl);
-          const crossGroup = fallbackCit.citIndex < groupStart || fallbackCit.citIndex >= groupEnd;
-          console.log(`[Image] Exa fallback${crossGroup ? " (cross-group)" : ""} for nugget ${i}: ${fallbackCit.imageUrl}`);
-        } else {
-          console.log(`[Image] No image for nugget ${i} — frontend will use album art`);
-        }
+        console.log(`[Image] Wikipedia fallback for nugget ${i}: ${result.value.url}`);
+      } else if (!rawNuggets[i]._resolvedImageUrl) {
+        console.log(`[Image] No image for nugget ${i} — frontend will use album art`);
       }
     }
 

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -513,6 +513,38 @@ function isActualImageUrl(url: string): boolean {
   }
 }
 
+// Exa citations are bucketed by nugget: each nugget owns a contiguous
+// window of citIndex values. Keep in sync with the citation-builder.
+const CITATION_GROUP_SIZE = 10;
+const NUGGET_COUNT = 3;
+
+// Picks an unused Exa citation image for a nugget, preferring the nugget's
+// own citation group and falling back to any unused image. Mutates the
+// target with _resolvedImageUrl / _resolvedImageTitle and records the URL
+// in usedImageUrls. Returns the chosen citation (for logging) or null.
+function resolveExaImageForNugget(
+  target: { _resolvedImageUrl?: string; _resolvedImageTitle?: string },
+  nuggetIndex: number,
+  exaCitationsStrict: ExaCitation[],
+  usedImageUrls: Set<string>,
+): ExaCitation | null {
+  if (target._resolvedImageUrl) return null;
+  const groupStart = nuggetIndex * CITATION_GROUP_SIZE;
+  const groupEnd = groupStart + CITATION_GROUP_SIZE;
+  const usable = (c: ExaCitation) =>
+    !!c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl);
+  const match =
+    exaCitationsStrict.find((c) => c.citIndex >= groupStart && c.citIndex < groupEnd && usable(c)) ??
+    exaCitationsStrict.find(usable);
+  if (match?.imageUrl) {
+    target._resolvedImageUrl = match.imageUrl;
+    target._resolvedImageTitle = match.title;
+    usedImageUrls.add(match.imageUrl);
+    return match;
+  }
+  return null;
+}
+
 // ── Word-boundary matching helper ─────────────────────────────────────
 // Uses regex \b to prevent "pete" matching inside "peter" or "cornelia" matching "Cornelia Murr"
 function wordBoundaryMatch(haystack: string, needle: string): boolean {
@@ -3010,7 +3042,7 @@ Return ONLY valid JSON:
                     if (!res.ok) {
                       if (res.status === 429 && attempt < 2) {
                         console.log(`[SSE] 429 for ${def.kind}, retrying in 2s...`);
-                        await new Promise(r => setTimeout(r, 2000));
+                        await new Promise((resolve) => setTimeout(resolve, 2000));
                         continue;
                       }
                       throw new Error(`Gemini returned ${res.status} for ${def.kind}`);
@@ -3018,7 +3050,7 @@ Return ONLY valid JSON:
                     const data = await res.json();
                     const text = data.candidates?.[0]?.content?.parts?.[0]?.text || "";
                     if (!text.trim()) {
-                      if (attempt < 2) { await new Promise(r => setTimeout(r, 1000)); continue; }
+                      if (attempt < 2) { await new Promise((resolve) => setTimeout(resolve, 1000)); continue; }
                       throw new Error(`Empty Gemini response for ${def.kind}`);
                     }
                     const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
@@ -3043,24 +3075,7 @@ Return ONLY valid JSON:
 
                 // ── Image: Exa first (instant), Wikipedia fallback ──
                 const nuggetIndex = streamedIndex;
-                if (!nuggetData._resolvedImageUrl) {
-                  const groupStart = nuggetIndex * 10;
-                  const groupEnd = groupStart + 10;
-                  let exaCit = exaCitationsStrict.find((c) =>
-                    c.citIndex >= groupStart && c.citIndex < groupEnd &&
-                    c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
-                  );
-                  if (!exaCit) {
-                    exaCit = exaCitationsStrict.find((c) =>
-                      c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
-                    );
-                  }
-                  if (exaCit?.imageUrl) {
-                    nuggetData._resolvedImageUrl = exaCit.imageUrl;
-                    nuggetData._resolvedImageTitle = exaCit.title;
-                    usedImageUrls.add(exaCit.imageUrl);
-                  }
-                }
+                resolveExaImageForNugget(nuggetData, nuggetIndex, exaCitationsStrict, usedImageUrls);
                 if (!nuggetData._resolvedImageUrl && isValidImageQuery(nuggetData.imageSearchQuery)) {
                   try {
                     const wikiResult = await resolveNuggetImage(nuggetData.imageSearchQuery!);
@@ -3094,7 +3109,7 @@ Return ONLY valid JSON:
                   type: "nugget",
                   index: streamedIndex,
                   nugget: assembled,
-                  totalExpected: 3,
+                  totalExpected: NUGGET_COUNT,
                 })}\n\n`;
                 try { streamController.enqueue(encoder.encode(event)); } catch { /* stream closed */ }
                 console.log(`[SSE] Streamed ${def.kind} nugget ${streamedIndex}: "${assembled.headline?.slice(0, 40)}"`);
@@ -3103,9 +3118,11 @@ Return ONLY valid JSON:
 
               // ── Done ──
               artistSummary = sseArtistSummary;
-              noTrackData = false;
-              rawNuggets = streamedNuggets.map((n: any) => n);
-              const doneEvent = `data: ${JSON.stringify({ type: "done", artistSummary: sseArtistSummary, externalLinks: buildExternalLinks(), noTrackData: false })}\n\n`;
+              // Match batch path: sparse/missing track facts + skipped track search
+              // signal "no track data" so the client can adjust downstream UI.
+              noTrackData = !curatedFacts?.trackFacts?.length && trackSearchSkipped;
+              rawNuggets = streamedNuggets;
+              const doneEvent = `data: ${JSON.stringify({ type: "done", artistSummary: sseArtistSummary, externalLinks: buildExternalLinks(), noTrackData })}\n\n`;
               try {
                 streamController.enqueue(encoder.encode(doneEvent));
                 streamController.close();
@@ -3138,24 +3155,12 @@ Return ONLY valid JSON:
     // Exa citation images first (instant — data already in memory)
     if (exaCitationsStrict.length) {
       for (let i = 0; i < rawNuggets.length; i++) {
-        if (rawNuggets[i]._resolvedImageUrl) continue;
-        const groupStart = i * 10;
-        const groupEnd = groupStart + 10;
-        let exaCit = exaCitationsStrict.find((c) =>
-          c.citIndex >= groupStart && c.citIndex < groupEnd &&
-          c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
-        );
-        if (!exaCit) {
-          exaCit = exaCitationsStrict.find((c) =>
-            c.imageUrl && !usedImageUrls.has(c.imageUrl) && !isGarbageImage(c.imageUrl) && isActualImageUrl(c.imageUrl)
-          );
-        }
-        if (exaCit?.imageUrl) {
-          rawNuggets[i]._resolvedImageUrl = exaCit.imageUrl;
-          rawNuggets[i]._resolvedImageTitle = exaCit.title;
-          usedImageUrls.add(exaCit.imageUrl);
-          const crossGroup = exaCit.citIndex < groupStart || exaCit.citIndex >= groupEnd;
-          console.log(`[Image] Exa${crossGroup ? " (cross-group)" : ""} for nugget ${i}: ${exaCit.imageUrl}`);
+        const picked = resolveExaImageForNugget(rawNuggets[i], i, exaCitationsStrict, usedImageUrls);
+        if (picked) {
+          const groupStart = i * CITATION_GROUP_SIZE;
+          const groupEnd = groupStart + CITATION_GROUP_SIZE;
+          const crossGroup = picked.citIndex < groupStart || picked.citIndex >= groupEnd;
+          console.log(`[Image] Exa${crossGroup ? " (cross-group)" : ""} for nugget ${i}: ${picked.imageUrl}`);
         }
       }
     }

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -535,12 +535,14 @@ const CITATION_GROUP = {
 // Path-specific extras (e.g. "Prefer birthplace" for the direct path, where
 // no curated origin is available) are appended as rules 9+ via the `extras`
 // argument.
-const WRITER_BASE_RULES = [
-  (artist: string) => `The listener can HEAR the music. Tell them what they CAN'T know from listening — stories, history, people, places, creative context.`,
-  (_artist: string) => `Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.`,
-  (_artist: string) => `VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.`,
-  (_artist: string) => `If uncertain about a fact, OMIT IT. One confident true sentence beats three hedged guesses.`,
-  (artist: string) => `Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading your headline, you failed.
+type WriterRule = string | ((artist: string) => string);
+
+const WRITER_BASE_RULES: WriterRule[] = [
+  `The listener can HEAR the music. Tell them what they CAN'T know from listening — stories, history, people, places, creative context.`,
+  `Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.`,
+  `VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.`,
+  `If uncertain about a fact, OMIT IT. One confident true sentence beats three hedged guesses.`,
+  (artist) => `Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading your headline, you failed.
    SAME FACT, TWO WAYS:
    - SUMMARY (bad): "A scrapped Gucci Mane beat became 'HUMBLE.'" → gives away the whole story, nothing left to read
    - CURIOSITY (good): "HUMBLE. was never meant for Kendrick" → wait, whose beat was it? I need to read more
@@ -549,14 +551,15 @@ const WRITER_BASE_RULES = [
    The test: does the headline make you ask "wait, what?" or "tell me more"? If it just states a fact, rewrite it.
    Use "${artist}" by name in headlines — never say "this artist" or "he"/"she" without naming them.
    NEVER use title case. NEVER use "[Name]'s [Abstract Noun]".`,
-  (artist: string) => `NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
+  (artist) => `NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
    SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.`,
-  (artist: string) => `Do NOT recommend artists who share ANY part of ${artist}'s name.`,
-  (_artist: string) => `Do NOT use fabricated publisher names like "General Knowledge" or "Music Analysis". Use the artist's real website, Bandcamp, Spotify, or a real music publication.`,
+  (artist) => `Do NOT recommend artists who share ANY part of ${artist}'s name.`,
+  `Do NOT use fabricated publisher names like "General Knowledge" or "Music Analysis". Use the artist's real website, Bandcamp, Spotify, or a real music publication.`,
 ];
 
 function buildWriterNonNegotiables(artist: string, extras: string[] = []): string {
-  const base = WRITER_BASE_RULES.map((r, i) => `${i + 1}. ${r(artist)}`).join("\n");
+  const renderRule = (r: WriterRule) => typeof r === "function" ? r(artist) : r;
+  const base = WRITER_BASE_RULES.map((r, i) => `${i + 1}. ${renderRule(r)}`).join("\n");
   const extraBlock = extras.length
     ? "\n" + extras.map((e, i) => `${WRITER_BASE_RULES.length + 1 + i}. ${e}`).join("\n")
     : "";
@@ -2946,6 +2949,9 @@ Return ONLY valid JSON:
         start(controller) {
           streamController = controller;
 
+          // start() is synchronous per the ReadableStream spec — wrap the
+          // async generation in an IIFE so we can return immediately with
+          // the stream wired up, and emit events as work completes.
           (async () => {
             try {
               // ── Step 1: Run Curator (same as batch path) ──
@@ -3064,12 +3070,17 @@ Return ONLY valid JSON:
                 }
 
                 let nuggetData: any = null;
+                const WRITER_CALL_TIMEOUT_MS = 30_000;
                 for (let attempt = 0; attempt < 3; attempt++) {
                   try {
+                    // Per-attempt abort guard — a hanging Gemini response
+                    // would otherwise hold the SSE connection open until
+                    // the edge function's hard timeout fires.
                     const res = await fetch(geminiUrl, {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify(callBody),
+                      signal: AbortSignal.timeout(WRITER_CALL_TIMEOUT_MS),
                     });
                     if (!res.ok) {
                       if (res.status === 429 && attempt < 2) {
@@ -3168,6 +3179,10 @@ Return ONLY valid JSON:
               // post-IIFE path (cache writes, metrics) sees the same values
               // the SSE client received.
               artistSummary = sseArtistSummary;
+              // trackSearchSkipped is set earlier, inside the Exa phase 2
+              // strategy block (SEMI-STANDARD / ARTIST-HEAVY / SPARSE paths)
+              // which runs before this IIFE. It tracks whether we skipped
+              // the track-specific Exa search, not whether the Writer ran.
               noTrackData = !curatedFacts?.trackFacts?.length && trackSearchSkipped;
               rawNuggets = streamedNuggets;
 

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -535,16 +535,12 @@ const CITATION_GROUP = {
 // Path-specific extras (e.g. "Prefer birthplace" for the direct path, where
 // no curated origin is available) are appended as rules 9+ via the `extras`
 // argument.
-function buildWriterNonNegotiables(artist: string, extras: string[] = []): string {
-  const extraBlock = extras.length
-    ? "\n" + extras.map((e, i) => `${9 + i}. ${e}`).join("\n")
-    : "";
-  return `WRITING RULES — NON-NEGOTIABLE:
-1. The listener can HEAR the music. Tell them what they CAN'T know from listening — stories, history, people, places, creative context.
-2. Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.
-3. VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.
-4. If uncertain about a fact, OMIT IT. One confident true sentence beats three hedged guesses.
-5. Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading your headline, you failed.
+const WRITER_BASE_RULES = [
+  (artist: string) => `The listener can HEAR the music. Tell them what they CAN'T know from listening — stories, history, people, places, creative context.`,
+  (_artist: string) => `Dig like Nardwuar — find the specific detail nobody else would. Prioritize "almost didn't happen" stories, unlikely origins, specific people who changed the trajectory.`,
+  (_artist: string) => `VOICE GUARD: Never hedge ("likely", "suggests", "perhaps") — state facts or skip them. Never describe sound ("sonic landscape", "soundscape") — the listener can hear it. Write with the confidence of someone who KNOWS this, not someone guessing.`,
+  (_artist: string) => `If uncertain about a fact, OMIT IT. One confident true sentence beats three hedged guesses.`,
+  (artist: string) => `Headlines must CREATE A CURIOSITY GAP — say just enough to intrigue, withhold enough that the reader MUST read the body. If someone can skip the body after reading your headline, you failed.
    SAME FACT, TWO WAYS:
    - SUMMARY (bad): "A scrapped Gucci Mane beat became 'HUMBLE.'" → gives away the whole story, nothing left to read
    - CURIOSITY (good): "HUMBLE. was never meant for Kendrick" → wait, whose beat was it? I need to read more
@@ -552,17 +548,26 @@ function buildWriterNonNegotiables(artist: string, extras: string[] = []): strin
    MORE BAD: "He recorded his first EP in a closet at 16" / "Aaron Doh's Early Digital Footprint Takes Shape" / "The Creative Evolution Behind the Music" / "this artist's creative path"
    The test: does the headline make you ask "wait, what?" or "tell me more"? If it just states a fact, rewrite it.
    Use "${artist}" by name in headlines — never say "this artist" or "he"/"she" without naming them.
-   NEVER use title case. NEVER use "[Name]'s [Abstract Noun]".
-6. NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
-   SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.
-7. Do NOT recommend artists who share ANY part of ${artist}'s name.
-8. Do NOT use fabricated publisher names. Use the artist's real website, Bandcamp, Spotify, or a real music publication.${extraBlock}`;
+   NEVER use title case. NEVER use "[Name]'s [Abstract Noun]".`,
+  (artist: string) => `NO VAGUE FILLER. If a sentence could apply to any artist (e.g., "promoting messages of love and hope", "unique blend of genres", "committed to authentic artistry"), it's worthless. Every sentence must contain a detail that ONLY applies to THIS artist.
+   SWAP TEST: if you can replace "${artist}" with any other artist's name and the sentence still works, DELETE IT. It means you wrote nothing specific.`,
+  (artist: string) => `Do NOT recommend artists who share ANY part of ${artist}'s name.`,
+  (_artist: string) => `Do NOT use fabricated publisher names. Use the artist's real website, Bandcamp, Spotify, or a real music publication.`,
+];
+
+function buildWriterNonNegotiables(artist: string, extras: string[] = []): string {
+  const base = WRITER_BASE_RULES.map((r, i) => `${i + 1}. ${r(artist)}`).join("\n");
+  const extraBlock = extras.length
+    ? "\n" + extras.map((e, i) => `${WRITER_BASE_RULES.length + 1 + i}. ${e}`).join("\n")
+    : "";
+  return `WRITING RULES — NON-NEGOTIABLE:\n${base}${extraBlock}`;
 }
 
 // Picks an unused Exa citation image for a nugget, preferring the nugget's
 // own citation group and falling back to any unused image. Mutates the
 // target with _resolvedImageUrl / _resolvedImageTitle and records the URL
-// in usedImageUrls. Returns the chosen citation (for logging) or null.
+// in usedImageUrls. Returns the chosen citation (for logging), or null if
+// the target already had an image resolved or no unused image was available.
 function resolveExaImageForNugget(
   target: { _resolvedImageUrl?: string; _resolvedImageTitle?: string },
   nuggetIndex: number,
@@ -2938,11 +2943,19 @@ Return ONLY valid JSON:
           (async () => {
             try {
               // ── Step 1: Run Curator (same as batch path) ──
+              // Bounded so a slow/hanging Curator can't starve the SSE stream —
+              // if it exceeds the budget, fall through to the direct path.
               _ts("curator");
               let curatedFacts: any = null;
               if (exaPromptContext) {
+                const CURATOR_TIMEOUT_MS = 20_000;
                 try {
-                  curatedFacts = await curateResearch(artist, title, album, exaPromptContext, "", GOOGLE_AI_API_KEY, resolvedSpotifyInfo);
+                  curatedFacts = await Promise.race([
+                    curateResearch(artist, title, album, exaPromptContext, "", GOOGLE_AI_API_KEY, resolvedSpotifyInfo),
+                    new Promise<never>((_, reject) =>
+                      setTimeout(() => reject(new Error(`Curator timeout (${CURATOR_TIMEOUT_MS}ms)`)), CURATOR_TIMEOUT_MS)
+                    ),
+                  ]);
                 } catch (e) {
                   console.warn("[SSE] Curator failed, proceeding with direct path:", e);
                 }
@@ -2982,9 +2995,15 @@ Return ONLY valid JSON:
               let streamedIndex = 0;
               const streamedNuggets: any[] = [];
               let sseArtistSummary = "";
+              const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GOOGLE_AI_API_KEY}`;
 
               // ── Step 4: Generate + stream each nugget ──
-              for (const def of nuggetDefs) {
+              // defIdx (not streamedIndex) is the stable citation-group index:
+              // if a nugget is skipped by validation, streamedIndex stays put
+              // but defIdx keeps advancing, so the next nugget still maps to
+              // its correct Exa citation window (artist=0, track=1, discovery=2).
+              for (let defIdx = 0; defIdx < nuggetDefs.length; defIdx++) {
+                const def = nuggetDefs[defIdx];
                 _ts(`writer_${def.kind}`);
                 const allPrevHeadlines = [...prevHeadlines, ...generatedHeadlines];
                 const nonRepeat = allPrevHeadlines.length > 0
@@ -3029,7 +3048,6 @@ Return ONLY valid JSON:
   }
 }`;
 
-                const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GOOGLE_AI_API_KEY}`;
                 const effectiveTemp = isSparseData ? Math.min(tierConfig.temperature, 0.75) : tierConfig.temperature;
                 const callBody: any = {
                   contents: [{ role: "user", parts: [{ text: singlePrompt }] }],
@@ -3088,11 +3106,13 @@ Return ONLY valid JSON:
                   continue;
                 }
 
-                generatedHeadlines.push(nuggetData.headline || nuggetData.text || "");
+                const headlineForHistory = nuggetData.headline || nuggetData.text;
+                if (headlineForHistory) generatedHeadlines.push(headlineForHistory);
 
                 // ── Image: Exa first (instant), Wikipedia fallback ──
-                const nuggetIndex = streamedIndex;
-                resolveExaImageForNugget(nuggetData, nuggetIndex, exaCitationsStrict, usedImageUrls);
+                // Use defIdx (not streamedIndex) so citation grouping stays
+                // aligned even when earlier nuggets are skipped by validation.
+                resolveExaImageForNugget(nuggetData, defIdx, exaCitationsStrict, usedImageUrls);
                 if (!nuggetData._resolvedImageUrl && isValidImageQuery(nuggetData.imageSearchQuery)) {
                   try {
                     const wikiResult = await resolveNuggetImage(nuggetData.imageSearchQuery!);
@@ -3126,7 +3146,7 @@ Return ONLY valid JSON:
                   type: "nugget",
                   index: streamedIndex,
                   nugget: assembled,
-                  totalExpected: NUGGET_COUNT,
+                  totalExpected: nuggetDefs.length,
                 })}\n\n`;
                 try { streamController.enqueue(encoder.encode(event)); } catch { /* stream closed */ }
                 console.log(`[SSE] Streamed ${def.kind} nugget ${streamedIndex}: "${assembled.headline?.slice(0, 40)}"`);


### PR DESCRIPTION
## Summary

- **Progressive SSE streaming**: Writer split into 3 sequential `gemini-2.5-flash` calls (one per nugget kind). Each nugget streams the moment it generates + resolves an image, instead of waiting for all 3 to complete. First nugget arrives ~5-10s after Curator, vs previous 15-25s batch wait.
- **Image order flipped**: Exa citation images checked first (instant — already in memory from research phase). Wikipedia only runs as fallback when Exa has no image. Eliminates 2-10s per-nugget async delay in the streaming loop.
- **All tiers use `gemini-2.5-flash`**: Dropped `gemini-2.5-pro` for nerd tier in the progressive path. Faster generation, ~2x cheaper, minimal quality tradeoff.
- **TypewriterText body peek fix**: Headline wrapper has `min-h-[3.5rem]` so body paragraph doesn't briefly peek during character-by-character animation.
- **Nugget pacing**: 10s minimum display time per nugget. When new nuggets stream in, they queue and auto-advance after the timer expires. User can swipe manually anytime. Prevents jarring mid-read content swaps.

## Test plan

- [ ] Mobile: open a non-seed track → first nugget should appear within 25-40s (not 50-85s)
- [ ] Second and third nuggets arrive 3-8s apart, with 10s display pacing
- [ ] TypewriterText animation: body text stays below fold during typing
- [ ] Swipe dots update immediately when new nuggets unlock (user can swipe before auto-advance)
- [ ] Seed tracks (Billie, Radiohead) still work instantly
- [ ] Desktop non-SSE path still works (JSON fallback unchanged)
- [ ] `npm test` — 193 passing, `npm run build` — clean
- [ ] Edge function deployed to Supabase (version 17)