### PR TITLE
fix: nugget stacking, playback dead-end, and sparse-artist hallucination

### DIFF
--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -150,6 +150,12 @@ export function useAINuggets(
     if (!artist || !title) return;
     setFromCache(false);
 
+    // Clear stale state from a previous track so SSE appends don't stack
+    // nuggets across track boundaries (the SSE path uses functional
+    // updaters: setNuggets(prev => [...prev, nugget])).
+    setNuggets([]);
+    setSources(new Map());
+
     // ── In-memory cache check ──────────────────────────────────────
     // Include regenerateKey so repeat listens (which bump the key) always
     // miss the cache and trigger fresh generation.

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1063,19 +1063,25 @@ export default function Listen() {
 
   // Delayed safety-net: if the track was loaded but isn't playing after 4s
   // (autoPlay PUT to Spotify failed silently or the effect above fired
-  // within the 2s guard window), retry play(). This avoids the previous
-  // dead-end where the auto-resume deps didn't re-fire after the guard
-  // expired, leaving the track paused indefinitely.
+  // within the 2s guard window), retry play(). Reads isPlaying and
+  // currentTrackUri through refs so the timer sees fresh values without
+  // adding deps that would recreate the timer on every playback tick.
+  const isPlayingRef = useRef(isPlaying);
+  useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
+  const currentTrackUriRef = useRef(player.currentTrackUri);
+  useEffect(() => { currentTrackUriRef.current = player.currentTrackUri; }, [player.currentTrackUri]);
+
   useEffect(() => {
     if (isExternalListenMode || !trackUri) return;
+    const capturedUri = trackUri;
     const timer = setTimeout(() => {
-      if (player.currentTrackUri === trackUri && !isPlaying) {
+      if (currentTrackUriRef.current === capturedUri && !isPlayingRef.current) {
         console.log("[Listen] Safety-net: track loaded but not playing after 4s — retrying play()");
         play();
       }
     }, 4000);
     return () => clearTimeout(timer);
-  }, [trackUri, isExternalListenMode]);
+  }, [trackUri, isExternalListenMode, play]);
 
   useEffect(() => {
     if (trackNuggets.length === 0) return;

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1061,22 +1061,24 @@ export default function Listen() {
     }
   }, [play, isExternalListenMode, trackUri, player.currentTrackUri]);
 
-  // Delayed safety-net: if the track was loaded but isn't playing after 4s
-  // (autoPlay PUT to Spotify failed silently or the effect above fired
-  // within the 2s guard window), retry play(). Reads isPlaying and
-  // currentTrackUri through refs so the timer sees fresh values without
-  // adding deps that would recreate the timer on every playback tick.
+  // Delayed safety-net: if the track was loaded but NEVER started playing
+  // after 4s (autoPlay PUT failed or auto-resume fired in the 2s guard),
+  // retry play(). Skips if the track has played at any point since the URI
+  // changed — so a deliberate pause within 4s won't be force-resumed.
   const isPlayingRef = useRef(isPlaying);
   useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
   const currentTrackUriRef = useRef(player.currentTrackUri);
   useEffect(() => { currentTrackUriRef.current = player.currentTrackUri; }, [player.currentTrackUri]);
+  const hasEverPlayedRef = useRef(false);
+  useEffect(() => { hasEverPlayedRef.current = false; }, [trackUri]);
+  useEffect(() => { if (isPlaying) hasEverPlayedRef.current = true; }, [isPlaying]);
 
   useEffect(() => {
     if (isExternalListenMode || !trackUri) return;
     const capturedUri = trackUri;
     const timer = setTimeout(() => {
-      if (currentTrackUriRef.current === capturedUri && !isPlayingRef.current) {
-        console.log("[Listen] Safety-net: track loaded but not playing after 4s — retrying play()");
+      if (currentTrackUriRef.current === capturedUri && !isPlayingRef.current && !hasEverPlayedRef.current) {
+        console.log("[Listen] Safety-net: track never started after 4s — retrying play()");
         play();
       }
     }, 4000);

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1056,12 +1056,26 @@ export default function Listen() {
       // handle playback via the Spotify API. Calling resume() too early
       // would briefly play the OLD track. On very slow SDK loads (>2s)
       // this guard expires and resume() acts as a safety net.
-      // TODO: clear trackLoadTimestampRef on Spotify SDK "ready" event
-      // for a more robust handoff instead of a fixed timeout.
       if (Date.now() - trackLoadTimestampRef.current < 2000) return;
       play();
     }
   }, [play, isExternalListenMode, trackUri, player.currentTrackUri]);
+
+  // Delayed safety-net: if the track was loaded but isn't playing after 4s
+  // (autoPlay PUT to Spotify failed silently or the effect above fired
+  // within the 2s guard window), retry play(). This avoids the previous
+  // dead-end where the auto-resume deps didn't re-fire after the guard
+  // expired, leaving the track paused indefinitely.
+  useEffect(() => {
+    if (isExternalListenMode || !trackUri) return;
+    const timer = setTimeout(() => {
+      if (player.currentTrackUri === trackUri && !isPlaying) {
+        console.log("[Listen] Safety-net: track loaded but not playing after 4s — retrying play()");
+        play();
+      }
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [trackUri, isExternalListenMode]);
 
   useEffect(() => {
     if (trackNuggets.length === 0) return;

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1392,7 +1392,31 @@ const HALLUCINATED_PUBLISHERS = [
   "music data insights", "internal data", "musicdatainsights",
   "ai music database", "music insights", "artist database",
   "music analytics", "song insights", "track insights",
+  // Domain-pattern hallucinations: Gemini invents plausible-sounding
+  // music databases/platforms that don't exist.
+  "musicmetricsvault", "musicmetrics", "metricsvault",
+  "sonic scroll", "sonicscroll", "the sonic scroll",
+  "music vault", "musicvault", "artist vault",
+  "beat archive", "beatarchive", "sound archive",
+  "track vault", "trackvault", "music archive",
+  "resident advisor", // Gemini confuses with Resident Advisor (RA) but invents non-existent articles
 ];
+
+// Known real music publications — used as a positive signal when deciding
+// whether a publisher is fabricated. NOT a whitelist (unlisted publishers
+// aren't rejected), but an unverified source from a known-real publisher
+// is more trustworthy than one from an unknown domain.
+const KNOWN_REAL_PUBLISHERS = new Set([
+  "spotify", "bandcamp", "soundcloud", "youtube", "apple music",
+  "pitchfork", "rolling stone", "nme", "billboard", "the guardian",
+  "stereogum", "consequence", "the fader", "complex", "xxl",
+  "genius", "allmusic", "discogs", "musicbrainz", "last.fm",
+  "wikipedia", "resident advisor", "ra", "mixmag", "dj mag",
+  "sound on sound", "tape op", "the quietus", "tiny mix tapes",
+  "the wire", "fact", "noisey", "vice", "vulture", "spin",
+  "exclaim", "paste", "under the radar", "clash", "diy",
+  "the line of best fit", "the needle drop", "fantano",
+]);
 
 function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { valid: boolean; issues: string[]; hallucinated: boolean; vagueHeadlines: boolean } {
   const issues: string[] = [];
@@ -1646,7 +1670,8 @@ Use this to:
 ACCURACY RULES (non-negotiable):
 - Do NOT fabricate a narrative. If you don't have verified facts, write about what you DO know (even if it's just genre, location, or catalog data).
 - Source type MUST be "youtube", "article", or "interview" — NEVER use "internal-data", "database", or invented types.
-- Publisher MUST be a real publication or platform (e.g., "Bandcamp", "Spotify", "SoundCloud", "YouTube"). NEVER invent publishers like "Music Data Insights".
+- Publisher MUST be a REAL, EXISTING publication or platform (e.g., "Bandcamp", "Spotify", "SoundCloud", "YouTube", "Pitchfork", "Rolling Stone"). NEVER invent publisher names or domains. If you cannot name a real publisher, use "Spotify" (you always have Spotify catalog data).
+- NEVER invent studio names, engineer names, collaborator names, or anecdotes. If you don't know the real studio, don't name one. If you don't know the engineer, don't name one. Fabricated specifics (fake names, fake studios, fake incidents) are worse than honest generality.
 - Do NOT frame lack of information as a deliberate artistic choice (e.g., "operates as a digital ghost", "deliberate anti-persona"). A small artist is not automatically mysterious.
 - For the track nugget: write about the artist's creative context, NOT the track's sound or mood.
 
@@ -2629,12 +2654,8 @@ Return ONLY valid JSON:
     console.timeEnd("[Timing] Gemini (Curator + Writer)"); _te("gemini");
     } else {
       // SSE path: rawNuggets populated inside the streaming IIFE below.
-      // groundingChunks stays empty on this path — the per-nugget Writer
-      // calls happen inside the IIFE and the resulting grounding metadata
-      // isn't aggregated here. assembleNugget's realChunks fallback
-      // therefore only resolves against Exa citations on SSE requests;
-      // the Google-search grounding fallback is batch-only. If this
-      // becomes load-bearing, thread chunks out of the IIFE.
+      // groundingChunks starts empty but is populated incrementally as
+      // each per-nugget Writer call returns grounding metadata.
       rawNuggets = [];
       groundingChunks = [];
     }
@@ -3105,6 +3126,14 @@ Return ONLY valid JSON:
                       }
                       throw new Error(`Empty Gemini response for ${def.kind}`);
                     }
+                    // Capture per-nugget grounding chunks so assembleNugget's
+                    // source-resolution chain can verify URLs against real
+                    // Google Search results (previously SSE-only gap).
+                    const perNuggetChunks = data.candidates?.[0]?.groundingMetadata?.groundingChunks || [];
+                    if (perNuggetChunks.length > 0) {
+                      groundingChunks.push(...perNuggetChunks);
+                      console.log(`[SSE] ${def.kind}: ${perNuggetChunks.length} grounding chunks captured`);
+                    }
                     const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
                     const parsed = JSON.parse(cleaned);
                     nuggetData = parsed.nugget || (parsed.nuggets?.[0]);
@@ -3159,6 +3188,17 @@ Return ONLY valid JSON:
                 if (HALLUCINATED_PUBLISHERS.some(hp => publisher.includes(hp))) {
                   console.log(`[SSE] Skipping hallucinated publisher: ${def.kind}`);
                   continue;
+                }
+                // Unverified source + unknown publisher = likely fabricated.
+                // assembleNugget sets verified=false when no Exa citation or
+                // grounding chunk matched — if the publisher also isn't a
+                // known real publication, Gemini almost certainly invented it.
+                if (isSparseData && assembled.source?.verified === false) {
+                  const pubLower = publisher.replace(/^(the |www\.)/, "").replace(/\.(com|net|org|io|xyz)$/, "");
+                  if (!KNOWN_REAL_PUBLISHERS.has(pubLower) && !KNOWN_REAL_PUBLISHERS.has(publisher)) {
+                    console.log(`[SSE] Skipping unverified source from unknown publisher "${assembled.source.publisher}" for sparse artist: ${def.kind}`);
+                    continue;
+                  }
                 }
 
                 // ── Stream immediately ──

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1399,7 +1399,6 @@ const HALLUCINATED_PUBLISHERS = [
   "music vault", "musicvault", "artist vault",
   "beat archive", "beatarchive", "sound archive",
   "track vault", "trackvault", "music archive",
-  "resident advisor", // Gemini confuses with Resident Advisor (RA) but invents non-existent articles
 ];
 
 // Known real music publications — used as a positive signal when deciding
@@ -3194,8 +3193,8 @@ Return ONLY valid JSON:
                 // grounding chunk matched — if the publisher also isn't a
                 // known real publication, Gemini almost certainly invented it.
                 if (isSparseData && assembled.source?.verified === false) {
-                  const pubLower = publisher.replace(/^(the |www\.)/, "").replace(/\.(com|net|org|io|xyz)$/, "");
-                  if (!KNOWN_REAL_PUBLISHERS.has(pubLower) && !KNOWN_REAL_PUBLISHERS.has(publisher)) {
+                  const pubNormalized = publisher.toLowerCase().replace(/^(the |www\.)/, "").replace(/\.(com|net|org|io|xyz)$/, "");
+                  if (!KNOWN_REAL_PUBLISHERS.has(pubNormalized) && !KNOWN_REAL_PUBLISHERS.has(publisher.toLowerCase())) {
                     console.log(`[SSE] Skipping unverified source from unknown publisher "${assembled.source.publisher}" for sparse artist: ${def.kind}`);
                     continue;
                   }


### PR DESCRIPTION
## Summary
Fixes three bugs observed while testing Ty Symph ("4U" → "Better"):

- **Nugget stacking (5 dots):** SSE streaming appended nuggets across track boundaries — old track's nuggets stayed in state. Fixed by clearing `nuggets`/`sources` at the top of `generate()`.
- **Playback dead-end:** After `navigateToRelated()` resolved, the auto-resume effect fired within the 2s guard and never re-fired. Added a 4s safety-net that retries `play()` if the track loaded but isn't playing.
- **Sparse-artist hallucination:** Gemini fabricated studios ("Northwood Labs"), engineers ("Kai Seraph"), and domains ("musicmetricsvault.com") for unknown artists. Three-layer fix:
  - Collect per-nugget grounding chunks in SSE (were previously discarded) so `assembleNugget` can verify source URLs
  - Expand `HALLUCINATED_PUBLISHERS` + add `KNOWN_REAL_PUBLISHERS` whitelist; for sparse artists, skip nuggets with unverified sources from unknown publishers
  - Strengthen sparse-data prompt: explicitly forbids fabricating specific names/studios/incidents

## Test plan
- [ ] Play a sparse/unknown artist — verify no fabricated studios, engineers, or fake domains appear
- [ ] Play 2+ tracks in sequence — verify nuggets reset between tracks (3 dots, not 5+)
- [ ] Track auto-advance — verify playback starts within 5s of the mini player updating
- [ ] Known artist (e.g., Kendrick) — verify nuggets still generate normally with real sources
- [ ] Cached track replay — verify instant load, no stacking