### PR TITLE
refactor: rename UserProfile spotify* taste fields to service-agnostic names

### DIFF
--- a/Dev.md
+++ b/Dev.md
@@ -192,7 +192,7 @@ User enters Last.fm username
   → On Browse load: lastfm-sync called again (uses cache)
 
 On Companion/Generate:
-  → generate-companion receives: lastFmUsername, spotifyTopArtists, spotifyTopTracks, streamingService
+  → generate-companion receives: lastFmUsername, topArtists, topTracks, streamingService
   → Internally calls lastfm-sync to get taste context
   → Merges all signals into a RAG prompt context block
   → Gemini uses context to tailor "Explore Next" category

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -36,6 +36,42 @@ interface TasteData {
   trackImages?: { title: string; artist: string; imageUrl: string }[];
 }
 
+/** Legacy localStorage payload shape. Pre-rename profiles used `spotify*`
+ *  prefixed keys even after Apple Music support landed. `parseStoredProfile`
+ *  promotes these to the unprefixed keys on read. Drop after soak. */
+interface LegacyProfileShape {
+  spotifyTopArtists?: string[];
+  spotifyTopTracks?: string[];
+  spotifyArtistImages?: Record<string, string>;
+  spotifyArtistIds?: Record<string, string>;
+  spotifyTrackImages?: UserProfile["trackImages"];
+}
+
+function parseStoredProfile(raw: string | null): UserProfile | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as UserProfile & LegacyProfileShape;
+    const {
+      spotifyTopArtists,
+      spotifyTopTracks,
+      spotifyArtistImages,
+      spotifyArtistIds,
+      spotifyTrackImages,
+      ...rest
+    } = parsed;
+    return {
+      ...rest,
+      topArtists: rest.topArtists ?? spotifyTopArtists,
+      topTracks: rest.topTracks ?? spotifyTopTracks,
+      artistImages: rest.artistImages ?? spotifyArtistImages,
+      artistIds: rest.artistIds ?? spotifyArtistIds,
+      trackImages: rest.trackImages ?? spotifyTrackImages,
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   const { data } = await supabase
     .from("profiles")
@@ -57,11 +93,11 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   return {
     streamingService: service,
     lastFmUsername: data.last_fm_username || undefined,
-    spotifyTopArtists: taste?.topArtists ?? undefined,
-    spotifyTopTracks: taste?.topTracks ?? undefined,
-    spotifyArtistImages: taste?.artistImages ?? undefined,
-    spotifyArtistIds: taste?.artistIds ?? undefined,
-    spotifyTrackImages: taste?.trackImages ?? undefined,
+    topArtists: taste?.topArtists ?? undefined,
+    topTracks: taste?.topTracks ?? undefined,
+    artistImages: taste?.artistImages ?? undefined,
+    artistIds: taste?.artistIds ?? undefined,
+    trackImages: taste?.trackImages ?? undefined,
     calculatedTier: (data.tier as UserProfile["calculatedTier"]) || "casual",
   };
 }
@@ -71,31 +107,32 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
  *
  * Priority:
  *  1. Preserve an explicit streamingService on whichever source is the base
- *  2. Fall back to "Spotify" only if spotifyTopArtists is populated (legacy
- *     profile rows from before streaming_service was persisted)
+ *  2. Fall back to "Spotify" only if topArtists is populated (legacy
+ *     profile rows from before streaming_service was persisted; all such
+ *     rows predate Apple Music support and are Spotify by construction)
  *  3. Otherwise empty string (guest-like state)
  *
  * Exported for unit testing. Used by useUserProfile's hydrate effect.
  */
 export function resolveStreamingService(
   baseService: UserProfile["streamingService"] | undefined,
-  spotifyTopArtistsCount: number
+  topArtistsCount: number
 ): UserProfile["streamingService"] {
   if (baseService) return baseService;
-  if (spotifyTopArtistsCount > 0) return "Spotify";
+  if (topArtistsCount > 0) return "Spotify";
   return "";
 }
 
 async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
   // Build taste data from profile fields
   const tasteData: TasteData | null =
-    p.spotifyTopArtists || p.spotifyTopTracks
+    p.topArtists || p.topTracks
       ? {
-          topArtists: p.spotifyTopArtists ?? [],
-          topTracks: p.spotifyTopTracks ?? [],
-          artistImages: p.spotifyArtistImages ?? {},
-          artistIds: p.spotifyArtistIds ?? {},
-          trackImages: p.spotifyTrackImages ?? [],
+          topArtists: p.topArtists ?? [],
+          topTracks: p.topTracks ?? [],
+          artistImages: p.artistImages ?? {},
+          artistIds: p.artistIds ?? {},
+          trackImages: p.trackImages ?? [],
         }
       : null;
 
@@ -122,14 +159,9 @@ async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
 export function useUserProfile() {
   const { user } = useAuth();
 
-  const [profile, setProfileState] = useState<UserProfile | null>(() => {
-    try {
-      const raw = localStorage.getItem(PROFILE_KEY);
-      return raw ? JSON.parse(raw) : null;
-    } catch {
-      return null;
-    }
-  });
+  const [profile, setProfileState] = useState<UserProfile | null>(() =>
+    parseStoredProfile(localStorage.getItem(PROFILE_KEY))
+  );
 
   // Sync across hook instances: every call to useUserProfile has its own
   // independent useState slot, so when Connect.tsx saves a profile, other
@@ -137,15 +169,7 @@ export function useUserProfile() {
   // event fired by saveProfile/clearProfile and re-read from localStorage.
   // Also listens to the native `storage` event for cross-tab sync.
   useEffect(() => {
-    const sync = () => {
-      try {
-        const raw = localStorage.getItem(PROFILE_KEY);
-        const next = raw ? (JSON.parse(raw) as UserProfile) : null;
-        setProfileState(next);
-      } catch {
-        setProfileState(null);
-      }
-    };
+    const sync = () => setProfileState(parseStoredProfile(localStorage.getItem(PROFILE_KEY)));
     const onStorage = (e: StorageEvent) => {
       if (e.key === PROFILE_KEY) sync();
     };
@@ -165,23 +189,21 @@ export function useUserProfile() {
     let cancelled = false;
     loadProfileFromDB(user.id).then((dbProfile) => {
       if (cancelled || !dbProfile) return;
-      const local = (() => {
-        try { return JSON.parse(localStorage.getItem(PROFILE_KEY) || "null"); } catch { return null; }
-      })() as UserProfile | null;
+      const local = parseStoredProfile(localStorage.getItem(PROFILE_KEY));
 
-      // If local already has Spotify taste data, it's fresher — don't overwrite it with stale DB.
+      // If local already has taste data, it's fresher — don't overwrite it with stale DB.
       // Preserve local's streamingService if set (handles Apple Music users who previously
       // had Spotify data in the same profile row).
-      if (local?.spotifyTopArtists?.length && local.spotifyArtistImages
-          && Object.keys(local.spotifyArtistImages).length > 0) {
-        // Only pull non-Spotify fields from DB (tier, lastFm) if local is missing them
+      if (local?.topArtists?.length && local.artistImages
+          && Object.keys(local.artistImages).length > 0) {
+        // Only pull non-taste fields from DB (tier, lastFm) if local is missing them
         const merged: UserProfile = {
           ...local,
           calculatedTier: local.calculatedTier || dbProfile.calculatedTier,
           lastFmUsername: local.lastFmUsername || dbProfile.lastFmUsername,
           streamingService: resolveStreamingService(
             local.streamingService,
-            local.spotifyTopArtists?.length ?? 0
+            local.topArtists?.length ?? 0
           ),
         };
         localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
@@ -189,16 +211,16 @@ export function useUserProfile() {
         return;
       }
 
-      // No local Spotify data — use DB profile (e.g. new device sign-in).
+      // No local taste data — use DB profile (e.g. new device sign-in).
       const merged: UserProfile = {
         ...dbProfile,
         streamingService: resolveStreamingService(
           dbProfile.streamingService,
-          dbProfile.spotifyTopArtists?.length ?? 0
+          dbProfile.topArtists?.length ?? 0
         ),
-        spotifyArtistImages: dbProfile.spotifyArtistImages ?? local?.spotifyArtistImages,
-        spotifyArtistIds: dbProfile.spotifyArtistIds ?? local?.spotifyArtistIds,
-        spotifyTrackImages: dbProfile.spotifyTrackImages ?? local?.spotifyTrackImages,
+        artistImages: dbProfile.artistImages ?? local?.artistImages,
+        artistIds: dbProfile.artistIds ?? local?.artistIds,
+        trackImages: dbProfile.trackImages ?? local?.trackImages,
       };
       localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
       notifyProfileUpdated();
@@ -224,12 +246,7 @@ export function useUserProfile() {
 }
 
 export function getStoredProfile(): UserProfile | null {
-  try {
-    const raw = localStorage.getItem(PROFILE_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
+  return parseStoredProfile(localStorage.getItem(PROFILE_KEY));
 }
 
 // ── Tier helpers ──────────────────────────────────────────────────────────────

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -38,7 +38,8 @@ interface TasteData {
 
 /** Legacy localStorage payload shape. Pre-rename profiles used `spotify*`
  *  prefixed keys even after Apple Music support landed. `parseStoredProfile`
- *  promotes these to the unprefixed keys on read. Drop after soak. */
+ *  promotes these to the unprefixed keys on read.
+ *  @deprecated Drop after soak — tracked in #51 P3.11. */
 interface LegacyProfileShape {
   spotifyTopArtists?: string[];
   spotifyTopTracks?: string[];

--- a/src/hooks/usePersonalizedCatalog.ts
+++ b/src/hooks/usePersonalizedCatalog.ts
@@ -40,10 +40,10 @@ interface RealArtist { name: string; imageUrl: string; tags: string[]; }
 
 function artistImageUrl(
   name: string,
-  spotifyImages?: Record<string, string>,
+  artistImages?: Record<string, string>,
   resolved?: Map<string, string>,
 ): string {
-  if (spotifyImages?.[name]) return spotifyImages[name];
+  if (artistImages?.[name]) return artistImages[name];
   const cached = resolved?.get(name) || artistImageCache.get(name);
   if (cached) return cached;
   return `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(name)}&backgroundColor=1a1a2e&textColor=ffffff&fontSize=38`;
@@ -52,10 +52,10 @@ function artistImageUrl(
 function trackCoverUrl(
   trackName: string,
   artistName: string,
-  spotifyTrackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
+  trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
 ): string {
-  if (spotifyTrackImages) {
-    const match = spotifyTrackImages.find(
+  if (trackImages) {
+    const match = trackImages.find(
       (t) =>
         t.title.toLowerCase() === trackName.toLowerCase() &&
         t.artist.toLowerCase() === artistName.toLowerCase()
@@ -87,15 +87,15 @@ function parseTrackString(t: string): { trackTitle: string; artistName: string }
 function trackTile(
   t: string,
   idPrefix: string,
-  spotifyTrackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
+  trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
 ): BrowseTile {
   const { trackTitle, artistName } = parseTrackString(t);
-  const trackInfo = spotifyTrackImages?.find(
+  const trackInfo = trackImages?.find(
     (img) => img.title.toLowerCase() === trackTitle.toLowerCase() && img.artist.toLowerCase() === artistName.toLowerCase()
   );
   return {
     id: `${idPrefix}-${t}`,
-    imageUrl: trackCoverUrl(trackTitle, artistName, spotifyTrackImages),
+    imageUrl: trackCoverUrl(trackTitle, artistName, trackImages),
     title: trackTitle,
     subtitle: artistName,
     href: realTrackHref(artistName, trackTitle, undefined, trackInfo?.uri),
@@ -123,14 +123,14 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
   // Merged top-artist list
   const topArtistNames = useMemo<string[]>(() => {
     const names: string[] = [];
-    if (profile?.spotifyTopArtists?.length) names.push(...profile.spotifyTopArtists);
+    if (profile?.topArtists?.length) names.push(...profile.topArtists);
     if (lastFmData?.topArtists?.length) {
       lastFmData.topArtists.forEach((a) => {
         if (!names.includes(a.name)) names.push(a.name);
       });
     }
     return names;
-  }, [profile?.spotifyTopArtists, lastFmData?.topArtists]);
+  }, [profile?.topArtists, lastFmData?.topArtists]);
 
   // Fetch Last.fm data
   useEffect(() => {
@@ -174,10 +174,10 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
   useEffect(() => {
     if (!profile) return;
     let cancelled = false;
-    const cachedImages = profile.spotifyArtistImages || {};
-    const cachedIds = profile.spotifyArtistIds || {};
+    const cachedImages = profile.artistImages || {};
+    const cachedIds = profile.artistIds || {};
     const artistNames = [
-      ...(profile.spotifyTopArtists || []),
+      ...(profile.topArtists || []),
       ...(lastFmData?.topArtists?.map((a) => a.name) || []),
       ...recommendations.map((a) => a.name),
     ];
@@ -235,13 +235,13 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     if (!profile) return [];
 
     const allRows: BrowseRow[] = [];
-    const spotifyTracks = profile.spotifyTopTracks || [];
-    const spotifyTrackImgs = profile.spotifyTrackImages;
-    const spotifyArtistImgs = profile.spotifyArtistImages;
+    const topTracks = profile.topTracks || [];
+    const trackImgs = profile.trackImages;
+    const artistImgs = profile.artistImages;
     // Active-service prefix for all artist links in the Browse rows.
-    // spotifyTrackImages / spotifyArtistImages are legacy-named fields
-    // populated from the active service's taste data, so "spotify" is
-    // just the default fallback when no explicit service is set.
+    // trackImages / artistImages are populated from the active service's
+    // taste data; "spotify" is just the default fallback when no explicit
+    // service is set.
     const activeService = serviceParamFromProfile(profile.streamingService);
 
     // ── 1. "Jump Back In" — recent tracks or top tracks ──────────────
@@ -249,8 +249,8 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
 
       if (lastFmData?.recentTracks?.length) {
         lastFmData.recentTracks.slice(0, 10).forEach((t) => {
-          const image = t.imageUrl || trackCoverUrl(t.name, t.artist, spotifyTrackImgs);
-          const spotifyMatch = spotifyTrackImgs?.find(
+          const image = t.imageUrl || trackCoverUrl(t.name, t.artist, trackImgs);
+          const trackMatch = trackImgs?.find(
             (img) => img.title.toLowerCase() === t.name.toLowerCase() && img.artist.toLowerCase() === t.artist.toLowerCase()
           );
           recentTiles.push({
@@ -258,13 +258,13 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
             imageUrl: image,
             title: t.name,
             subtitle: t.artist,
-            href: realTrackHref(t.artist, t.name, t.album, spotifyMatch?.uri),
+            href: realTrackHref(t.artist, t.name, t.album, trackMatch?.uri),
             isRealTrack: true,
           });
         });
-    } else if (spotifyTracks.length) {
-      spotifyTracks.slice(0, 8).forEach((t) => {
-        recentTiles.push(trackTile(t, "recent", spotifyTrackImgs));
+    } else if (topTracks.length) {
+      topTracks.slice(0, 8).forEach((t) => {
+        recentTiles.push(trackTile(t, "recent", trackImgs));
       });
     }
 
@@ -275,12 +275,12 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     // ── 2. "Your Top Artists" ────────────────────────────────────────
     if (topArtistNames.length > 0) {
       // cachedArtistIds holds catalog IDs from the active service's
-      // taste data (legacy-named spotifyArtistIds field). Falls back
-      // to the runtime-resolved map when a given name wasn't in taste.
-      const cachedArtistIds = profile.spotifyArtistIds || {};
+      // taste data. Falls back to the runtime-resolved map when a given
+      // name wasn't in taste.
+      const cachedArtistIds = profile.artistIds || {};
       const topArtistTiles: BrowseTile[] = topArtistNames.slice(0, 20).map((name) => ({
         id: `artist-${name}`,
-        imageUrl: artistImageUrl(name, spotifyArtistImgs, resolvedImages),
+        imageUrl: artistImageUrl(name, artistImgs, resolvedImages),
         title: name,
         subtitle: "Artist",
         href: artistHref(name, cachedArtistIds[name] || resolvedIds.get(name), activeService),
@@ -289,9 +289,9 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     }
 
     // ── 3. "Your Top Tracks" ─────────────────────────────────────────
-    if (spotifyTracks.length > 0) {
-      const trackTiles = spotifyTracks.slice(0, 15).map((t) =>
-        trackTile(t, "track", spotifyTrackImgs)
+    if (topTracks.length > 0) {
+      const trackTiles = topTracks.slice(0, 15).map((t) =>
+        trackTile(t, "track", trackImgs)
       );
       allRows.push({ label: "Your Top Tracks", items: trackTiles, size: "md" });
     }
@@ -300,7 +300,7 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     if (recommendations.length > 0) {
       const recTiles: BrowseTile[] = recommendations.slice(0, 15).map((a) => ({
         id: `rec-${a.name}`,
-        imageUrl: artistImageUrl(a.name, spotifyArtistImgs, resolvedImages),
+        imageUrl: artistImageUrl(a.name, artistImgs, resolvedImages),
         title: a.name,
         subtitle: a.tags.slice(0, 2).join(", ") || "Artist",
         href: artistHref(a.name, resolvedIds.get(a.name), activeService),
@@ -308,10 +308,10 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
       allRows.push({ label: "Recommended For You", items: recTiles, size: "lg" });
     }
 
-    // ── 5. "Deep Cuts" — later Spotify top tracks (positions 8–15) ───
-    if (spotifyTracks.length > 8) {
-      const deepCuts = spotifyTracks.slice(8, 15).map((t) =>
-        trackTile(t, "deep", spotifyTrackImgs)
+    // ── 5. "Deep Cuts" — later top tracks (positions 8–15) ───────────
+    if (topTracks.length > 8) {
+      const deepCuts = topTracks.slice(8, 15).map((t) =>
+        trackTile(t, "deep", trackImgs)
       );
       allRows.push({ label: "Deep Cuts", items: deepCuts, size: "sm" });
     }
@@ -337,7 +337,7 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
         if (genreArtists.length >= 3) {
           const genreTiles: BrowseTile[] = genreArtists.map((a) => ({
             id: `genre-${a.name}`,
-            imageUrl: artistImageUrl(a.name, spotifyArtistImgs, resolvedImages),
+            imageUrl: artistImageUrl(a.name, artistImgs, resolvedImages),
             title: a.name,
             subtitle: a.tags.slice(0, 2).join(", ") || "Artist",
             href: artistHref(a.name, resolvedIds.get(a.name), activeService),

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -178,11 +178,17 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // extracted storefront id rather than the whole response so the
     // diagnostic stays tight — the rest of the payload (supported
     // languages, etc.) is noise for what we're trying to diagnose.
+    //
+    // MusicKit JS v3's api.music() wraps the HTTP response as
+    // { request, response, data }, where `data` is Apple's response body:
+    // { data: Array<{ id, type, attributes }> }. So the storefront entry
+    // lives at response.data.data[0] — NOT response.data[0], which was
+    // the original shape and silently logged `{id: undefined, name: undefined}`.
     try {
       const storefront = await m.api?.music?.("v1/me/storefront") as {
-        data?: Array<{ id?: string; attributes?: { name?: string } }>;
+        data?: { data?: Array<{ id?: string; attributes?: { name?: string } }> };
       } | undefined;
-      const entry = storefront?.data?.[0];
+      const entry = storefront?.data?.data?.[0];
       console.log("[AppleMusic] /v1/me/storefront ok:", {
         id: entry?.id,
         name: entry?.attributes?.name,

--- a/src/mock/types.ts
+++ b/src/mock/types.ts
@@ -95,12 +95,12 @@ export interface UserProfile {
   /** Service-agnostic display name (populated from Spotify or user input for Apple Music) */
   displayName?: string;
   spotifyDisplayName?: string;    // e.g. "Peter Rango" — from Spotify OAuth
-  // Spotify taste profile — populated after OAuth, stored as serialised top artists/tracks
-  spotifyTopArtists?: string[];   // e.g. ["Radiohead", "Björk", "Portishead"]
-  spotifyTopTracks?: string[];    // e.g. ["Karma Police", "Hyperballad"]
-  // Spotify image maps — artist name → image URL, track "title — artist" → album art URL
-  spotifyArtistImages?: Record<string, string>;
-  spotifyArtistIds?: Record<string, string>;   // artist name → Spotify artist ID
-  spotifyTrackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[];
+  // Service-agnostic taste profile — populated from the active streaming service
+  topArtists?: string[];          // e.g. ["Radiohead", "Björk", "Portishead"]
+  topTracks?: string[];           // e.g. ["Karma Police", "Hyperballad"]
+  // Image maps — artist name → image URL, track "title — artist" → album art URL
+  artistImages?: Record<string, string>;
+  artistIds?: Record<string, string>;   // artist name → service-specific artist ID
+  trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[];
   calculatedTier: "casual" | "curious" | "nerd";
 }

--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -62,16 +62,16 @@ export default function Companion() {
     if (realTrackMeta) {
       // Try to get cover art: cached from companion data > profile > DiceBear fallback
       let coverArtUrl = data?.coverArtUrl || "";
-      if (!coverArtUrl && profile?.spotifyTrackImages) {
-        const match = profile.spotifyTrackImages.find(
+      if (!coverArtUrl && profile?.trackImages) {
+        const match = profile.trackImages.find(
           (t) =>
             t.title.toLowerCase() === realTrackMeta.title.toLowerCase() &&
             t.artist.toLowerCase() === realTrackMeta.artist.toLowerCase()
         );
         if (match?.imageUrl) coverArtUrl = match.imageUrl;
       }
-      if (!coverArtUrl && profile?.spotifyArtistImages?.[realTrackMeta.artist]) {
-        coverArtUrl = profile.spotifyArtistImages[realTrackMeta.artist];
+      if (!coverArtUrl && profile?.artistImages?.[realTrackMeta.artist]) {
+        coverArtUrl = profile.artistImages[realTrackMeta.artist];
       }
       if (!coverArtUrl) {
         coverArtUrl = `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(realTrackMeta.artist + realTrackMeta.title)}&backgroundColor=111827&textColor=ffffff&fontSize=30`;
@@ -84,10 +84,10 @@ export default function Companion() {
       };
     }
     return null;
-  }, [realTrackMeta, data?.coverArtUrl, profile?.spotifyTrackImages, profile?.spotifyArtistImages]);
+  }, [realTrackMeta, data?.coverArtUrl, profile?.trackImages, profile?.artistImages]);
 
   const artistName = trackInfo?.artist || "";
-  const artistFallbackImage = data?.artistImage || profile?.spotifyArtistImages?.[artistName] || "";
+  const artistFallbackImage = data?.artistImage || profile?.artistImages?.[artistName] || "";
   const artistImage = useArtistImage(artistName, artistFallbackImage);
 
   const artistGenres: string[] = [];

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -166,11 +166,11 @@ export default function Connect() {
     const profile: UserProfile = {
       streamingService,
       spotifyDisplayName: pendingDisplayName || undefined,
-      spotifyTopArtists: pendingSpotifyArtists || undefined,
-      spotifyTopTracks: pendingSpotifyTracks || undefined,
-      spotifyArtistImages: Object.keys(pendingArtistImages).length ? pendingArtistImages : undefined,
-      spotifyArtistIds: Object.keys(pendingArtistIds).length ? pendingArtistIds : undefined,
-      spotifyTrackImages: pendingTrackImages.length ? pendingTrackImages : undefined,
+      topArtists: pendingSpotifyArtists || undefined,
+      topTracks: pendingSpotifyTracks || undefined,
+      artistImages: Object.keys(pendingArtistImages).length ? pendingArtistImages : undefined,
+      artistIds: Object.keys(pendingArtistIds).length ? pendingArtistIds : undefined,
+      trackImages: pendingTrackImages.length ? pendingTrackImages : undefined,
       lastFmUsername: lastFmUsername.trim() || undefined,
       calculatedTier: t,
     };

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -37,8 +37,8 @@ export default function Connect() {
   const [direction, setDirection] = useState(1);
   const [spotifyConnecting, setSpotifyConnecting] = useState(false);
   const [spotifyConnected, setSpotifyConnected] = useState(false);
-  const [pendingSpotifyArtists, setPendingSpotifyArtists] = useState<string[] | null>(null);
-  const [pendingSpotifyTracks, setPendingSpotifyTracks] = useState<string[] | null>(null);
+  const [pendingTopArtists, setPendingTopArtists] = useState<string[] | null>(null);
+  const [pendingTopTracks, setPendingTopTracks] = useState<string[] | null>(null);
   const [pendingArtistImages, setPendingArtistImages] = useState<Record<string, string>>({});
   const [pendingArtistIds, setPendingArtistIds] = useState<Record<string, string>>({});
   const [pendingTrackImages, setPendingTrackImages] = useState<{ title: string; artist: string; imageUrl: string; uri?: string }[]>([]);
@@ -77,8 +77,8 @@ export default function Connect() {
       try {
         const { displayName, topArtists, topTracks, artistImages, artistIds, trackImages } = JSON.parse(raw);
         setSpotifyConnected(true);
-        setPendingSpotifyArtists(topArtists);
-        setPendingSpotifyTracks(topTracks);
+        setPendingTopArtists(topArtists);
+        setPendingTopTracks(topTracks);
         if (displayName) setPendingDisplayName(displayName);
         if (artistImages) setPendingArtistImages(artistImages);
         if (artistIds) setPendingArtistIds(artistIds);
@@ -113,19 +113,16 @@ export default function Connect() {
       if (musicUserToken) {
         setAppleMusicConnected(true);
 
-        // Fetch the user's Apple Music taste profile via the apple-taste
-        // edge function. Stored under the same pending* state Spotify
-        // uses — the legacy field names (pendingSpotifyArtists etc.)
-        // carry the active service's taste data. A null return means
-        // Apple returned an error, the MUT is invalid, or the user has
-        // no listening history yet. In all cases we proceed to the
-        // tier picker rather than blocking onboarding — but we set a
-        // warning state so the user sees an inline note explaining why
-        // Browse will show only demo tracks on first load.
+        // Fetch the user's Apple Music taste profile. Both services
+        // populate the same pending* state. A null return means Apple
+        // returned an error, the MUT is invalid, or the user has no
+        // listening history yet — in all cases we proceed to the tier
+        // picker rather than blocking onboarding, but set a warning
+        // state so the user understands why Browse starts sparse.
         const taste = await fetchAppleMusicTaste(musicUserToken);
         if (taste) {
-          setPendingSpotifyArtists(taste.topArtists);
-          setPendingSpotifyTracks(taste.topTracks);
+          setPendingTopArtists(taste.topArtists);
+          setPendingTopTracks(taste.topTracks);
           if (taste.displayName) setPendingDisplayName(taste.displayName);
           setPendingArtistImages(taste.artistImages);
           setPendingArtistIds(taste.artistIds);
@@ -166,8 +163,8 @@ export default function Connect() {
     const profile: UserProfile = {
       streamingService,
       spotifyDisplayName: pendingDisplayName || undefined,
-      topArtists: pendingSpotifyArtists || undefined,
-      topTracks: pendingSpotifyTracks || undefined,
+      topArtists: pendingTopArtists || undefined,
+      topTracks: pendingTopTracks || undefined,
       artistImages: Object.keys(pendingArtistImages).length ? pendingArtistImages : undefined,
       artistIds: Object.keys(pendingArtistIds).length ? pendingArtistIds : undefined,
       trackImages: pendingTrackImages.length ? pendingTrackImages : undefined,
@@ -215,7 +212,7 @@ export default function Connect() {
                   <div className="flex flex-col gap-3 w-full">
 
                     {/* Spotify — connect or show connected */}
-                    {!pendingSpotifyArtists ? (
+                    {!pendingTopArtists ? (
                       <button onClick={handleConnectSpotify} disabled={spotifyConnecting} className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground transition-all duration-200 disabled:opacity-70 border-green-500/40 hover:border-green-500 hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]">
                         <img src={spotifyLogo} alt="Spotify" className="w-8 h-8 object-contain" />
                         <span className="flex-1">Spotify</span>
@@ -226,7 +223,7 @@ export default function Connect() {
                         <img src={spotifyLogo} alt="Spotify" className="w-8 h-8 object-contain" />
                         <div className="flex-1 min-w-0">
                           <p>Spotify</p>
-                          <p className="text-xs font-normal text-green-400 truncate">Connected · {pendingSpotifyArtists.slice(0, 3).join(", ")}{pendingSpotifyArtists.length > 3 ? "..." : ""}</p>
+                          <p className="text-xs font-normal text-green-400 truncate">Connected · {pendingTopArtists.slice(0, 3).join(", ")}{pendingTopArtists.length > 3 ? "..." : ""}</p>
                         </div>
                         <span className="text-xs font-semibold text-green-400">✓</span>
                       </div>

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -82,16 +82,16 @@ export default function Listen() {
     if (!realTrackMeta) return null;
     // Try URL query param first (demo tiles pass ?art=), then profile, then DiceBear
     let coverArtUrl = urlArt;
-    if (!coverArtUrl && profile?.spotifyTrackImages) {
-      const match = profile.spotifyTrackImages.find(
+    if (!coverArtUrl && profile?.trackImages) {
+      const match = profile.trackImages.find(
         (t) =>
           t.title.toLowerCase() === realTrackMeta.title.toLowerCase() &&
           t.artist.toLowerCase() === realTrackMeta.artist.toLowerCase()
       );
       if (match?.imageUrl) coverArtUrl = match.imageUrl;
     }
-    if (!coverArtUrl && profile?.spotifyArtistImages?.[realTrackMeta.artist]) {
-      coverArtUrl = profile.spotifyArtistImages[realTrackMeta.artist];
+    if (!coverArtUrl && profile?.artistImages?.[realTrackMeta.artist]) {
+      coverArtUrl = profile.artistImages[realTrackMeta.artist];
     }
     if (!coverArtUrl) {
       coverArtUrl = `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(realTrackMeta.artist + realTrackMeta.title)}&backgroundColor=111827&textColor=ffffff&fontSize=30`;
@@ -107,7 +107,7 @@ export default function Listen() {
       coverArtUrl,
       trackNumber: 1,
     };
-  }, [realTrackMeta, trackId, urlArt, profile?.spotifyTrackImages, profile?.spotifyArtistImages]);
+  }, [realTrackMeta, trackId, urlArt, profile?.trackImages, profile?.artistImages]);
 
   // ── Playback source resolution ───────────────────────────────────────
   const { hasSpotifyToken } = useSpotifyToken();
@@ -351,7 +351,7 @@ export default function Listen() {
             (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
           );
           if (recs.length > 0) {
-            const topArtists = new Set((profile?.spotifyTopArtists || []).map((a: string) => a.toLowerCase()));
+            const topArtists = new Set((profile?.topArtists || []).map((a: string) => a.toLowerCase()));
             const boosted = recs.filter((t) => topArtists.has(t.artist.toLowerCase()));
             const pool = boosted.length > 0 ? boosted : recs;
             navigateTo(pool[Math.floor(Math.random() * Math.min(pool.length, 3))]);
@@ -380,13 +380,13 @@ export default function Listen() {
       }
 
       // P4: User's catalog (prefer different artist, relax if needed).
-      // spotifyTrackImages is legacy-named but populated from the active
-      // service's taste data (Spotify or Apple via apple-taste).
-      const userTracks = (profile?.spotifyTrackImages || []).filter(
+      // trackImages is populated from the active service's taste data
+      // (Spotify or Apple via apple-taste).
+      const userTracks = (profile?.trackImages || []).filter(
         (t) => t.uri && notPlayed(t.artist, t.title) && t.artist.toLowerCase() !== artistLower
       );
       const relaxed = userTracks.length > 0 ? userTracks
-        : (profile?.spotifyTrackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
+        : (profile?.trackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
       if (relaxed.length > 0) {
         const pick = relaxed[Math.floor(Math.random() * relaxed.length)];
         navigateTo({ artist: pick.artist, title: pick.title, album: "", uri: pick.uri });
@@ -601,7 +601,7 @@ export default function Listen() {
   // AI-generated nuggets with real sources
   const tier = (profile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
   useTierAccent(tier);
-  const artistImageUrl = (track?.artist && profile?.spotifyArtistImages?.[track.artist]) || track?.coverArtUrl || "";
+  const artistImageUrl = (track?.artist && profile?.artistImages?.[track.artist]) || track?.coverArtUrl || "";
   const { nuggets: aiNuggets, sources: aiSources, loading: aiLoading, error: aiError, listenCount, artistSummary, fromCache: aiFromCache } = useAINuggets(
     trackId,
     track?.artist || "",
@@ -612,8 +612,8 @@ export default function Listen() {
     track?.coverArtUrl,
     artistImageUrl,
     tier,
-    profile?.spotifyTopArtists,
-    profile?.spotifyTopTracks
+    profile?.topArtists,
+    profile?.topTracks
   );
 
   // Log AI nugget errors for debugging

--- a/src/pages/SpotifyCallback.tsx
+++ b/src/pages/SpotifyCallback.tsx
@@ -67,11 +67,11 @@ export default function SpotifyCallback() {
           ...profile,
           streamingService: "Spotify",
           spotifyDisplayName: taste.displayName || profile.spotifyDisplayName,
-          spotifyTopArtists: taste.topArtists,
-          spotifyTopTracks: taste.topTracks,
-          spotifyArtistImages: taste.artistImages,
-          spotifyArtistIds: taste.artistIds,
-          spotifyTrackImages: taste.trackImages,
+          topArtists: taste.topArtists,
+          topTracks: taste.topTracks,
+          artistImages: taste.artistImages,
+          artistIds: taste.artistIds,
+          trackImages: taste.trackImages,
         });
       }
       // If no profile exists yet (direct OAuth before setup), store data in sessionStorage

--- a/src/test/resolveStreamingService.test.ts
+++ b/src/test/resolveStreamingService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { resolveStreamingService } from "@/hooks/useMusicNerdState";
 
 // Regression: useMusicNerdState previously force-set streamingService="Spotify"
-// whenever dbProfile.spotifyTopArtists existed, even for Apple Music users.
+// whenever dbProfile.topArtists existed, even for Apple Music users.
 // This silently downgraded Apple Music users whose row still had legacy
 // Spotify taste data. The new logic prefers the explicit service when set.
 
@@ -13,20 +13,20 @@ describe("resolveStreamingService", () => {
     expect(resolveStreamingService("YouTube Music", 20)).toBe("YouTube Music");
   });
 
-  it("preserves Apple Music even when spotifyTopArtists is populated (the bug fix)", () => {
+  it("preserves Apple Music even when topArtists is populated (the bug fix)", () => {
     // Scenario: user first connected Spotify, later switched to Apple Music.
     // Their DB row still has spotify_taste. The old logic clobbered service
     // back to "Spotify" on the next DB load — this test locks that invariant.
     expect(resolveStreamingService("Apple Music", 20)).toBe("Apple Music");
   });
 
-  it("falls back to Spotify when service is unset but spotifyTopArtists is populated", () => {
+  it("falls back to Spotify when service is unset but topArtists is populated", () => {
     // Legacy rows from before streaming_service was persisted
     expect(resolveStreamingService(undefined, 15)).toBe("Spotify");
     expect(resolveStreamingService("", 15)).toBe("Spotify");
   });
 
-  it("returns empty string when service is unset and no spotifyTopArtists", () => {
+  it("returns empty string when service is unset and no topArtists", () => {
     expect(resolveStreamingService(undefined, 0)).toBe("");
     expect(resolveStreamingService("", 0)).toBe("");
   });

--- a/src/test/useUserProfile.test.ts
+++ b/src/test/useUserProfile.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/integrations/supabase/client", () => ({
   },
 }));
 
-import { useUserProfile } from "@/hooks/useMusicNerdState";
+import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import type { UserProfile } from "@/mock/types";
 
 const PROFILE_KEY = "musicnerd_profile";
@@ -104,5 +104,52 @@ describe("useUserProfile cross-instance sync", () => {
     // Apple Music playback: PlayerProvider needs to see the new service
     // to create the correct engine.
     expect(b.current.profile?.streamingService).toBe("Apple Music");
+  });
+});
+
+// Locks the localStorage read-compat that lets profiles written before the
+// spotify* → unprefixed rename (tracked in #51 P3.11) keep working. Drop
+// these tests when the compat shim is removed after soak.
+describe("getStoredProfile legacy-key migration", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("promotes all five legacy spotify* keys to their unprefixed counterparts", () => {
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Apple Music",
+      calculatedTier: "nerd",
+      spotifyTopArtists: ["Radiohead"],
+      spotifyTopTracks: ["Karma Police"],
+      spotifyArtistImages: { Radiohead: "radiohead.jpg" },
+      spotifyArtistIds: { Radiohead: "sp-1" },
+      spotifyTrackImages: [{ title: "Karma Police", artist: "Radiohead", imageUrl: "kp.jpg" }],
+    }));
+
+    const profile = getStoredProfile();
+    expect(profile?.topArtists).toEqual(["Radiohead"]);
+    expect(profile?.topTracks).toEqual(["Karma Police"]);
+    expect(profile?.artistImages).toEqual({ Radiohead: "radiohead.jpg" });
+    expect(profile?.artistIds).toEqual({ Radiohead: "sp-1" });
+    expect(profile?.trackImages).toEqual([{ title: "Karma Police", artist: "Radiohead", imageUrl: "kp.jpg" }]);
+    // Legacy keys are dropped from the in-memory profile
+    expect((profile as Record<string, unknown>)?.spotifyTopArtists).toBeUndefined();
+  });
+
+  it("prefers new keys when both legacy and new are present", () => {
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Spotify",
+      calculatedTier: "casual",
+      topArtists: ["Björk"],
+      spotifyTopArtists: ["Radiohead"],
+    }));
+
+    const profile = getStoredProfile();
+    expect(profile?.topArtists).toEqual(["Björk"]);
+  });
+
+  it("returns null for missing or malformed payload", () => {
+    expect(getStoredProfile()).toBeNull();
+
+    localStorage.setItem(PROFILE_KEY, "{not valid json");
+    expect(getStoredProfile()).toBeNull();
   });
 });

--- a/src/test/useUserProfile.test.ts
+++ b/src/test/useUserProfile.test.ts
@@ -146,6 +146,22 @@ describe("getStoredProfile legacy-key migration", () => {
     expect(profile?.topArtists).toEqual(["Björk"]);
   });
 
+  it("promotes a partial legacy profile, leaving absent fields undefined", () => {
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Apple Music",
+      calculatedTier: "casual",
+      spotifyTopArtists: ["Beach House"],
+      // no topTracks, no image maps, no artist ids
+    }));
+
+    const profile = getStoredProfile();
+    expect(profile?.topArtists).toEqual(["Beach House"]);
+    expect(profile?.topTracks).toBeUndefined();
+    expect(profile?.artistImages).toBeUndefined();
+    expect(profile?.artistIds).toBeUndefined();
+    expect(profile?.trackImages).toBeUndefined();
+  });
+
   it("returns null for missing or malformed payload", () => {
     expect(getStoredProfile()).toBeNull();
 


### PR DESCRIPTION
## Summary
- Rename the five `UserProfile` taste fields that were labelled `spotify*` despite being populated from the active streaming service (Spotify or Apple Music). The prefix was leftover from the single-service era and was silently misleading readers of `usePersonalizedCatalog`, `Listen.tsx`, and `Companion.tsx`.
- Add a one-shot localStorage read-compat layer (`parseStoredProfile`) so existing users don't lose their taste data on this deploy. Legacy keys are promoted to the unprefixed names on read; writes only emit the new names. The compat can be dropped after soak.
- Also fixes a long-standing diagnostic log bug in `AppleMusicPlaybackEngine.logSubscriptionStatus`: MusicKit JS v3's `api.music()` wraps the body as `{request, response, data}`, so `/v1/me/storefront` data lives at `data.data[0]` rather than `data[0]`. The old code silently logged `{id: undefined, name: undefined}`; verified live in dev that it now prints `{id: us, name: United States}`.

## Scope

**Renamed (5 fields):**
| Old | New |
|---|---|
| `spotifyTopArtists` | `topArtists` |
| `spotifyTopTracks` | `topTracks` |
| `spotifyArtistImages` | `artistImages` |
| `spotifyArtistIds` | `artistIds` |
| `spotifyTrackImages` | `trackImages` |

**Kept as-is:** `spotifyDisplayName` (genuinely from Spotify OAuth; parallel service-agnostic `displayName` already exists).

**Files touched (11):** `src/mock/types.ts` (type def), `src/hooks/useMusicNerdState.ts` (load/save/merge + compat), `src/hooks/usePersonalizedCatalog.ts`, `src/pages/{Connect,Listen,Companion,SpotifyCallback}.tsx`, `src/lib/engines/AppleMusicPlaybackEngine.ts` (log-shape fix), `src/test/{resolveStreamingService,useUserProfile}.test.ts`, `Dev.md`.

## Persistence

- **DB:** no migration. `TasteData` JSONB in `music_taste`/`spotify_taste` already used unprefixed names — the rename only flattens the in-memory mapping back to match.
- **localStorage:** existing profile payloads still carry the old keys. `parseStoredProfile` maps them on read and writes drop them. Tests lock this contract.

## Test plan

- [x] `npm test` — 205 passing (added 3 for the legacy-key migration contract)
- [x] `npm run build` — clean
- [x] Dev-browser smoke: connected Apple Music, `/browse` renders all 7 taste-driven rows (Jump Back In / Your Top Artists / Your Top Tracks / Recommended For You / Deep Cuts / More Electronic / Demo Tracks)
- [x] Live diagnostic verified: `[AppleMusic] /v1/me/storefront ok: {id: us, name: United States}` now prints correctly

## Related

- #51 P3.11 (this PR)
- #51 P1.2 — the diagnostic log fix is the small slice of P1.2 that was a real bug. The 30s-preview part of P1.2 is a browser DRM limitation (no Widevine/FairPlay in automation contexts), not an app issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)