### PR TITLE
test: ArtistProfile + AlbumDetail catalog-routing tests (P3.8)

### DIFF
--- a/src/test/AlbumDetail.apple.test.tsx
+++ b/src/test/AlbumDetail.apple.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
 // Mock supabase BEFORE importing AlbumDetail so the component picks up
@@ -33,7 +33,7 @@ function fakeAlbumResponse(id: string, name: string, artistId: string, artistNam
       tracks: [],
     },
     error: null,
-  } as unknown as ReturnType<typeof supabase.functions.invoke> extends Promise<infer R> ? R : never;
+  } as any;
 }
 
 function renderAt(path: string) {
@@ -94,7 +94,9 @@ describe("AlbumDetail catalog routing", () => {
   it("bare apple:: with empty album id short-circuits before the edge call", async () => {
     renderAt("/album/apple::");
 
-    await new Promise((r) => setTimeout(r, 10));
+    // Drain pending microtasks/effects deterministically instead of a
+    // timer-based wait, which can race on slow CI runners.
+    await act(async () => {});
     expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/src/test/AlbumDetail.apple.test.tsx
+++ b/src/test/AlbumDetail.apple.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+// Mock supabase BEFORE importing AlbumDetail so the component picks up
+// the mocked client. AlbumDetail does not use useUserProfile or
+// useArtistImage, so the mock surface is even smaller than ArtistProfile.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: { invoke: vi.fn() },
+  },
+}));
+
+import AlbumDetail from "@/pages/AlbumDetail";
+import { supabase } from "@/integrations/supabase/client";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+function fakeAlbumResponse(id: string, name: string, artistId: string, artistName: string) {
+  return {
+    data: {
+      found: true,
+      album: {
+        id,
+        name,
+        imageUrl: "",
+        releaseDate: "1997-05-21",
+        albumType: "album",
+        totalTracks: 12,
+        artist: { id: artistId, name: artistName },
+        label: "",
+      },
+      tracks: [],
+    },
+    error: null,
+  } as unknown as ReturnType<typeof supabase.functions.invoke> extends Promise<infer R> ? R : never;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/album/:albumId" element={<AlbumDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("MusicKit", { getInstance: () => ({ storefrontCountryCode: "us" }) });
+  invoke.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Locks the apple::/spotify:: prefix routing to their respective
+// `service` param in the spotify-album edge-function call. The
+// service param is what the backend branches on — getting it wrong
+// silently fetches from the wrong catalog.
+
+describe("AlbumDetail catalog routing", () => {
+  it("apple:: prefix invokes spotify-album with service='apple' + storefront", async () => {
+    invoke.mockResolvedValueOnce(fakeAlbumResponse("987654321", "OK Computer", "123456789", "Radiohead"));
+
+    renderAt("/album/apple::987654321::Radiohead::123456789");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-album", {
+      body: {
+        albumId: "987654321",
+        service: "apple",
+        storefront: "us",
+      },
+    });
+  });
+
+  it("spotify:: prefix invokes spotify-album with service='spotify' (no storefront)", async () => {
+    invoke.mockResolvedValueOnce(
+      fakeAlbumResponse("6dVIqQ8qmQ5GBnJ9shOYGE", "OK Computer", "4Z8W4fKeB5YxbusRsdQVPb", "Radiohead"),
+    );
+
+    renderAt("/album/spotify::6dVIqQ8qmQ5GBnJ9shOYGE::Radiohead::4Z8W4fKeB5YxbusRsdQVPb");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-album", {
+      body: {
+        albumId: "6dVIqQ8qmQ5GBnJ9shOYGE",
+        service: "spotify",
+      },
+    });
+  });
+
+  it("bare apple:: with empty album id short-circuits before the edge call", async () => {
+    renderAt("/album/apple::");
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/ArtistProfile.apple.test.tsx
+++ b/src/test/ArtistProfile.apple.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+// Mock supabase BEFORE importing ArtistProfile so the component picks up
+// the mocked client. Also mock useUserProfile + useArtistImage to keep
+// the test surface narrow — routing + edge-function invocation only.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: { invoke: vi.fn() },
+  },
+}));
+vi.mock("@/hooks/useMusicNerdState", () => ({
+  useUserProfile: () => ({ profile: null, saveProfile: vi.fn(), clearProfile: vi.fn() }),
+}));
+vi.mock("@/hooks/useArtistImage", () => ({
+  useArtistImage: () => null,
+}));
+
+import ArtistProfile from "@/pages/ArtistProfile";
+import { supabase } from "@/integrations/supabase/client";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+function fakeArtistResponse(id: string, name: string) {
+  return {
+    data: {
+      found: true,
+      artist: { id, name, imageUrl: "", genres: [], followers: 0 },
+      topTracks: [],
+      albums: [],
+      relatedArtists: [],
+    },
+    error: null,
+  } as unknown as ReturnType<typeof supabase.functions.invoke> extends Promise<infer R> ? R : never;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/artist/:artistId" element={<ArtistProfile />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("MusicKit", { getInstance: () => ({ storefrontCountryCode: "us" }) });
+  invoke.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Locks the apple::/spotify:: prefix routing to their respective
+// `service` param in the spotify-artist edge-function call.
+// Without this test, a regression that drops the service param (or
+// flips the two) would silently send Apple users to the Spotify
+// catalog — manifesting as wrong artist data or a 404, not a build
+// error.
+
+describe("ArtistProfile catalog routing", () => {
+  it("apple:: prefix invokes spotify-artist with service='apple' + storefront", async () => {
+    invoke.mockResolvedValueOnce(fakeArtistResponse("123456789", "Radiohead"));
+
+    renderAt("/artist/apple::123456789::Radiohead");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-artist", {
+      body: {
+        service: "apple",
+        artistId: "123456789",
+        storefront: "us",
+      },
+    });
+  });
+
+  it("spotify:: prefix invokes spotify-artist with service='spotify' (no storefront)", async () => {
+    invoke.mockResolvedValueOnce(fakeArtistResponse("4Z8W4fKeB5YxbusRsdQVPb", "Radiohead"));
+
+    renderAt("/artist/spotify::4Z8W4fKeB5YxbusRsdQVPb::Radiohead");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-artist", {
+      body: {
+        service: "spotify",
+        artistId: "4Z8W4fKeB5YxbusRsdQVPb",
+      },
+    });
+  });
+
+  it("falls back to artistName when no catalog id is in the route (bare apple:: with empty id)", async () => {
+    // apple:: with an empty id bucket returns null from parseAppleArtist,
+    // so neither the apple nor spotify branch renders. Confirms the
+    // parse-null path short-circuits the edge function call entirely.
+    renderAt("/artist/apple::");
+
+    // No time for the effect to fire — useEffect runs synchronously in
+    // the next tick; waitFor gives it a chance before we assert silence.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/ArtistProfile.apple.test.tsx
+++ b/src/test/ArtistProfile.apple.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, act } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 
 // Mock supabase BEFORE importing ArtistProfile so the component picks up
@@ -32,7 +32,7 @@ function fakeArtistResponse(id: string, name: string) {
       relatedArtists: [],
     },
     error: null,
-  } as unknown as ReturnType<typeof supabase.functions.invoke> extends Promise<infer R> ? R : never;
+  } as any;
 }
 
 function renderAt(path: string) {
@@ -90,15 +90,15 @@ describe("ArtistProfile catalog routing", () => {
     });
   });
 
-  it("falls back to artistName when no catalog id is in the route (bare apple:: with empty id)", async () => {
-    // apple:: with an empty id bucket returns null from parseAppleArtist,
-    // so neither the apple nor spotify branch renders. Confirms the
-    // parse-null path short-circuits the edge function call entirely.
+  it("bare apple:: with empty id short-circuits before the edge call", async () => {
+    // parseAppleArtist returns null for an empty id bucket, so neither
+    // the apple nor spotify branch renders RealArtistProfile — the
+    // edge function must not fire at all.
     renderAt("/artist/apple::");
 
-    // No time for the effect to fire — useEffect runs synchronously in
-    // the next tick; waitFor gives it a chance before we assert silence.
-    await new Promise((r) => setTimeout(r, 10));
+    // Drain pending microtasks/effects deterministically instead of a
+    // timer-based wait, which can race on slow CI runners.
+    await act(async () => {});
     expect(invoke).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Adds component-level tests covering the `apple::` / `spotify::` prefix routing in both page components. Locks the `service` param that each page passes to the `spotify-artist` / `spotify-album` edge functions — the single field the backend branches on to pick Spotify vs Apple Music catalog.

## Scope

Two new test files, no runtime changes:

- `src/test/ArtistProfile.apple.test.tsx` — 3 tests
- `src/test/AlbumDetail.apple.test.tsx` — 3 tests

Each page is mounted inside a `MemoryRouter` with a synthetic `apple::` or `spotify::` path. `supabase.functions.invoke` is a `vi.fn()`, and `withAppleStorefront`'s `MusicKit` lookup is stubbed to `"us"` so the storefront attachment is observable on the Apple branch.

## Coverage

**ArtistProfile** (`src/test/ArtistProfile.apple.test.tsx`):
- `apple::ID::Name` → `invoke("spotify-artist", { body: { service: "apple", artistId, storefront: "us" } })`
- `spotify::ID::Name` → `invoke("spotify-artist", { body: { service: "spotify", artistId } })` (no storefront)
- Bare `apple::` with empty id → parse-null, invoke never fires

**AlbumDetail** (`src/test/AlbumDetail.apple.test.tsx`):
- `apple::albumId::artist::artistAppleId` → `invoke("spotify-album", { body: { albumId, service: "apple", storefront: "us" } })`
- `spotify::albumId::artist::artistSpotifyId` → `invoke("spotify-album", { body: { albumId, service: "spotify" } })`
- Bare `apple::` with empty id → parse-null short-circuits

## Why it matters

A regression that drops the `service` param or flips the two prefixes would silently send Apple users to the Spotify catalog. Wrong-catalog responses manifest as bad artist data or a 404, not a build error — invisible until a user reports it. These tests catch that class of regression at CI time.

## Test plan

- [x] `npm test` — 230 passing (+6)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

## Related

- P3.8 in #51 — this is the last Active item; after this PR merges #51 has only Deferred items left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)