### PR TITLE
refactor: drop legacy spotify_taste column from profiles

### DIFF
--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -85,11 +85,8 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   const service = (data.streaming_service as UserProfile["streamingService"]) || "";
   const serviceKey = service === "Spotify" ? "spotify" : service === "Apple Music" ? "apple" : null;
 
-  // Read taste from music_taste (new, keyed by service) → fall back to spotify_taste (legacy)
   const musicTaste = data.music_taste as Record<string, TasteData> | null;
-  const taste: TasteData | null =
-    (serviceKey && musicTaste?.[serviceKey]) ||
-    (data.spotify_taste as TasteData | null);
+  const taste: TasteData | null = serviceKey ? (musicTaste?.[serviceKey] ?? null) : null;
 
   return {
     streamingService: service,
@@ -125,7 +122,6 @@ export function resolveStreamingService(
 }
 
 async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
-  // Build taste data from profile fields
   const tasteData: TasteData | null =
     p.topArtists || p.topTracks
       ? {
@@ -137,18 +133,15 @@ async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
         }
       : null;
 
-  // Determine service key for music_taste JSONB
   const serviceKey = p.streamingService === "Spotify" ? "spotify"
     : p.streamingService === "Apple Music" ? "apple" : null;
 
-  // Dual-write: spotify_taste (legacy) + music_taste (new, keyed by service)
   await supabase.from("profiles").upsert(
     {
       user_id: userId,
       tier: p.calculatedTier,
       streaming_service: p.streamingService,
       last_fm_username: p.lastFmUsername || null,
-      spotify_taste: tasteData,
       music_taste: serviceKey && tasteData ? { [serviceKey]: tasteData } : null,
     },
     { onConflict: "user_id" }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -154,7 +154,7 @@ export type Database = {
           created_at: string
           id: string
           last_fm_username: string | null
-          spotify_taste: Json | null
+          music_taste: Json | null
           streaming_service: string | null
           tier: string
           updated_at: string
@@ -164,7 +164,7 @@ export type Database = {
           created_at?: string
           id?: string
           last_fm_username?: string | null
-          spotify_taste?: Json | null
+          music_taste?: Json | null
           streaming_service?: string | null
           tier?: string
           updated_at?: string
@@ -174,7 +174,7 @@ export type Database = {
           created_at?: string
           id?: string
           last_fm_username?: string | null
-          spotify_taste?: Json | null
+          music_taste?: Json | null
           streaming_service?: string | null
           tier?: string
           updated_at?: string

--- a/src/test/resolveStreamingService.test.ts
+++ b/src/test/resolveStreamingService.test.ts
@@ -15,8 +15,9 @@ describe("resolveStreamingService", () => {
 
   it("preserves Apple Music even when topArtists is populated (the bug fix)", () => {
     // Scenario: user first connected Spotify, later switched to Apple Music.
-    // Their DB row still has spotify_taste. The old logic clobbered service
-    // back to "Spotify" on the next DB load — this test locks that invariant.
+    // Their row still carries Spotify-origin topArtists. The old logic
+    // clobbered service back to "Spotify" on the next DB load — this test
+    // locks that invariant.
     expect(resolveStreamingService("Apple Music", 20)).toBe("Apple Music");
   });
 

--- a/supabase/migrations/20260416213446_drop_spotify_taste_from_profiles.sql
+++ b/supabase/migrations/20260416213446_drop_spotify_taste_from_profiles.sql
@@ -1,0 +1,8 @@
+-- Drop the legacy spotify_taste column from profiles.
+-- The dual-write pattern (spotify_taste + music_taste) shipped in
+-- 20260408200000_apple_music_support.sql. music_taste is now the sole
+-- source of truth for taste data, keyed by service ("spotify", "apple").
+-- The live DB has 0 rows at drop time — no data loss.
+
+ALTER TABLE public.profiles
+  DROP COLUMN IF EXISTS spotify_taste;


### PR DESCRIPTION
## Summary

- Drops the `spotify_taste` column from `profiles`. `music_taste` (shipped in PR #30 on 2026-04-10) has been the service-keyed source of truth ever since; this PR removes the dual-write + legacy-fallback paths that were left in place for soak.
- Also syncs `src/integrations/supabase/types.ts` — PR #30 added `music_taste` to the DB and the hook but never regenerated the checked-in types. This PR replaces `spotify_taste` with `music_taste` in Row/Insert/Update so the types match what the schema will be post-migration.

## Scope

**New migration:** `supabase/migrations/20260416213446_drop_spotify_taste_from_profiles.sql` — one `ALTER TABLE … DROP COLUMN IF EXISTS spotify_taste`.

**`src/hooks/useMusicNerdState.ts`:**
- `saveProfileToDB` — drop the `spotify_taste: tasteData` upsert line + the "Dual-write" comment
- `loadProfileFromDB` — drop the `|| (data.spotify_taste as TasteData | null)` fallback; simplifies to `serviceKey ? (musicTaste?.[serviceKey] ?? null) : null`

**`src/integrations/supabase/types.ts`:** 3 generated entries (Row/Insert/Update) have `spotify_taste` replaced by `music_taste`.

**`src/test/resolveStreamingService.test.ts`:** one scenario comment reworded (used `spotify_taste` as an active concept).

## Safety

- `profiles` has **0 rows** on `tvdb` at drop time — no data to lose.
- **Code-first, migration-second** ordering: the new code never writes `spotify_taste`, so it runs cleanly against either schema state. The migration can apply whenever the deploy pipeline runs it.

## Test plan

- [x] `npm test` — 206 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

## Related

- P3.12 in #51
- Follows PR #30 (introduced `music_taste`) and PR #65 (field rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)