### PR TITLE
fix: Companion rules-of-hooks violation (conditional useMemo after early return)

### DIFF
--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -141,16 +141,9 @@ export default function Companion() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rawTrackId, tier, retryKey]);
 
-  if (!trackInfo) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-6">
-        <p className="text-muted-foreground">Track not found.</p>
-      </div>
-    );
-  }
-
   // Derive effective listen count from the data — the cache may return a higher
   // tier than the URL requested, so use the max across URL param and nugget data.
+  // Must run before the !trackInfo early return to satisfy rules-of-hooks.
   const effectiveListenCount = useMemo(() => {
     if (!data?.nuggets?.length) return urlListenCount;
     const maxFromData = Math.max(...data.nuggets.map((n) => n.listenUnlockLevel || 1));
@@ -176,6 +169,14 @@ export default function Companion() {
       return n;
     });
   }, [data?.nuggets, trackInfo?.coverArtUrl, trackInfo?.title, artistImage, artistName]);
+
+  if (!trackInfo) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-6">
+        <p className="text-muted-foreground">Track not found.</p>
+      </div>
+    );
+  }
 
   // Return nuggets for a section — show all nuggets up to the effective listen count.
   // Newer listens (higher listenUnlockLevel) appear first so fresh content is prominent.


### PR DESCRIPTION
## Summary

Two `useMemo` hooks in `Companion.tsx` (`effectiveListenCount`, `enrichedNuggets`) were declared AFTER the `if (!trackInfo) return ...` early return. When `trackInfo` flips from null (first render, while `data` is loading) to populated (post-hydration), the number of hooks called changes — React pairs state slots by call order, so a mismatch can corrupt state or trigger the hard \"Rendered more hooks than during the previous render.\" crash.

Fix: move both hooks above the early return. They already handle the null-data case internally (`if (!data?.nuggets?.length)` / `if (!data?.nuggets)`), so this is a straight reorder — no logic change.

## Diff

`src/pages/Companion.tsx` — 9 lines added / 8 removed (net +1).

## Why it matters

React's Rules of Hooks are strict for a reason — violations manifest as confusing runtime bugs (wrong state values, silent stale data, or an error boundary trip) rather than build errors. Companion users are typically the \"deep-dive from QR\" path; a mis-paired state slot there would surface as a blank page or mis-rendered nugget without an obvious cause.

## Test plan

- [x] `npm run lint` — 126 errors → 124 (both `react-hooks/rules-of-hooks` errors resolved)
- [x] `npm test` — 230 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

## Related

- Partial resolution of #18 (lint cleanup). The remaining 124 errors are almost entirely `@typescript-eslint/no-explicit-any` in Supabase edge functions — no runtime impact; deferred as prototype-era tech debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)