### PR TITLE
Promote to main: bug fixes + Apple Music enrichment + skip cascade refactor

### DIFF
--- a/Dev.md
+++ b/Dev.md
@@ -192,7 +192,7 @@ User enters Last.fm username
   → On Browse load: lastfm-sync called again (uses cache)
 
 On Companion/Generate:
-  → generate-companion receives: lastFmUsername, spotifyTopArtists, spotifyTopTracks, streamingService
+  → generate-companion receives: lastFmUsername, topArtists, topTracks, streamingService
   → Internally calls lastfm-sync to get taste context
   → Merges all signals into a RAG prompt context block
   → Gemini uses context to tailor "Explore Next" category

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -150,6 +150,12 @@ export function useAINuggets(
     if (!artist || !title) return;
     setFromCache(false);
 
+    // Clear stale state from a previous track so SSE appends don't stack
+    // nuggets across track boundaries (the SSE path uses functional
+    // updaters: setNuggets(prev => [...prev, nugget])).
+    setNuggets([]);
+    setSources(new Map());
+
     // ── In-memory cache check ──────────────────────────────────────
     // Include regenerateKey so repeat listens (which bump the key) always
     // miss the cache and trigger fresh generation.

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -85,11 +85,8 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   const service = (data.streaming_service as UserProfile["streamingService"]) || "";
   const serviceKey = service === "Spotify" ? "spotify" : service === "Apple Music" ? "apple" : null;
 
-  // Read taste from music_taste (new, keyed by service) → fall back to spotify_taste (legacy)
   const musicTaste = data.music_taste as Record<string, TasteData> | null;
-  const taste: TasteData | null =
-    (serviceKey && musicTaste?.[serviceKey]) ||
-    (data.spotify_taste as TasteData | null);
+  const taste: TasteData | null = serviceKey ? (musicTaste?.[serviceKey] ?? null) : null;
 
   return {
     streamingService: service,
@@ -125,7 +122,6 @@ export function resolveStreamingService(
 }
 
 async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
-  // Build taste data from profile fields
   const tasteData: TasteData | null =
     p.topArtists || p.topTracks
       ? {
@@ -137,18 +133,15 @@ async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
         }
       : null;
 
-  // Determine service key for music_taste JSONB
   const serviceKey = p.streamingService === "Spotify" ? "spotify"
     : p.streamingService === "Apple Music" ? "apple" : null;
 
-  // Dual-write: spotify_taste (legacy) + music_taste (new, keyed by service)
   await supabase.from("profiles").upsert(
     {
       user_id: userId,
       tier: p.calculatedTier,
       streaming_service: p.streamingService,
       last_fm_username: p.lastFmUsername || null,
-      spotify_taste: tasteData,
       music_taste: serviceKey && tasteData ? { [serviceKey]: tasteData } : null,
     },
     { onConflict: "user_id" }

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -36,6 +36,43 @@ interface TasteData {
   trackImages?: { title: string; artist: string; imageUrl: string }[];
 }
 
+/** Legacy localStorage payload shape. Pre-rename profiles used `spotify*`
+ *  prefixed keys even after Apple Music support landed. `parseStoredProfile`
+ *  promotes these to the unprefixed keys on read.
+ *  @deprecated Drop after soak — tracked in #51 P3.11. */
+interface LegacyProfileShape {
+  spotifyTopArtists?: string[];
+  spotifyTopTracks?: string[];
+  spotifyArtistImages?: Record<string, string>;
+  spotifyArtistIds?: Record<string, string>;
+  spotifyTrackImages?: UserProfile["trackImages"];
+}
+
+function parseStoredProfile(raw: string | null): UserProfile | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as UserProfile & LegacyProfileShape;
+    const {
+      spotifyTopArtists,
+      spotifyTopTracks,
+      spotifyArtistImages,
+      spotifyArtistIds,
+      spotifyTrackImages,
+      ...rest
+    } = parsed;
+    return {
+      ...rest,
+      topArtists: rest.topArtists ?? spotifyTopArtists,
+      topTracks: rest.topTracks ?? spotifyTopTracks,
+      artistImages: rest.artistImages ?? spotifyArtistImages,
+      artistIds: rest.artistIds ?? spotifyArtistIds,
+      trackImages: rest.trackImages ?? spotifyTrackImages,
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   const { data } = await supabase
     .from("profiles")
@@ -57,11 +94,11 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
   return {
     streamingService: service,
     lastFmUsername: data.last_fm_username || undefined,
-    spotifyTopArtists: taste?.topArtists ?? undefined,
-    spotifyTopTracks: taste?.topTracks ?? undefined,
-    spotifyArtistImages: taste?.artistImages ?? undefined,
-    spotifyArtistIds: taste?.artistIds ?? undefined,
-    spotifyTrackImages: taste?.trackImages ?? undefined,
+    topArtists: taste?.topArtists ?? undefined,
+    topTracks: taste?.topTracks ?? undefined,
+    artistImages: taste?.artistImages ?? undefined,
+    artistIds: taste?.artistIds ?? undefined,
+    trackImages: taste?.trackImages ?? undefined,
     calculatedTier: (data.tier as UserProfile["calculatedTier"]) || "casual",
   };
 }
@@ -71,31 +108,32 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
  *
  * Priority:
  *  1. Preserve an explicit streamingService on whichever source is the base
- *  2. Fall back to "Spotify" only if spotifyTopArtists is populated (legacy
- *     profile rows from before streaming_service was persisted)
+ *  2. Fall back to "Spotify" only if topArtists is populated (legacy
+ *     profile rows from before streaming_service was persisted; all such
+ *     rows predate Apple Music support and are Spotify by construction)
  *  3. Otherwise empty string (guest-like state)
  *
  * Exported for unit testing. Used by useUserProfile's hydrate effect.
  */
 export function resolveStreamingService(
   baseService: UserProfile["streamingService"] | undefined,
-  spotifyTopArtistsCount: number
+  topArtistsCount: number
 ): UserProfile["streamingService"] {
   if (baseService) return baseService;
-  if (spotifyTopArtistsCount > 0) return "Spotify";
+  if (topArtistsCount > 0) return "Spotify";
   return "";
 }
 
 async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
   // Build taste data from profile fields
   const tasteData: TasteData | null =
-    p.spotifyTopArtists || p.spotifyTopTracks
+    p.topArtists || p.topTracks
       ? {
-          topArtists: p.spotifyTopArtists ?? [],
-          topTracks: p.spotifyTopTracks ?? [],
-          artistImages: p.spotifyArtistImages ?? {},
-          artistIds: p.spotifyArtistIds ?? {},
-          trackImages: p.spotifyTrackImages ?? [],
+          topArtists: p.topArtists ?? [],
+          topTracks: p.topTracks ?? [],
+          artistImages: p.artistImages ?? {},
+          artistIds: p.artistIds ?? {},
+          trackImages: p.trackImages ?? [],
         }
       : null;
 
@@ -122,14 +160,9 @@ async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
 export function useUserProfile() {
   const { user } = useAuth();
 
-  const [profile, setProfileState] = useState<UserProfile | null>(() => {
-    try {
-      const raw = localStorage.getItem(PROFILE_KEY);
-      return raw ? JSON.parse(raw) : null;
-    } catch {
-      return null;
-    }
-  });
+  const [profile, setProfileState] = useState<UserProfile | null>(() =>
+    parseStoredProfile(localStorage.getItem(PROFILE_KEY))
+  );
 
   // Sync across hook instances: every call to useUserProfile has its own
   // independent useState slot, so when Connect.tsx saves a profile, other
@@ -137,15 +170,7 @@ export function useUserProfile() {
   // event fired by saveProfile/clearProfile and re-read from localStorage.
   // Also listens to the native `storage` event for cross-tab sync.
   useEffect(() => {
-    const sync = () => {
-      try {
-        const raw = localStorage.getItem(PROFILE_KEY);
-        const next = raw ? (JSON.parse(raw) as UserProfile) : null;
-        setProfileState(next);
-      } catch {
-        setProfileState(null);
-      }
-    };
+    const sync = () => setProfileState(parseStoredProfile(localStorage.getItem(PROFILE_KEY)));
     const onStorage = (e: StorageEvent) => {
       if (e.key === PROFILE_KEY) sync();
     };
@@ -165,23 +190,21 @@ export function useUserProfile() {
     let cancelled = false;
     loadProfileFromDB(user.id).then((dbProfile) => {
       if (cancelled || !dbProfile) return;
-      const local = (() => {
-        try { return JSON.parse(localStorage.getItem(PROFILE_KEY) || "null"); } catch { return null; }
-      })() as UserProfile | null;
+      const local = parseStoredProfile(localStorage.getItem(PROFILE_KEY));
 
-      // If local already has Spotify taste data, it's fresher — don't overwrite it with stale DB.
+      // If local already has taste data, it's fresher — don't overwrite it with stale DB.
       // Preserve local's streamingService if set (handles Apple Music users who previously
       // had Spotify data in the same profile row).
-      if (local?.spotifyTopArtists?.length && local.spotifyArtistImages
-          && Object.keys(local.spotifyArtistImages).length > 0) {
-        // Only pull non-Spotify fields from DB (tier, lastFm) if local is missing them
+      if (local?.topArtists?.length && local.artistImages
+          && Object.keys(local.artistImages).length > 0) {
+        // Only pull non-taste fields from DB (tier, lastFm) if local is missing them
         const merged: UserProfile = {
           ...local,
           calculatedTier: local.calculatedTier || dbProfile.calculatedTier,
           lastFmUsername: local.lastFmUsername || dbProfile.lastFmUsername,
           streamingService: resolveStreamingService(
             local.streamingService,
-            local.spotifyTopArtists?.length ?? 0
+            local.topArtists?.length ?? 0
           ),
         };
         localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
@@ -189,16 +212,16 @@ export function useUserProfile() {
         return;
       }
 
-      // No local Spotify data — use DB profile (e.g. new device sign-in).
+      // No local taste data — use DB profile (e.g. new device sign-in).
       const merged: UserProfile = {
         ...dbProfile,
         streamingService: resolveStreamingService(
           dbProfile.streamingService,
-          dbProfile.spotifyTopArtists?.length ?? 0
+          dbProfile.topArtists?.length ?? 0
         ),
-        spotifyArtistImages: dbProfile.spotifyArtistImages ?? local?.spotifyArtistImages,
-        spotifyArtistIds: dbProfile.spotifyArtistIds ?? local?.spotifyArtistIds,
-        spotifyTrackImages: dbProfile.spotifyTrackImages ?? local?.spotifyTrackImages,
+        artistImages: dbProfile.artistImages ?? local?.artistImages,
+        artistIds: dbProfile.artistIds ?? local?.artistIds,
+        trackImages: dbProfile.trackImages ?? local?.trackImages,
       };
       localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
       notifyProfileUpdated();
@@ -224,12 +247,7 @@ export function useUserProfile() {
 }
 
 export function getStoredProfile(): UserProfile | null {
-  try {
-    const raw = localStorage.getItem(PROFILE_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
+  return parseStoredProfile(localStorage.getItem(PROFILE_KEY));
 }
 
 // ── Tier helpers ──────────────────────────────────────────────────────────────

--- a/src/hooks/usePersonalizedCatalog.ts
+++ b/src/hooks/usePersonalizedCatalog.ts
@@ -40,10 +40,10 @@ interface RealArtist { name: string; imageUrl: string; tags: string[]; }
 
 function artistImageUrl(
   name: string,
-  spotifyImages?: Record<string, string>,
+  artistImages?: Record<string, string>,
   resolved?: Map<string, string>,
 ): string {
-  if (spotifyImages?.[name]) return spotifyImages[name];
+  if (artistImages?.[name]) return artistImages[name];
   const cached = resolved?.get(name) || artistImageCache.get(name);
   if (cached) return cached;
   return `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(name)}&backgroundColor=1a1a2e&textColor=ffffff&fontSize=38`;
@@ -52,10 +52,10 @@ function artistImageUrl(
 function trackCoverUrl(
   trackName: string,
   artistName: string,
-  spotifyTrackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
+  trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
 ): string {
-  if (spotifyTrackImages) {
-    const match = spotifyTrackImages.find(
+  if (trackImages) {
+    const match = trackImages.find(
       (t) =>
         t.title.toLowerCase() === trackName.toLowerCase() &&
         t.artist.toLowerCase() === artistName.toLowerCase()
@@ -87,15 +87,15 @@ function parseTrackString(t: string): { trackTitle: string; artistName: string }
 function trackTile(
   t: string,
   idPrefix: string,
-  spotifyTrackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
+  trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[],
 ): BrowseTile {
   const { trackTitle, artistName } = parseTrackString(t);
-  const trackInfo = spotifyTrackImages?.find(
+  const trackInfo = trackImages?.find(
     (img) => img.title.toLowerCase() === trackTitle.toLowerCase() && img.artist.toLowerCase() === artistName.toLowerCase()
   );
   return {
     id: `${idPrefix}-${t}`,
-    imageUrl: trackCoverUrl(trackTitle, artistName, spotifyTrackImages),
+    imageUrl: trackCoverUrl(trackTitle, artistName, trackImages),
     title: trackTitle,
     subtitle: artistName,
     href: realTrackHref(artistName, trackTitle, undefined, trackInfo?.uri),
@@ -123,14 +123,14 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
   // Merged top-artist list
   const topArtistNames = useMemo<string[]>(() => {
     const names: string[] = [];
-    if (profile?.spotifyTopArtists?.length) names.push(...profile.spotifyTopArtists);
+    if (profile?.topArtists?.length) names.push(...profile.topArtists);
     if (lastFmData?.topArtists?.length) {
       lastFmData.topArtists.forEach((a) => {
         if (!names.includes(a.name)) names.push(a.name);
       });
     }
     return names;
-  }, [profile?.spotifyTopArtists, lastFmData?.topArtists]);
+  }, [profile?.topArtists, lastFmData?.topArtists]);
 
   // Fetch Last.fm data
   useEffect(() => {
@@ -174,10 +174,10 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
   useEffect(() => {
     if (!profile) return;
     let cancelled = false;
-    const cachedImages = profile.spotifyArtistImages || {};
-    const cachedIds = profile.spotifyArtistIds || {};
+    const cachedImages = profile.artistImages || {};
+    const cachedIds = profile.artistIds || {};
     const artistNames = [
-      ...(profile.spotifyTopArtists || []),
+      ...(profile.topArtists || []),
       ...(lastFmData?.topArtists?.map((a) => a.name) || []),
       ...recommendations.map((a) => a.name),
     ];
@@ -235,13 +235,13 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     if (!profile) return [];
 
     const allRows: BrowseRow[] = [];
-    const spotifyTracks = profile.spotifyTopTracks || [];
-    const spotifyTrackImgs = profile.spotifyTrackImages;
-    const spotifyArtistImgs = profile.spotifyArtistImages;
+    const topTracks = profile.topTracks || [];
+    const trackImgs = profile.trackImages;
+    const artistImgs = profile.artistImages;
     // Active-service prefix for all artist links in the Browse rows.
-    // spotifyTrackImages / spotifyArtistImages are legacy-named fields
-    // populated from the active service's taste data, so "spotify" is
-    // just the default fallback when no explicit service is set.
+    // trackImages / artistImages are populated from the active service's
+    // taste data; "spotify" is just the default fallback when no explicit
+    // service is set.
     const activeService = serviceParamFromProfile(profile.streamingService);
 
     // ── 1. "Jump Back In" — recent tracks or top tracks ──────────────
@@ -249,8 +249,8 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
 
       if (lastFmData?.recentTracks?.length) {
         lastFmData.recentTracks.slice(0, 10).forEach((t) => {
-          const image = t.imageUrl || trackCoverUrl(t.name, t.artist, spotifyTrackImgs);
-          const spotifyMatch = spotifyTrackImgs?.find(
+          const image = t.imageUrl || trackCoverUrl(t.name, t.artist, trackImgs);
+          const trackMatch = trackImgs?.find(
             (img) => img.title.toLowerCase() === t.name.toLowerCase() && img.artist.toLowerCase() === t.artist.toLowerCase()
           );
           recentTiles.push({
@@ -258,13 +258,13 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
             imageUrl: image,
             title: t.name,
             subtitle: t.artist,
-            href: realTrackHref(t.artist, t.name, t.album, spotifyMatch?.uri),
+            href: realTrackHref(t.artist, t.name, t.album, trackMatch?.uri),
             isRealTrack: true,
           });
         });
-    } else if (spotifyTracks.length) {
-      spotifyTracks.slice(0, 8).forEach((t) => {
-        recentTiles.push(trackTile(t, "recent", spotifyTrackImgs));
+    } else if (topTracks.length) {
+      topTracks.slice(0, 8).forEach((t) => {
+        recentTiles.push(trackTile(t, "recent", trackImgs));
       });
     }
 
@@ -275,12 +275,12 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     // ── 2. "Your Top Artists" ────────────────────────────────────────
     if (topArtistNames.length > 0) {
       // cachedArtistIds holds catalog IDs from the active service's
-      // taste data (legacy-named spotifyArtistIds field). Falls back
-      // to the runtime-resolved map when a given name wasn't in taste.
-      const cachedArtistIds = profile.spotifyArtistIds || {};
+      // taste data. Falls back to the runtime-resolved map when a given
+      // name wasn't in taste.
+      const cachedArtistIds = profile.artistIds || {};
       const topArtistTiles: BrowseTile[] = topArtistNames.slice(0, 20).map((name) => ({
         id: `artist-${name}`,
-        imageUrl: artistImageUrl(name, spotifyArtistImgs, resolvedImages),
+        imageUrl: artistImageUrl(name, artistImgs, resolvedImages),
         title: name,
         subtitle: "Artist",
         href: artistHref(name, cachedArtistIds[name] || resolvedIds.get(name), activeService),
@@ -289,9 +289,9 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     }
 
     // ── 3. "Your Top Tracks" ─────────────────────────────────────────
-    if (spotifyTracks.length > 0) {
-      const trackTiles = spotifyTracks.slice(0, 15).map((t) =>
-        trackTile(t, "track", spotifyTrackImgs)
+    if (topTracks.length > 0) {
+      const trackTiles = topTracks.slice(0, 15).map((t) =>
+        trackTile(t, "track", trackImgs)
       );
       allRows.push({ label: "Your Top Tracks", items: trackTiles, size: "md" });
     }
@@ -300,7 +300,7 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     if (recommendations.length > 0) {
       const recTiles: BrowseTile[] = recommendations.slice(0, 15).map((a) => ({
         id: `rec-${a.name}`,
-        imageUrl: artistImageUrl(a.name, spotifyArtistImgs, resolvedImages),
+        imageUrl: artistImageUrl(a.name, artistImgs, resolvedImages),
         title: a.name,
         subtitle: a.tags.slice(0, 2).join(", ") || "Artist",
         href: artistHref(a.name, resolvedIds.get(a.name), activeService),
@@ -308,10 +308,10 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
       allRows.push({ label: "Recommended For You", items: recTiles, size: "lg" });
     }
 
-    // ── 5. "Deep Cuts" — later Spotify top tracks (positions 8–15) ───
-    if (spotifyTracks.length > 8) {
-      const deepCuts = spotifyTracks.slice(8, 15).map((t) =>
-        trackTile(t, "deep", spotifyTrackImgs)
+    // ── 5. "Deep Cuts" — later top tracks (positions 8–15) ───────────
+    if (topTracks.length > 8) {
+      const deepCuts = topTracks.slice(8, 15).map((t) =>
+        trackTile(t, "deep", trackImgs)
       );
       allRows.push({ label: "Deep Cuts", items: deepCuts, size: "sm" });
     }
@@ -337,7 +337,7 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
         if (genreArtists.length >= 3) {
           const genreTiles: BrowseTile[] = genreArtists.map((a) => ({
             id: `genre-${a.name}`,
-            imageUrl: artistImageUrl(a.name, spotifyArtistImgs, resolvedImages),
+            imageUrl: artistImageUrl(a.name, artistImgs, resolvedImages),
             title: a.name,
             subtitle: a.tags.slice(0, 2).join(", ") || "Artist",
             href: artistHref(a.name, resolvedIds.get(a.name), activeService),

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -154,7 +154,7 @@ export type Database = {
           created_at: string
           id: string
           last_fm_username: string | null
-          spotify_taste: Json | null
+          music_taste: Json | null
           streaming_service: string | null
           tier: string
           updated_at: string
@@ -164,7 +164,7 @@ export type Database = {
           created_at?: string
           id?: string
           last_fm_username?: string | null
-          spotify_taste?: Json | null
+          music_taste?: Json | null
           streaming_service?: string | null
           tier?: string
           updated_at?: string
@@ -174,7 +174,7 @@ export type Database = {
           created_at?: string
           id?: string
           last_fm_username?: string | null
-          spotify_taste?: Json | null
+          music_taste?: Json | null
           streaming_service?: string | null
           tier?: string
           updated_at?: string

--- a/src/lib/engines/AppleMusicPlaybackEngine.ts
+++ b/src/lib/engines/AppleMusicPlaybackEngine.ts
@@ -178,11 +178,17 @@ export class AppleMusicPlaybackEngine implements PlaybackEngine {
     // extracted storefront id rather than the whole response so the
     // diagnostic stays tight — the rest of the payload (supported
     // languages, etc.) is noise for what we're trying to diagnose.
+    //
+    // MusicKit JS v3's api.music() wraps the HTTP response as
+    // { request, response, data }, where `data` is Apple's response body:
+    // { data: Array<{ id, type, attributes }> }. So the storefront entry
+    // lives at response.data.data[0] — NOT response.data[0], which was
+    // the original shape and silently logged `{id: undefined, name: undefined}`.
     try {
       const storefront = await m.api?.music?.("v1/me/storefront") as {
-        data?: Array<{ id?: string; attributes?: { name?: string } }>;
+        data?: { data?: Array<{ id?: string; attributes?: { name?: string } }> };
       } | undefined;
-      const entry = storefront?.data?.[0];
+      const entry = storefront?.data?.data?.[0];
       console.log("[AppleMusic] /v1/me/storefront ok:", {
         id: entry?.id,
         name: entry?.attributes?.name,

--- a/src/lib/skipCascade.ts
+++ b/src/lib/skipCascade.ts
@@ -1,0 +1,175 @@
+import type { UserProfile } from "@/mock/types";
+import { DEMO_TRACKS, getDemoTrackUri } from "@/data/seedNuggets";
+import { withAppleStorefront } from "@/lib/appleStorefront";
+
+/** Shape of a track result returned by spotify-search / spotify-artist edge functions. */
+export interface SpotifyTrackResult {
+  title: string;
+  artist: string;
+  album?: string;
+  uri?: string;
+}
+
+export interface SkipPick {
+  artist: string;
+  title: string;
+  album: string;
+  uri: string;
+}
+
+/** Minimal `supabase.functions.invoke` shape — parameterized so tests can
+ *  pass a plain Vitest `vi.fn()` instead of mocking the full client. */
+export type InvokeFn = (
+  functionName: string,
+  options: { body: Record<string, unknown> },
+) => Promise<{ data: unknown; error?: unknown }>;
+
+export interface SkipCascadeDeps {
+  track: { artist: string; title: string };
+  trackUri: string | undefined;
+  profile: UserProfile | null;
+  isAppleMusicUser: boolean;
+  spotifyAlbumUri: string | null | undefined;
+  isInSessionHistory: (artist: string, title: string) => boolean;
+  invoke: InvokeFn;
+}
+
+/** Shape of the P1 `spotify-album` tracks response. */
+interface AlbumTrack {
+  artist: string;
+  title: string;
+  album?: string;
+  uri?: string;
+}
+
+/** 5-level priority cascade to pick the next track when the user skips.
+ *
+ *  P1: Spotify album continuation (skipped for Apple users)
+ *  P2: Spotify recommendations, taste-weighted (skipped for Apple users)
+ *  P3: Same-artist top tracks via spotify-artist edge function (both services)
+ *  P4: User's trackImages catalog (prefer different artist, relax if needed)
+ *  P5: Demo track fallback
+ *
+ *  P1 reads `spotifyAlbumUri` which only the Spotify playback engine populates.
+ *  P2 relies on Spotify's seed-based recommendations endpoint — Apple has no
+ *  equivalent, so firing it would be a wasted round trip that always returns
+ *  `{tracks:[]}`. Gated explicitly on `!isAppleMusicUser` so a future
+ *  PlayerContext change can't accidentally route Apple users through the
+ *  Spotify catalog.
+ *
+ *  Returns `null` only when the user has exhausted every candidate in their
+ *  session history — extremely rare; callers should just keep the current
+ *  track in that case. */
+export async function pickNextTrack(deps: SkipCascadeDeps): Promise<SkipPick | null> {
+  const {
+    track,
+    trackUri,
+    profile,
+    isAppleMusicUser,
+    spotifyAlbumUri,
+    isInSessionHistory,
+    invoke,
+  } = deps;
+
+  const titleLower = track.title.toLowerCase();
+  const artistLower = track.artist.toLowerCase();
+  const notPlayed = (a: string, t: string) => !isInSessionHistory(a, t);
+  const service: "apple" | "spotify" = isAppleMusicUser ? "apple" : "spotify";
+
+  if (!isAppleMusicUser) {
+    // P1: Album continuation — play next track on the same album.
+    if (spotifyAlbumUri) {
+      const albumId = spotifyAlbumUri.replace("spotify:album:", "");
+      if (/^[a-zA-Z0-9]{20,25}$/.test(albumId)) {
+        const { data } = await invoke("spotify-album", {
+          body: { albumId, service: "spotify" },
+        });
+        const albumData = data as { tracks?: AlbumTrack[] } | null;
+        if (albumData?.tracks?.length) {
+          const currentIdx = albumData.tracks.findIndex((t) => t.uri === trackUri);
+          if (currentIdx >= 0 && currentIdx < albumData.tracks.length - 1) {
+            const next = albumData.tracks[currentIdx + 1];
+            if (notPlayed(next.artist, next.title)) {
+              return {
+                artist: next.artist,
+                title: next.title,
+                album: next.album || "",
+                uri: next.uri || "",
+              };
+            }
+          }
+        }
+      }
+    }
+
+    // P2: Spotify recommendations (taste-weighted — boost user's top artists).
+    if (trackUri) {
+      const { data } = await invoke("spotify-search", {
+        body: { recommend: trackUri, service: "spotify" },
+      });
+      const recData = data as { tracks?: SpotifyTrackResult[] } | null;
+      const recs = (recData?.tracks || []).filter(
+        (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title),
+      );
+      if (recs.length > 0) {
+        const topArtists = new Set((profile?.topArtists || []).map((a) => a.toLowerCase()));
+        const boosted = recs.filter((t) => topArtists.has(t.artist.toLowerCase()));
+        const pool = boosted.length > 0 ? boosted : recs;
+        const pick = pool[Math.floor(Math.random() * Math.min(pool.length, 3))];
+        return {
+          artist: pick.artist,
+          title: pick.title,
+          album: pick.album || "",
+          uri: pick.uri || "",
+        };
+      }
+    }
+  }
+
+  // P3: Same-artist top tracks. Works for both services via `service` + storefront.
+  const artistBody = withAppleStorefront({ artistName: track.artist, service }, service);
+  const { data: artistInvoke } = await invoke("spotify-artist", { body: artistBody });
+  const artistData = artistInvoke as { topTracks?: SpotifyTrackResult[] } | null;
+  if (artistData?.topTracks?.length) {
+    const candidates = artistData.topTracks.filter(
+      (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title),
+    );
+    if (candidates.length > 0) {
+      const pick = candidates[Math.floor(Math.random() * Math.min(candidates.length, 5))];
+      return {
+        artist: pick.artist,
+        title: pick.title,
+        album: pick.album || "",
+        uri: pick.uri || "",
+      };
+    }
+  }
+
+  // P4: User's catalog (prefer different artist, relax if needed). `trackImages`
+  // is populated from the active service's taste data (Spotify or Apple via apple-taste).
+  const userTracks = (profile?.trackImages || []).filter(
+    (t) => t.uri && notPlayed(t.artist, t.title) && t.artist.toLowerCase() !== artistLower,
+  );
+  const relaxed = userTracks.length > 0
+    ? userTracks
+    : (profile?.trackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
+  if (relaxed.length > 0) {
+    const pick = relaxed[Math.floor(Math.random() * relaxed.length)];
+    return { artist: pick.artist, title: pick.title, album: "", uri: pick.uri ?? "" };
+  }
+
+  // P5: Demo track fallback. For Apple users, filter to tracks with an
+  // appleMusicUri so we don't navigate to an unplayable URI.
+  const playableDemos = DEMO_TRACKS.filter((d) => {
+    if (!notPlayed(d.artist, d.title)) return false;
+    if (isAppleMusicUser) return !!d.appleMusicUri;
+    return true;
+  });
+  if (playableDemos.length > 0) {
+    const pick = playableDemos[Math.floor(Math.random() * playableDemos.length)];
+    const uri = getDemoTrackUri(pick, profile?.streamingService);
+    return { artist: pick.artist, title: pick.title, album: pick.album, uri };
+  }
+
+  return null;
+}

--- a/src/mock/types.ts
+++ b/src/mock/types.ts
@@ -95,12 +95,12 @@ export interface UserProfile {
   /** Service-agnostic display name (populated from Spotify or user input for Apple Music) */
   displayName?: string;
   spotifyDisplayName?: string;    // e.g. "Peter Rango" — from Spotify OAuth
-  // Spotify taste profile — populated after OAuth, stored as serialised top artists/tracks
-  spotifyTopArtists?: string[];   // e.g. ["Radiohead", "Björk", "Portishead"]
-  spotifyTopTracks?: string[];    // e.g. ["Karma Police", "Hyperballad"]
-  // Spotify image maps — artist name → image URL, track "title — artist" → album art URL
-  spotifyArtistImages?: Record<string, string>;
-  spotifyArtistIds?: Record<string, string>;   // artist name → Spotify artist ID
-  spotifyTrackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[];
+  // Service-agnostic taste profile — populated from the active streaming service
+  topArtists?: string[];          // e.g. ["Radiohead", "Björk", "Portishead"]
+  topTracks?: string[];           // e.g. ["Karma Police", "Hyperballad"]
+  // Image maps — artist name → image URL, track "title — artist" → album art URL
+  artistImages?: Record<string, string>;
+  artistIds?: Record<string, string>;   // artist name → service-specific artist ID
+  trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[];
   calculatedTier: "casual" | "curious" | "nerd";
 }

--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -62,16 +62,16 @@ export default function Companion() {
     if (realTrackMeta) {
       // Try to get cover art: cached from companion data > profile > DiceBear fallback
       let coverArtUrl = data?.coverArtUrl || "";
-      if (!coverArtUrl && profile?.spotifyTrackImages) {
-        const match = profile.spotifyTrackImages.find(
+      if (!coverArtUrl && profile?.trackImages) {
+        const match = profile.trackImages.find(
           (t) =>
             t.title.toLowerCase() === realTrackMeta.title.toLowerCase() &&
             t.artist.toLowerCase() === realTrackMeta.artist.toLowerCase()
         );
         if (match?.imageUrl) coverArtUrl = match.imageUrl;
       }
-      if (!coverArtUrl && profile?.spotifyArtistImages?.[realTrackMeta.artist]) {
-        coverArtUrl = profile.spotifyArtistImages[realTrackMeta.artist];
+      if (!coverArtUrl && profile?.artistImages?.[realTrackMeta.artist]) {
+        coverArtUrl = profile.artistImages[realTrackMeta.artist];
       }
       if (!coverArtUrl) {
         coverArtUrl = `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(realTrackMeta.artist + realTrackMeta.title)}&backgroundColor=111827&textColor=ffffff&fontSize=30`;
@@ -84,10 +84,10 @@ export default function Companion() {
       };
     }
     return null;
-  }, [realTrackMeta, data?.coverArtUrl, profile?.spotifyTrackImages, profile?.spotifyArtistImages]);
+  }, [realTrackMeta, data?.coverArtUrl, profile?.trackImages, profile?.artistImages]);
 
   const artistName = trackInfo?.artist || "";
-  const artistFallbackImage = data?.artistImage || profile?.spotifyArtistImages?.[artistName] || "";
+  const artistFallbackImage = data?.artistImage || profile?.artistImages?.[artistName] || "";
   const artistImage = useArtistImage(artistName, artistFallbackImage);
 
   const artistGenres: string[] = [];

--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -141,16 +141,9 @@ export default function Companion() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rawTrackId, tier, retryKey]);
 
-  if (!trackInfo) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-6">
-        <p className="text-muted-foreground">Track not found.</p>
-      </div>
-    );
-  }
-
   // Derive effective listen count from the data — the cache may return a higher
   // tier than the URL requested, so use the max across URL param and nugget data.
+  // Must run before the !trackInfo early return to satisfy rules-of-hooks.
   const effectiveListenCount = useMemo(() => {
     if (!data?.nuggets?.length) return urlListenCount;
     const maxFromData = Math.max(...data.nuggets.map((n) => n.listenUnlockLevel || 1));
@@ -176,6 +169,14 @@ export default function Companion() {
       return n;
     });
   }, [data?.nuggets, trackInfo?.coverArtUrl, trackInfo?.title, artistImage, artistName]);
+
+  if (!trackInfo) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-6">
+        <p className="text-muted-foreground">Track not found.</p>
+      </div>
+    );
+  }
 
   // Return nuggets for a section — show all nuggets up to the effective listen count.
   // Newer listens (higher listenUnlockLevel) appear first so fresh content is prominent.

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -37,8 +37,8 @@ export default function Connect() {
   const [direction, setDirection] = useState(1);
   const [spotifyConnecting, setSpotifyConnecting] = useState(false);
   const [spotifyConnected, setSpotifyConnected] = useState(false);
-  const [pendingSpotifyArtists, setPendingSpotifyArtists] = useState<string[] | null>(null);
-  const [pendingSpotifyTracks, setPendingSpotifyTracks] = useState<string[] | null>(null);
+  const [pendingTopArtists, setPendingTopArtists] = useState<string[] | null>(null);
+  const [pendingTopTracks, setPendingTopTracks] = useState<string[] | null>(null);
   const [pendingArtistImages, setPendingArtistImages] = useState<Record<string, string>>({});
   const [pendingArtistIds, setPendingArtistIds] = useState<Record<string, string>>({});
   const [pendingTrackImages, setPendingTrackImages] = useState<{ title: string; artist: string; imageUrl: string; uri?: string }[]>([]);
@@ -77,8 +77,8 @@ export default function Connect() {
       try {
         const { displayName, topArtists, topTracks, artistImages, artistIds, trackImages } = JSON.parse(raw);
         setSpotifyConnected(true);
-        setPendingSpotifyArtists(topArtists);
-        setPendingSpotifyTracks(topTracks);
+        setPendingTopArtists(topArtists);
+        setPendingTopTracks(topTracks);
         if (displayName) setPendingDisplayName(displayName);
         if (artistImages) setPendingArtistImages(artistImages);
         if (artistIds) setPendingArtistIds(artistIds);
@@ -113,19 +113,16 @@ export default function Connect() {
       if (musicUserToken) {
         setAppleMusicConnected(true);
 
-        // Fetch the user's Apple Music taste profile via the apple-taste
-        // edge function. Stored under the same pending* state Spotify
-        // uses — the legacy field names (pendingSpotifyArtists etc.)
-        // carry the active service's taste data. A null return means
-        // Apple returned an error, the MUT is invalid, or the user has
-        // no listening history yet. In all cases we proceed to the
-        // tier picker rather than blocking onboarding — but we set a
-        // warning state so the user sees an inline note explaining why
-        // Browse will show only demo tracks on first load.
+        // Fetch the user's Apple Music taste profile. Both services
+        // populate the same pending* state. A null return means Apple
+        // returned an error, the MUT is invalid, or the user has no
+        // listening history yet — in all cases we proceed to the tier
+        // picker rather than blocking onboarding, but set a warning
+        // state so the user understands why Browse starts sparse.
         const taste = await fetchAppleMusicTaste(musicUserToken);
         if (taste) {
-          setPendingSpotifyArtists(taste.topArtists);
-          setPendingSpotifyTracks(taste.topTracks);
+          setPendingTopArtists(taste.topArtists);
+          setPendingTopTracks(taste.topTracks);
           if (taste.displayName) setPendingDisplayName(taste.displayName);
           setPendingArtistImages(taste.artistImages);
           setPendingArtistIds(taste.artistIds);
@@ -166,11 +163,11 @@ export default function Connect() {
     const profile: UserProfile = {
       streamingService,
       spotifyDisplayName: pendingDisplayName || undefined,
-      spotifyTopArtists: pendingSpotifyArtists || undefined,
-      spotifyTopTracks: pendingSpotifyTracks || undefined,
-      spotifyArtistImages: Object.keys(pendingArtistImages).length ? pendingArtistImages : undefined,
-      spotifyArtistIds: Object.keys(pendingArtistIds).length ? pendingArtistIds : undefined,
-      spotifyTrackImages: pendingTrackImages.length ? pendingTrackImages : undefined,
+      topArtists: pendingTopArtists || undefined,
+      topTracks: pendingTopTracks || undefined,
+      artistImages: Object.keys(pendingArtistImages).length ? pendingArtistImages : undefined,
+      artistIds: Object.keys(pendingArtistIds).length ? pendingArtistIds : undefined,
+      trackImages: pendingTrackImages.length ? pendingTrackImages : undefined,
       lastFmUsername: lastFmUsername.trim() || undefined,
       calculatedTier: t,
     };
@@ -215,7 +212,7 @@ export default function Connect() {
                   <div className="flex flex-col gap-3 w-full">
 
                     {/* Spotify — connect or show connected */}
-                    {!pendingSpotifyArtists ? (
+                    {!pendingTopArtists ? (
                       <button onClick={handleConnectSpotify} disabled={spotifyConnecting} className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground transition-all duration-200 disabled:opacity-70 border-green-500/40 hover:border-green-500 hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]">
                         <img src={spotifyLogo} alt="Spotify" className="w-8 h-8 object-contain" />
                         <span className="flex-1">Spotify</span>
@@ -226,7 +223,7 @@ export default function Connect() {
                         <img src={spotifyLogo} alt="Spotify" className="w-8 h-8 object-contain" />
                         <div className="flex-1 min-w-0">
                           <p>Spotify</p>
-                          <p className="text-xs font-normal text-green-400 truncate">Connected · {pendingSpotifyArtists.slice(0, 3).join(", ")}{pendingSpotifyArtists.length > 3 ? "..." : ""}</p>
+                          <p className="text-xs font-normal text-green-400 truncate">Connected · {pendingTopArtists.slice(0, 3).join(", ")}{pendingTopArtists.length > 3 ? "..." : ""}</p>
                         </div>
                         <span className="text-xs font-semibold text-green-400">✓</span>
                       </div>

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -82,16 +82,16 @@ export default function Listen() {
     if (!realTrackMeta) return null;
     // Try URL query param first (demo tiles pass ?art=), then profile, then DiceBear
     let coverArtUrl = urlArt;
-    if (!coverArtUrl && profile?.spotifyTrackImages) {
-      const match = profile.spotifyTrackImages.find(
+    if (!coverArtUrl && profile?.trackImages) {
+      const match = profile.trackImages.find(
         (t) =>
           t.title.toLowerCase() === realTrackMeta.title.toLowerCase() &&
           t.artist.toLowerCase() === realTrackMeta.artist.toLowerCase()
       );
       if (match?.imageUrl) coverArtUrl = match.imageUrl;
     }
-    if (!coverArtUrl && profile?.spotifyArtistImages?.[realTrackMeta.artist]) {
-      coverArtUrl = profile.spotifyArtistImages[realTrackMeta.artist];
+    if (!coverArtUrl && profile?.artistImages?.[realTrackMeta.artist]) {
+      coverArtUrl = profile.artistImages[realTrackMeta.artist];
     }
     if (!coverArtUrl) {
       coverArtUrl = `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(realTrackMeta.artist + realTrackMeta.title)}&backgroundColor=111827&textColor=ffffff&fontSize=30`;
@@ -107,7 +107,7 @@ export default function Listen() {
       coverArtUrl,
       trackNumber: 1,
     };
-  }, [realTrackMeta, trackId, urlArt, profile?.spotifyTrackImages, profile?.spotifyArtistImages]);
+  }, [realTrackMeta, trackId, urlArt, profile?.trackImages, profile?.artistImages]);
 
   // ── Playback source resolution ───────────────────────────────────────
   const { hasSpotifyToken } = useSpotifyToken();
@@ -351,7 +351,7 @@ export default function Listen() {
             (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
           );
           if (recs.length > 0) {
-            const topArtists = new Set((profile?.spotifyTopArtists || []).map((a: string) => a.toLowerCase()));
+            const topArtists = new Set((profile?.topArtists || []).map((a: string) => a.toLowerCase()));
             const boosted = recs.filter((t) => topArtists.has(t.artist.toLowerCase()));
             const pool = boosted.length > 0 ? boosted : recs;
             navigateTo(pool[Math.floor(Math.random() * Math.min(pool.length, 3))]);
@@ -380,13 +380,13 @@ export default function Listen() {
       }
 
       // P4: User's catalog (prefer different artist, relax if needed).
-      // spotifyTrackImages is legacy-named but populated from the active
-      // service's taste data (Spotify or Apple via apple-taste).
-      const userTracks = (profile?.spotifyTrackImages || []).filter(
+      // trackImages is populated from the active service's taste data
+      // (Spotify or Apple via apple-taste).
+      const userTracks = (profile?.trackImages || []).filter(
         (t) => t.uri && notPlayed(t.artist, t.title) && t.artist.toLowerCase() !== artistLower
       );
       const relaxed = userTracks.length > 0 ? userTracks
-        : (profile?.spotifyTrackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
+        : (profile?.trackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
       if (relaxed.length > 0) {
         const pick = relaxed[Math.floor(Math.random() * relaxed.length)];
         navigateTo({ artist: pick.artist, title: pick.title, album: "", uri: pick.uri });
@@ -601,7 +601,7 @@ export default function Listen() {
   // AI-generated nuggets with real sources
   const tier = (profile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
   useTierAccent(tier);
-  const artistImageUrl = (track?.artist && profile?.spotifyArtistImages?.[track.artist]) || track?.coverArtUrl || "";
+  const artistImageUrl = (track?.artist && profile?.artistImages?.[track.artist]) || track?.coverArtUrl || "";
   const { nuggets: aiNuggets, sources: aiSources, loading: aiLoading, error: aiError, listenCount, artistSummary, fromCache: aiFromCache } = useAINuggets(
     trackId,
     track?.artist || "",
@@ -612,8 +612,8 @@ export default function Listen() {
     track?.coverArtUrl,
     artistImageUrl,
     tier,
-    profile?.spotifyTopArtists,
-    profile?.spotifyTopTracks
+    profile?.topArtists,
+    profile?.topTracks
   );
 
   // Log AI nugget errors for debugging

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -943,12 +943,34 @@ export default function Listen() {
       // handle playback via the Spotify API. Calling resume() too early
       // would briefly play the OLD track. On very slow SDK loads (>2s)
       // this guard expires and resume() acts as a safety net.
-      // TODO: clear trackLoadTimestampRef on Spotify SDK "ready" event
-      // for a more robust handoff instead of a fixed timeout.
       if (Date.now() - trackLoadTimestampRef.current < 2000) return;
       play();
     }
   }, [play, isExternalListenMode, trackUri, player.currentTrackUri]);
+
+  // Delayed safety-net: if the track was loaded but NEVER started playing
+  // after 4s (autoPlay PUT failed or auto-resume fired in the 2s guard),
+  // retry play(). Skips if the track has played at any point since the URI
+  // changed — so a deliberate pause within 4s won't be force-resumed.
+  const isPlayingRef = useRef(isPlaying);
+  useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
+  const currentTrackUriRef = useRef(player.currentTrackUri);
+  useEffect(() => { currentTrackUriRef.current = player.currentTrackUri; }, [player.currentTrackUri]);
+  const hasEverPlayedRef = useRef(false);
+  useEffect(() => { hasEverPlayedRef.current = false; }, [trackUri]);
+  useEffect(() => { if (isPlaying) hasEverPlayedRef.current = true; }, [isPlaying]);
+
+  useEffect(() => {
+    if (isExternalListenMode || !trackUri) return;
+    const capturedUri = trackUri;
+    const timer = setTimeout(() => {
+      if (currentTrackUriRef.current === capturedUri && !isPlayingRef.current && !hasEverPlayedRef.current) {
+        console.log("[Listen] Safety-net: track never started after 4s — retrying play()");
+        play();
+      }
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [trackUri, isExternalListenMode, play]);
 
   useEffect(() => {
     if (trackNuggets.length === 0) return;

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -18,23 +18,16 @@ import { useIsMobile } from "@/hooks/use-mobile";
 const ImmersiveNuggetView = lazy(() => import("@/components/immersive/ImmersiveNuggetView"));
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useAINuggets } from "@/hooks/useAINuggets";
-import { getSeedCompanion, getDemoTrackById, getDemoTrackUri, DEMO_TRACKS } from "@/data/seedNuggets";
+import { getSeedCompanion, getDemoTrackById, getDemoTrackUri } from "@/data/seedNuggets";
 import { useSpotifyToken } from "@/hooks/useSpotifyToken";
 import { initiateSpotifyAuth } from "@/hooks/useSpotifyAuth";
 import { usePlayer } from "@/contexts/PlayerContext";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { withAppleStorefront } from "@/lib/appleStorefront";
+import { pickNextTrack, type SpotifyTrackResult } from "@/lib/skipCascade";
 import { useTierAccent } from "@/hooks/useTierAccent";
 import PageTransition from "@/components/PageTransition";
 import type { Nugget, Source, AnimationStyle } from "@/mock/types";
-
-/** Shape of a track result returned by the spotify-search edge function. */
-interface SpotifyTrackResult {
-  title: string;
-  artist: string;
-  album?: string;
-  uri?: string;
-}
 
 const HIDE_DELAY = 3000;
 
@@ -281,134 +274,28 @@ export default function Listen() {
     }
   }, [rawTrackId]);
 
-  // Navigate to the next track using a 5-level priority cascade:
-  // P1: Album continuation → P2: Spotify recs (taste-weighted) → P3: Same-artist top tracks
-  // → P4: User's catalog → P5: Demo track fallback
   const navigateToRelated = useCallback(async () => {
     if (!track) return;
     isNavigatingRef.current = true;
     setSkipLoading(true);
-    const titleLower = track.title.toLowerCase();
-    const artistLower = track.artist.toLowerCase();
 
     const enc = encodeURIComponent;
-    const navigateTo = (pick: { artist: string; title: string; album?: string; uri?: string }) => {
-      if (!mountedRef.current) return;
-      player.addToSessionHistory(pick.artist, pick.title);
-      navigate(`/listen/real::${enc(pick.artist)}::${enc(pick.title)}::${enc(pick.album || "")}::${enc(pick.uri || "")}`);
-    };
-    const notPlayed = (a: string, t: string) => !player.isInSessionHistory(a, t);
-
-    const service: "apple" | "spotify" = isAppleMusicUser ? "apple" : "spotify";
-
     try {
-      // P1-P4 cascade: album continuation → recommendations → same-artist
-      // top tracks → user catalog. Each P-level naturally falls through
-      // when the signal isn't available for the active service.
-      //   P1 is Spotify-only (reads player.spotifyStateTrack which only
-      //     the Spotify playback engine populates — skipped for Apple).
-      //   P2 recommend fires only for Spotify users; the Apple catalog
-      //     has no seed-based recommendations endpoint, so firing it
-      //     would be a wasted ~200ms round trip that always returns
-      //     {tracks:[]}.
-      //   P3 and P4 work for both services via the service param.
-
-      // P1: Album continuation — play next track on the same album.
-      // Gated on !isAppleMusicUser in addition to the spotifyStateTrack
-      // null check so a future PlayerContext change can't accidentally
-      // route Apple users through the Spotify catalog.
-      if (!isAppleMusicUser) {
-        const albumUri = player.spotifyStateTrack?.spotifyAlbumUri;
-        if (albumUri) {
-          const albumId = albumUri.replace("spotify:album:", "");
-          if (/^[a-zA-Z0-9]{20,25}$/.test(albumId)) {
-            const { data: albumData } = await supabase.functions.invoke("spotify-album", {
-              body: { albumId, service: "spotify" },
-            });
-            if (albumData?.tracks?.length) {
-              const currentIdx = albumData.tracks.findIndex(
-                (t: any) => t.uri === trackUri
-              );
-              if (currentIdx >= 0 && currentIdx < albumData.tracks.length - 1) {
-                const next = albumData.tracks[currentIdx + 1];
-                if (notPlayed(next.artist, next.title)) {
-                  navigateTo(next);
-                  return;
-                }
-              }
-            }
-          }
-        }
-
-        // P2: Spotify recommendations (taste-weighted — prefer user's
-        // top artists). Skipped for Apple users because Apple has no
-        // seed-based recommendations endpoint.
-        if (trackUri) {
-          const { data: recData } = await supabase.functions.invoke("spotify-search", {
-            body: { recommend: trackUri, service: "spotify" },
-          });
-          const recs = ((recData?.tracks || []) as SpotifyTrackResult[]).filter(
-            (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
-          );
-          if (recs.length > 0) {
-            const topArtists = new Set((profile?.topArtists || []).map((a: string) => a.toLowerCase()));
-            const boosted = recs.filter((t) => topArtists.has(t.artist.toLowerCase()));
-            const pool = boosted.length > 0 ? boosted : recs;
-            navigateTo(pool[Math.floor(Math.random() * Math.min(pool.length, 3))]);
-            return;
-          }
-        }
-      }
-
-      // P3: Same-artist top tracks (via spotify-artist, which caches).
-      // Works for both services via service + storefront.
-      const artistBody = withAppleStorefront(
-        { artistName: track.artist, service },
-        service,
-      );
-      const { data: artistData } = await supabase.functions.invoke("spotify-artist", {
-        body: artistBody,
+      const pick = await pickNextTrack({
+        track,
+        trackUri,
+        profile,
+        isAppleMusicUser,
+        spotifyAlbumUri: player.spotifyStateTrack?.spotifyAlbumUri,
+        isInSessionHistory: player.isInSessionHistory,
+        invoke: supabase.functions.invoke.bind(supabase.functions),
       });
-      if (artistData?.topTracks?.length) {
-        const candidates = (artistData.topTracks as SpotifyTrackResult[]).filter(
-          (t) => t.title.toLowerCase() !== titleLower && notPlayed(t.artist, t.title)
-        );
-        if (candidates.length > 0) {
-          navigateTo(candidates[Math.floor(Math.random() * Math.min(candidates.length, 5))]);
-          return;
-        }
+      if (pick && mountedRef.current) {
+        player.addToSessionHistory(pick.artist, pick.title);
+        navigate(`/listen/real::${enc(pick.artist)}::${enc(pick.title)}::${enc(pick.album)}::${enc(pick.uri)}`);
+      } else if (!pick) {
+        console.warn("[Listen] No next track found");
       }
-
-      // P4: User's catalog (prefer different artist, relax if needed).
-      // trackImages is populated from the active service's taste data
-      // (Spotify or Apple via apple-taste).
-      const userTracks = (profile?.trackImages || []).filter(
-        (t) => t.uri && notPlayed(t.artist, t.title) && t.artist.toLowerCase() !== artistLower
-      );
-      const relaxed = userTracks.length > 0 ? userTracks
-        : (profile?.trackImages || []).filter((t) => t.uri && notPlayed(t.artist, t.title));
-      if (relaxed.length > 0) {
-        const pick = relaxed[Math.floor(Math.random() * relaxed.length)];
-        navigateTo({ artist: pick.artist, title: pick.title, album: "", uri: pick.uri });
-        return;
-      }
-
-      // P5: Demo track fallback. For Apple Music users, filter to tracks
-      // that have an appleMusicUri so we don't navigate to an unplayable URI.
-      const playableDemos = DEMO_TRACKS.filter((d) => {
-        if (!notPlayed(d.artist, d.title)) return false;
-        if (isAppleMusicUser) return !!d.appleMusicUri;
-        return true;
-      });
-      if (playableDemos.length > 0) {
-        const pick = playableDemos[Math.floor(Math.random() * playableDemos.length)];
-        const uri = getDemoTrackUri(pick, profile?.streamingService);
-        navigateTo({ artist: pick.artist, title: pick.title, album: pick.album, uri });
-        return;
-      }
-
-      // True last resort: stay on current track
-      console.warn("[Listen] No next track found");
     } catch (err) {
       console.warn("[Listen] Skip next failed:", err);
     } finally {

--- a/src/pages/SpotifyCallback.tsx
+++ b/src/pages/SpotifyCallback.tsx
@@ -67,11 +67,11 @@ export default function SpotifyCallback() {
           ...profile,
           streamingService: "Spotify",
           spotifyDisplayName: taste.displayName || profile.spotifyDisplayName,
-          spotifyTopArtists: taste.topArtists,
-          spotifyTopTracks: taste.topTracks,
-          spotifyArtistImages: taste.artistImages,
-          spotifyArtistIds: taste.artistIds,
-          spotifyTrackImages: taste.trackImages,
+          topArtists: taste.topArtists,
+          topTracks: taste.topTracks,
+          artistImages: taste.artistImages,
+          artistIds: taste.artistIds,
+          trackImages: taste.trackImages,
         });
       }
       // If no profile exists yet (direct OAuth before setup), store data in sessionStorage

--- a/src/test/AlbumDetail.apple.test.tsx
+++ b/src/test/AlbumDetail.apple.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor, act } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+// Mock supabase BEFORE importing AlbumDetail so the component picks up
+// the mocked client. AlbumDetail does not use useUserProfile or
+// useArtistImage, so the mock surface is even smaller than ArtistProfile.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: { invoke: vi.fn() },
+  },
+}));
+
+import AlbumDetail from "@/pages/AlbumDetail";
+import { supabase } from "@/integrations/supabase/client";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+function fakeAlbumResponse(id: string, name: string, artistId: string, artistName: string) {
+  return {
+    data: {
+      found: true,
+      album: {
+        id,
+        name,
+        imageUrl: "",
+        releaseDate: "1997-05-21",
+        albumType: "album",
+        totalTracks: 12,
+        artist: { id: artistId, name: artistName },
+        label: "",
+      },
+      tracks: [],
+    },
+    error: null,
+  } as any;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/album/:albumId" element={<AlbumDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("MusicKit", { getInstance: () => ({ storefrontCountryCode: "us" }) });
+  invoke.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Locks the apple::/spotify:: prefix routing to their respective
+// `service` param in the spotify-album edge-function call. The
+// service param is what the backend branches on — getting it wrong
+// silently fetches from the wrong catalog.
+
+describe("AlbumDetail catalog routing", () => {
+  it("apple:: prefix invokes spotify-album with service='apple' + storefront", async () => {
+    invoke.mockResolvedValueOnce(fakeAlbumResponse("987654321", "OK Computer", "123456789", "Radiohead"));
+
+    renderAt("/album/apple::987654321::Radiohead::123456789");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-album", {
+      body: {
+        albumId: "987654321",
+        service: "apple",
+        storefront: "us",
+      },
+    });
+  });
+
+  it("spotify:: prefix invokes spotify-album with service='spotify' (no storefront)", async () => {
+    invoke.mockResolvedValueOnce(
+      fakeAlbumResponse("6dVIqQ8qmQ5GBnJ9shOYGE", "OK Computer", "4Z8W4fKeB5YxbusRsdQVPb", "Radiohead"),
+    );
+
+    renderAt("/album/spotify::6dVIqQ8qmQ5GBnJ9shOYGE::Radiohead::4Z8W4fKeB5YxbusRsdQVPb");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-album", {
+      body: {
+        albumId: "6dVIqQ8qmQ5GBnJ9shOYGE",
+        service: "spotify",
+      },
+    });
+  });
+
+  it("bare apple:: with empty album id short-circuits before the edge call", async () => {
+    renderAt("/album/apple::");
+
+    // Drain pending microtasks/effects deterministically instead of a
+    // timer-based wait, which can race on slow CI runners.
+    await act(async () => {});
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/ArtistProfile.apple.test.tsx
+++ b/src/test/ArtistProfile.apple.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor, act } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+// Mock supabase BEFORE importing ArtistProfile so the component picks up
+// the mocked client. Also mock useUserProfile + useArtistImage to keep
+// the test surface narrow — routing + edge-function invocation only.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: { invoke: vi.fn() },
+  },
+}));
+vi.mock("@/hooks/useMusicNerdState", () => ({
+  useUserProfile: () => ({ profile: null, saveProfile: vi.fn(), clearProfile: vi.fn() }),
+}));
+vi.mock("@/hooks/useArtistImage", () => ({
+  useArtistImage: () => null,
+}));
+
+import ArtistProfile from "@/pages/ArtistProfile";
+import { supabase } from "@/integrations/supabase/client";
+
+const invoke = vi.mocked(supabase.functions.invoke);
+
+function fakeArtistResponse(id: string, name: string) {
+  return {
+    data: {
+      found: true,
+      artist: { id, name, imageUrl: "", genres: [], followers: 0 },
+      topTracks: [],
+      albums: [],
+      relatedArtists: [],
+    },
+    error: null,
+  } as any;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/artist/:artistId" element={<ArtistProfile />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("MusicKit", { getInstance: () => ({ storefrontCountryCode: "us" }) });
+  invoke.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Locks the apple::/spotify:: prefix routing to their respective
+// `service` param in the spotify-artist edge-function call.
+// Without this test, a regression that drops the service param (or
+// flips the two) would silently send Apple users to the Spotify
+// catalog — manifesting as wrong artist data or a 404, not a build
+// error.
+
+describe("ArtistProfile catalog routing", () => {
+  it("apple:: prefix invokes spotify-artist with service='apple' + storefront", async () => {
+    invoke.mockResolvedValueOnce(fakeArtistResponse("123456789", "Radiohead"));
+
+    renderAt("/artist/apple::123456789::Radiohead");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-artist", {
+      body: {
+        service: "apple",
+        artistId: "123456789",
+        storefront: "us",
+      },
+    });
+  });
+
+  it("spotify:: prefix invokes spotify-artist with service='spotify' (no storefront)", async () => {
+    invoke.mockResolvedValueOnce(fakeArtistResponse("4Z8W4fKeB5YxbusRsdQVPb", "Radiohead"));
+
+    renderAt("/artist/spotify::4Z8W4fKeB5YxbusRsdQVPb::Radiohead");
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(invoke).toHaveBeenCalledWith("spotify-artist", {
+      body: {
+        service: "spotify",
+        artistId: "4Z8W4fKeB5YxbusRsdQVPb",
+      },
+    });
+  });
+
+  it("bare apple:: with empty id short-circuits before the edge call", async () => {
+    // parseAppleArtist returns null for an empty id bucket, so neither
+    // the apple nor spotify branch renders RealArtistProfile — the
+    // edge function must not fire at all.
+    renderAt("/artist/apple::");
+
+    // Drain pending microtasks/effects deterministically instead of a
+    // timer-based wait, which can race on slow CI runners.
+    await act(async () => {});
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/resolveStreamingService.test.ts
+++ b/src/test/resolveStreamingService.test.ts
@@ -15,8 +15,9 @@ describe("resolveStreamingService", () => {
 
   it("preserves Apple Music even when topArtists is populated (the bug fix)", () => {
     // Scenario: user first connected Spotify, later switched to Apple Music.
-    // Their DB row still has spotify_taste. The old logic clobbered service
-    // back to "Spotify" on the next DB load — this test locks that invariant.
+    // Their row still carries Spotify-origin topArtists. The old logic
+    // clobbered service back to "Spotify" on the next DB load — this test
+    // locks that invariant.
     expect(resolveStreamingService("Apple Music", 20)).toBe("Apple Music");
   });
 

--- a/src/test/resolveStreamingService.test.ts
+++ b/src/test/resolveStreamingService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { resolveStreamingService } from "@/hooks/useMusicNerdState";
 
 // Regression: useMusicNerdState previously force-set streamingService="Spotify"
-// whenever dbProfile.spotifyTopArtists existed, even for Apple Music users.
+// whenever dbProfile.topArtists existed, even for Apple Music users.
 // This silently downgraded Apple Music users whose row still had legacy
 // Spotify taste data. The new logic prefers the explicit service when set.
 
@@ -13,20 +13,20 @@ describe("resolveStreamingService", () => {
     expect(resolveStreamingService("YouTube Music", 20)).toBe("YouTube Music");
   });
 
-  it("preserves Apple Music even when spotifyTopArtists is populated (the bug fix)", () => {
+  it("preserves Apple Music even when topArtists is populated (the bug fix)", () => {
     // Scenario: user first connected Spotify, later switched to Apple Music.
     // Their DB row still has spotify_taste. The old logic clobbered service
     // back to "Spotify" on the next DB load — this test locks that invariant.
     expect(resolveStreamingService("Apple Music", 20)).toBe("Apple Music");
   });
 
-  it("falls back to Spotify when service is unset but spotifyTopArtists is populated", () => {
+  it("falls back to Spotify when service is unset but topArtists is populated", () => {
     // Legacy rows from before streaming_service was persisted
     expect(resolveStreamingService(undefined, 15)).toBe("Spotify");
     expect(resolveStreamingService("", 15)).toBe("Spotify");
   });
 
-  it("returns empty string when service is unset and no spotifyTopArtists", () => {
+  it("returns empty string when service is unset and no topArtists", () => {
     expect(resolveStreamingService(undefined, 0)).toBe("");
     expect(resolveStreamingService("", 0)).toBe("");
   });

--- a/src/test/skipCascade.test.ts
+++ b/src/test/skipCascade.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { pickNextTrack, type InvokeFn } from "@/lib/skipCascade";
+import type { UserProfile } from "@/mock/types";
+
+// Stub MusicKit for withAppleStorefront, and lock Math.random to 0 so
+// every "random" pick resolves to index 0 — tests stay deterministic
+// without having to predict the weighted branches.
+beforeEach(() => {
+  vi.stubGlobal("MusicKit", { getInstance: () => ({ storefrontCountryCode: "us" }) });
+  vi.spyOn(Math, "random").mockReturnValue(0);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const noHistory = () => false;
+
+const baseDeps = {
+  track: { artist: "Radiohead", title: "Karma Police" },
+  trackUri: "spotify:track:abc",
+  profile: null,
+  spotifyAlbumUri: null,
+  isInSessionHistory: noHistory,
+};
+
+function mockInvoke(map: Record<string, unknown | ((body: Record<string, unknown>) => unknown)>): InvokeFn {
+  return vi.fn(async (name: string, options: { body: Record<string, unknown> }) => {
+    const entry = map[name];
+    if (entry === undefined) return { data: null };
+    const data = typeof entry === "function" ? (entry as (b: Record<string, unknown>) => unknown)(options.body) : entry;
+    return { data };
+  });
+}
+
+describe("pickNextTrack skip cascade", () => {
+  describe("Spotify user", () => {
+    it("P1: returns the next album track when the current track is mid-album", async () => {
+      const invoke = mockInvoke({
+        "spotify-album": {
+          tracks: [
+            { artist: "Radiohead", title: "Karma Police", album: "OK Computer", uri: "spotify:track:abc" },
+            { artist: "Radiohead", title: "Fitter Happier", album: "OK Computer", uri: "spotify:track:fitter" },
+          ],
+        },
+      });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: "spotify:album:6dVIqQ8qmQ5GBnJ9shOYGE",
+        invoke,
+      });
+
+      expect(pick).toEqual({
+        artist: "Radiohead",
+        title: "Fitter Happier",
+        album: "OK Computer",
+        uri: "spotify:track:fitter",
+      });
+      expect(invoke).toHaveBeenCalledWith("spotify-album", expect.objectContaining({
+        body: expect.objectContaining({ service: "spotify" }),
+      }));
+    });
+
+    it("P1: falls through to P2 when the album URI has a malformed ID", async () => {
+      // albumId "short" fails /^[a-zA-Z0-9]{20,25}$/; guard bypasses the edge call.
+      const invoke = mockInvoke({
+        "spotify-search": { tracks: [{ artist: "Portishead", title: "Roads", uri: "spotify:track:roads" }] },
+      });
+      await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: "spotify:album:short",
+        invoke,
+      });
+      expect(invoke).not.toHaveBeenCalledWith("spotify-album", expect.anything());
+      expect(invoke).toHaveBeenCalledWith("spotify-search", expect.anything());
+    });
+
+    it("P1: falls through when the current track is the last on the album (off-by-one boundary)", async () => {
+      const invoke = mockInvoke({
+        "spotify-album": {
+          tracks: [
+            { artist: "Radiohead", title: "Other", uri: "spotify:track:other" },
+            { artist: "Radiohead", title: "Karma Police", uri: "spotify:track:abc" }, // last, matches baseDeps.trackUri
+          ],
+        },
+        "spotify-search": { tracks: [{ artist: "Portishead", title: "Roads", uri: "spotify:track:roads" }] },
+      });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: "spotify:album:6dVIqQ8qmQ5GBnJ9shOYGE",
+        invoke,
+      });
+      expect(pick?.title).toBe("Roads");
+    });
+
+    it("P1: falls through when the current track is not on the album (currentIdx === -1)", async () => {
+      const invoke = mockInvoke({
+        "spotify-album": { tracks: [{ artist: "Radiohead", title: "Other", uri: "spotify:track:nomatch" }] },
+        "spotify-search": { tracks: [{ artist: "Portishead", title: "Roads", uri: "spotify:track:roads" }] },
+      });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: "spotify:album:6dVIqQ8qmQ5GBnJ9shOYGE",
+        invoke,
+      });
+      expect(pick?.title).toBe("Roads");
+    });
+
+    it("P2: falls through to recommendations when no album continuation is available", async () => {
+      const invoke = mockInvoke({
+        "spotify-search": {
+          tracks: [{ artist: "Portishead", title: "Roads", uri: "spotify:track:roads" }],
+        },
+      });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: null,
+        invoke,
+      });
+
+      expect(pick?.title).toBe("Roads");
+      expect(invoke).toHaveBeenCalledWith("spotify-search", expect.objectContaining({
+        body: expect.objectContaining({ recommend: "spotify:track:abc", service: "spotify" }),
+      }));
+    });
+
+    it("P2: skipped when trackUri is undefined", async () => {
+      const invoke = mockInvoke({
+        "spotify-artist": { topTracks: [{ artist: "Radiohead", title: "Lucky", uri: "spotify:track:lucky" }] },
+      });
+      await pickNextTrack({
+        ...baseDeps,
+        trackUri: undefined,
+        isAppleMusicUser: false,
+        invoke,
+      });
+      expect(invoke).not.toHaveBeenCalledWith("spotify-search", expect.anything());
+      expect(invoke).toHaveBeenCalledWith("spotify-artist", expect.anything());
+    });
+
+    it("P2: filters out recommendations with the same title as the current track (case-insensitive)", async () => {
+      const invoke = mockInvoke({
+        "spotify-search": {
+          tracks: [
+            { artist: "Other", title: "KARMA POLICE", uri: "spotify:track:dup" },
+            { artist: "Portishead", title: "Roads", uri: "spotify:track:roads" },
+          ],
+        },
+      });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: null,
+        invoke,
+      });
+      expect(pick?.title).toBe("Roads");
+    });
+
+    it("P2: boosts recommendations from the user's top artists when present", async () => {
+      const invoke = mockInvoke({
+        "spotify-search": {
+          tracks: [
+            { artist: "Unknown Band", title: "Unranked", uri: "spotify:track:unknown" },
+            { artist: "Pink Floyd", title: "Time", uri: "spotify:track:time" },
+            { artist: "Random Act", title: "Random Song", uri: "spotify:track:random" },
+          ],
+        },
+      });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        spotifyAlbumUri: null,
+        profile: { topArtists: ["Pink Floyd"] } as UserProfile,
+        invoke,
+      });
+
+      // Math.random = 0 picks index 0 of the boosted pool. Only Pink Floyd
+      // matches the top-artist filter, so the boosted pool has one entry.
+      expect(pick?.artist).toBe("Pink Floyd");
+      expect(pick?.title).toBe("Time");
+    });
+
+    it("P5: Spotify user falls back to a demo track without the appleMusicUri filter", async () => {
+      const invoke = mockInvoke({
+        "spotify-album": { tracks: [] },
+        "spotify-search": { tracks: [] },
+        "spotify-artist": { topTracks: [] },
+      });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        profile: { streamingService: "Spotify", trackImages: [] } as UserProfile,
+        invoke,
+      });
+      expect(pick).not.toBeNull();
+      expect(pick?.uri).toMatch(/^spotify:track:/);
+    });
+  });
+
+  describe("Apple Music user", () => {
+    it("skips P1 and P2 entirely, calling spotify-artist with service: 'apple'", async () => {
+      const invoke = mockInvoke({
+        "spotify-artist": {
+          topTracks: [{ artist: "Radiohead", title: "Lucky", uri: "apple:song:lucky", album: "OK Computer" }],
+        },
+      });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        spotifyAlbumUri: "spotify:album:6dVIqQ8qmQ5GBnJ9shOYGE",
+        invoke,
+      });
+
+      expect(pick).toEqual({
+        artist: "Radiohead",
+        title: "Lucky",
+        album: "OK Computer",
+        uri: "apple:song:lucky",
+      });
+
+      // Only the P3 call should have fired — P1 (spotify-album) and P2
+      // (spotify-search) must be completely skipped.
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("spotify-artist", expect.objectContaining({
+        body: expect.objectContaining({
+          service: "apple",
+          artistName: "Radiohead",
+          storefront: "us",
+        }),
+      }));
+    });
+
+    it("falls through P3 → P4 using profile.trackImages when artist has no fresh top tracks", async () => {
+      const invoke = mockInvoke({ "spotify-artist": { topTracks: [] } });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        profile: {
+          trackImages: [
+            { title: "Glory", artist: "Jamie xx", imageUrl: "x.jpg", uri: "apple:song:glory" },
+          ],
+        } as UserProfile,
+        invoke,
+      });
+
+      expect(pick).toEqual({
+        artist: "Jamie xx",
+        title: "Glory",
+        album: "",
+        uri: "apple:song:glory",
+      });
+      expect(invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it("P4: uses the relaxed fallback when every user track is the same artist as current", async () => {
+      const invoke = mockInvoke({ "spotify-artist": { topTracks: [] } });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        profile: {
+          trackImages: [
+            { title: "Only Song", artist: "Radiohead", imageUrl: "x.jpg", uri: "apple:song:only" },
+          ],
+        } as UserProfile,
+        invoke,
+      });
+      // userTracks (different-artist filter) is empty → relaxed path picks the same-artist track.
+      expect(pick?.title).toBe("Only Song");
+      expect(pick?.artist).toBe("Radiohead");
+    });
+
+    it("P4: skips trackImages entries without a uri", async () => {
+      const invoke = mockInvoke({ "spotify-artist": { topTracks: [] } });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        profile: {
+          trackImages: [
+            { title: "No URI", artist: "X", imageUrl: "x.jpg", uri: "" },
+            { title: "Has URI", artist: "Y", imageUrl: "x.jpg", uri: "apple:song:yes" },
+          ],
+        } as UserProfile,
+        invoke,
+      });
+      expect(pick?.title).toBe("Has URI");
+    });
+
+    it("falls through P3 + P4 → P5 demo fallback, filtering to tracks with an appleMusicUri", async () => {
+      const invoke = mockInvoke({ "spotify-artist": { topTracks: [] } });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        profile: { streamingService: "Apple Music", trackImages: [] } as UserProfile,
+        invoke,
+      });
+
+      // P5 picks a demo track. We only assert it returned one — any demo
+      // with an appleMusicUri is valid given Math.random = 0.
+      expect(pick).not.toBeNull();
+      expect(pick?.uri).toBeTruthy();
+    });
+  });
+
+  describe("session history", () => {
+    it("filters out tracks already in the session history at every level", async () => {
+      const history = new Set(["radiohead::lucky"]);
+      const invoke = mockInvoke({
+        "spotify-artist": {
+          topTracks: [
+            { artist: "Radiohead", title: "Lucky", uri: "apple:song:lucky" },
+            { artist: "Radiohead", title: "Exit Music", uri: "apple:song:exit" },
+          ],
+        },
+      });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        isInSessionHistory: (a, t) => history.has(`${a.toLowerCase()}::${t.toLowerCase()}`),
+        invoke,
+      });
+
+      expect(pick?.title).toBe("Exit Music");
+    });
+  });
+
+  describe("exhausted", () => {
+    it("returns null only when every level falls through and all demos are in history", async () => {
+      const invoke = mockInvoke({
+        "spotify-album": { tracks: [] },
+        "spotify-search": { tracks: [] },
+        "spotify-artist": { topTracks: [] },
+      });
+
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: false,
+        profile: { trackImages: [] } as UserProfile,
+        // Mark every artist/title as played — demos included.
+        isInSessionHistory: () => true,
+        invoke,
+      });
+
+      expect(pick).toBeNull();
+    });
+
+    it("returns null for Apple users when every Apple-compatible demo is in history", async () => {
+      const invoke = mockInvoke({ "spotify-artist": { topTracks: [] } });
+      const pick = await pickNextTrack({
+        ...baseDeps,
+        isAppleMusicUser: true,
+        profile: { trackImages: [] } as UserProfile,
+        isInSessionHistory: () => true,
+        invoke,
+      });
+      expect(pick).toBeNull();
+    });
+  });
+
+  describe("error propagation", () => {
+    it("propagates errors from invoke to the caller", async () => {
+      const invoke = vi.fn(async () => {
+        throw new Error("edge function down");
+      }) as unknown as InvokeFn;
+      await expect(
+        pickNextTrack({ ...baseDeps, isAppleMusicUser: false, spotifyAlbumUri: null, invoke }),
+      ).rejects.toThrow("edge function down");
+    });
+  });
+});

--- a/src/test/useUserProfile.test.ts
+++ b/src/test/useUserProfile.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/integrations/supabase/client", () => ({
   },
 }));
 
-import { useUserProfile } from "@/hooks/useMusicNerdState";
+import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import type { UserProfile } from "@/mock/types";
 
 const PROFILE_KEY = "musicnerd_profile";
@@ -104,5 +104,68 @@ describe("useUserProfile cross-instance sync", () => {
     // Apple Music playback: PlayerProvider needs to see the new service
     // to create the correct engine.
     expect(b.current.profile?.streamingService).toBe("Apple Music");
+  });
+});
+
+// Locks the localStorage read-compat that lets profiles written before the
+// spotify* → unprefixed rename (tracked in #51 P3.11) keep working. Drop
+// these tests when the compat shim is removed after soak.
+describe("getStoredProfile legacy-key migration", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("promotes all five legacy spotify* keys to their unprefixed counterparts", () => {
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Apple Music",
+      calculatedTier: "nerd",
+      spotifyTopArtists: ["Radiohead"],
+      spotifyTopTracks: ["Karma Police"],
+      spotifyArtistImages: { Radiohead: "radiohead.jpg" },
+      spotifyArtistIds: { Radiohead: "sp-1" },
+      spotifyTrackImages: [{ title: "Karma Police", artist: "Radiohead", imageUrl: "kp.jpg" }],
+    }));
+
+    const profile = getStoredProfile();
+    expect(profile?.topArtists).toEqual(["Radiohead"]);
+    expect(profile?.topTracks).toEqual(["Karma Police"]);
+    expect(profile?.artistImages).toEqual({ Radiohead: "radiohead.jpg" });
+    expect(profile?.artistIds).toEqual({ Radiohead: "sp-1" });
+    expect(profile?.trackImages).toEqual([{ title: "Karma Police", artist: "Radiohead", imageUrl: "kp.jpg" }]);
+    // Legacy keys are dropped from the in-memory profile
+    expect((profile as Record<string, unknown>)?.spotifyTopArtists).toBeUndefined();
+  });
+
+  it("prefers new keys when both legacy and new are present", () => {
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Spotify",
+      calculatedTier: "casual",
+      topArtists: ["Björk"],
+      spotifyTopArtists: ["Radiohead"],
+    }));
+
+    const profile = getStoredProfile();
+    expect(profile?.topArtists).toEqual(["Björk"]);
+  });
+
+  it("promotes a partial legacy profile, leaving absent fields undefined", () => {
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({
+      streamingService: "Apple Music",
+      calculatedTier: "casual",
+      spotifyTopArtists: ["Beach House"],
+      // no topTracks, no image maps, no artist ids
+    }));
+
+    const profile = getStoredProfile();
+    expect(profile?.topArtists).toEqual(["Beach House"]);
+    expect(profile?.topTracks).toBeUndefined();
+    expect(profile?.artistImages).toBeUndefined();
+    expect(profile?.artistIds).toBeUndefined();
+    expect(profile?.trackImages).toBeUndefined();
+  });
+
+  it("returns null for missing or malformed payload", () => {
+    expect(getStoredProfile()).toBeNull();
+
+    localStorage.setItem(PROFILE_KEY, "{not valid json");
+    expect(getStoredProfile()).toBeNull();
   });
 });

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { getAppleDeveloperToken } from "../_shared/apple-token.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -122,6 +123,10 @@ async function getSpotifyAppToken(): Promise<string | null> {
   } catch { return null; }
 }
 
+// NAMING DEBT: this interface is now populated by both Spotify and Apple
+// Music paths. The "Spotify" prefix is legacy from the single-service era.
+// Rename to `ArtistEnrichmentInfo` or similar when touching the broader
+// spotify* → catalog-agnostic rename tracked in #51.
 interface SpotifyArtistInfo {
   genres: string[];
   relatedArtists: string[];
@@ -197,6 +202,194 @@ async function fetchSpotifyArtistInfo(artistName: string, spotifyTrackId?: strin
     };
   } catch (e) {
     console.error("[Spotify] Artist info fetch failed:", e);
+    return null;
+  }
+}
+
+// ── Apple Music artist data (mirrors fetchSpotifyArtistInfo for Apple users) ──
+//
+// Apple Music users reach this path because the frontend sends an `appleTrackId`
+// extracted from `apple:song:XXX` URIs. We use Apple's catalog API to resolve
+// the track's canonical artist (avoiding name collisions the way the Spotify
+// path uses /v1/tracks/:id) then fetch the artist's genre + top-songs view.
+//
+// Returns the same `SpotifyArtistInfo` shape so downstream prompt-building
+// code (line ~1529 and Exa strategy selection) doesn't have to branch on
+// service. Apple exposes no direct follower count, so `followers` is set
+// to 0 — downstream popularity logic will treat Apple artists as SPARSE
+// (conservative strategy) until we add a cross-service popularity signal.
+// Apple catalog free-text fields (genre names, track names, album names) flow
+// into the Gemini prompt. They're user-controllable at the Apple catalog level
+// (artists self-submit release metadata), so a crafted entry could inject
+// prompt instructions via newlines or break prompt structure via control chars.
+// Strip anything that isn't a safe printable character. Cap length as a second
+// line of defense against prompt stuffing.
+function sanitizeCatalogField(raw: unknown): string {
+  if (typeof raw !== "string") return "";
+  return raw
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[\x00-\x1f\x7f]/g, "")
+    .slice(0, 200)
+    .trim();
+}
+
+// Used for console.log / console.warn interpolation of user-supplied strings
+// (artist names). Prevents log forgery via embedded newlines that would forge
+// log lines that look like legitimate events from other subsystems.
+function sanitizeForLog(raw: string): string {
+  return raw.replace(/[\r\n\t]+/g, " ").slice(0, 200);
+}
+
+// Apple catalog calls run on the user-blocking critical path (racing Exa in
+// Promise.all). Cap each at this budget so a stuck Apple API response can't
+// hang the entire nugget generation.
+const APPLE_TIMEOUT_MS = 3000;
+
+// Single fetch helper for all Apple Music calls — wraps the manual
+// AbortController + setTimeout pattern (matching _shared/apple-utils.ts:360)
+// so individual call sites stay terse and adding a new call site in the
+// future can't accidentally skip the timeout or leak the timer. Propagates
+// the Response; callers check .ok or catch AbortError at the outer boundary.
+async function fetchWithAppleTimeout(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number = APPLE_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchAppleArtistInfo(
+  artistName: string,
+  appleTrackId?: string,
+): Promise<SpotifyArtistInfo | null> {
+  try {
+    const devToken = await getAppleDeveloperToken();
+    if (!devToken) return null;
+
+    // TODO(#51): storefront is hardcoded to 'us'. Artists prominent in other
+    // storefronts (Japan, Korea, LatAm) may not surface cleanly in US catalog
+    // name search. Track alongside the cross-service popularity signal
+    // follow-up — both want a per-request catalog-locale parameter.
+    const headers = { Authorization: `Bearer ${devToken}` };
+
+    // Track ID route: Apple's song endpoint exposes the canonical artist
+    // relationship, which we use to pick the exact artist page. Prevents
+    // name collisions between homonymous artists (e.g. two bands called
+    // "Nirvana"). Also captures the song's genreNames so downstream code
+    // can merge them with the artist-level genre list.
+    const safeArtistNameLog = sanitizeForLog(artistName);
+    let appleArtistId: string | null = null;
+    let songGenres: string[] = [];
+
+    if (appleTrackId) {
+      const songRes = await fetchWithAppleTimeout(
+        `https://api.music.apple.com/v1/catalog/us/songs/${appleTrackId}?include=artists`,
+        headers,
+      );
+      if (songRes.ok) {
+        const songData = await songRes.json();
+        const song = songData?.data?.[0];
+        const rawSongGenres = song?.attributes?.genreNames;
+        songGenres = Array.isArray(rawSongGenres) ? rawSongGenres : [];
+        appleArtistId = song?.relationships?.artists?.data?.[0]?.id || null;
+        if (appleArtistId) {
+          console.log(`[Apple Music] Resolved artist from track ID: ${safeArtistNameLog} (${appleArtistId})`);
+        }
+      } else {
+        // Log so Apple rate-limits (429) and upstream 5xx are distinguishable
+        // from legitimate "track not found" in edge function logs.
+        console.warn(`[Apple Music] songs/${appleTrackId} returned ${songRes.status}`);
+      }
+    }
+
+    // Name-search fallback: if the track-based resolution failed (track id
+    // invalid, song unavailable, relationship missing), fall back to the
+    // catalog search endpoint. Matches the Spotify path's fallback.
+    if (!appleArtistId) {
+      const q = encodeURIComponent(artistName.trim());
+      const searchRes = await fetchWithAppleTimeout(
+        `https://api.music.apple.com/v1/catalog/us/search?types=artists&limit=1&term=${q}`,
+        headers,
+      );
+      if (!searchRes.ok) {
+        console.warn(`[Apple Music] search returned ${searchRes.status} for "${safeArtistNameLog}"`);
+        return null;
+      }
+      const searchData = await searchRes.json();
+      appleArtistId = searchData?.results?.artists?.data?.[0]?.id || null;
+    }
+    if (!appleArtistId) return null;
+
+    // Fetch the artist page with views=top-songs so we get the top tracks
+    // the same way Spotify's /artists/:id/top-tracks gives us a priority
+    // list. `featured-release` surfaces the SINGLE most recent album —
+    // Apple doesn't expose a paginated "all albums" view in a single call,
+    // so Apple users get much narrower album context than Spotify (which
+    // fetches up to 20). Acceptable for the first pass; exploring
+    // `views=latest-release,full-albums` is a follow-up on #51.
+    const artistRes = await fetchWithAppleTimeout(
+      `https://api.music.apple.com/v1/catalog/us/artists/${appleArtistId}?views=top-songs,featured-release`,
+      headers,
+    );
+    if (!artistRes.ok) {
+      console.warn(`[Apple Music] artists/${appleArtistId} returned ${artistRes.status}`);
+      return null;
+    }
+    const artistData = await artistRes.json();
+    const artist = artistData?.data?.[0];
+    if (!artist) return null;
+
+    // Merge artist-level + song-level genres, strip Apple's "Music" catch-all
+    // label (appears on every catalog item, zero signal), and sanitize each
+    // value because these flow into the Gemini prompt where a crafted newline
+    // could inject instructions. Array.isArray guard protects against
+    // malformed Apple responses (null, string, object).
+    const mergedGenres = new Set<string>();
+    const rawArtistGenres = artist.attributes?.genreNames;
+    if (Array.isArray(rawArtistGenres)) {
+      for (const g of rawArtistGenres) {
+        const clean = sanitizeCatalogField(g);
+        if (clean && clean !== "Music") mergedGenres.add(clean);
+      }
+    }
+    for (const g of songGenres) {
+      const clean = sanitizeCatalogField(g);
+      if (clean && clean !== "Music") mergedGenres.add(clean);
+    }
+    const genres: string[] = Array.from(mergedGenres);
+
+    const rawTopSongs = artist.views?.["top-songs"]?.data;
+    const topSongs: Array<{ attributes?: { name?: unknown } }> = Array.isArray(rawTopSongs) ? rawTopSongs : [];
+    const topTrackNames: string[] = topSongs
+      .slice(0, 10)
+      .map((s) => sanitizeCatalogField(s?.attributes?.name))
+      .filter((n): n is string => n.length > 0);
+
+    // featured-release returns a single promoted album, so no slice needed —
+    // the Array.isArray guard is the meaningful protection here.
+    const rawFeaturedAlbums = artist.views?.["featured-release"]?.data;
+    const featuredAlbums: Array<{ attributes?: { name?: unknown } }> = Array.isArray(rawFeaturedAlbums) ? rawFeaturedAlbums : [];
+    const albumNames: string[] = featuredAlbums
+      .map((a) => sanitizeCatalogField(a?.attributes?.name))
+      .filter((n): n is string => n.length > 0);
+
+    console.log(`[Apple Music] ${safeArtistNameLog}: ${genres.length} genres, ${topTrackNames.length} tracks, ${albumNames.length} albums`);
+
+    return {
+      genres,
+      relatedArtists: [],
+      topTrackNames,
+      albumNames,
+      followers: 0, // Apple exposes no direct follower count — see header comment
+    };
+  } catch (e) {
+    console.error("[Apple Music] Artist info fetch failed:", e);
     return null;
   }
 }
@@ -1208,9 +1401,11 @@ async function curateResearch(
     warningsForWriter: ["Curation unavailable — writer should rely on its own knowledge"],
   };
 
-  // Build discography context for artist disambiguation
+  // Build discography context for artist disambiguation. The source may be
+  // Spotify OR Apple Music depending on which service the user is on — the
+  // generic "music catalog" phrasing keeps Gemini honest about origin.
   const discographySection = spotifyInfo && (spotifyInfo.albumNames.length > 0 || spotifyInfo.topTrackNames.length > 0)
-    ? `\nVERIFIED DISCOGRAPHY (from Spotify — use this to identify the CORRECT "${artist}"):
+    ? `\nVERIFIED DISCOGRAPHY (from music catalog — use this to identify the CORRECT "${artist}"):
 ${spotifyInfo.genres.length > 0 ? `Genres: ${spotifyInfo.genres.join(", ")}` : ""}
 ${spotifyInfo.albumNames.length > 0 ? `Albums/Singles: ${spotifyInfo.albumNames.join(", ")}` : ""}
 ${spotifyInfo.topTrackNames.length > 0 ? `Top tracks: ${spotifyInfo.topTrackNames.join(", ")}` : ""}
@@ -1593,9 +1788,11 @@ Use this to:
   const hasLastFmTags = lastFmTags && lastFmTags.length > 0;
 
   let musicDataContext = `\nMUSIC DATA for "${artist}":`;
-  // Spotify catalog data
+  // Catalog data — source may be Spotify OR Apple Music. Prompt labels stay
+  // service-agnostic because Gemini copies source names verbatim into nugget
+  // text (see the Last.fm comment below for prior burn on this exact issue).
   if (hasSpotifyGenres) {
-    musicDataContext += `\nSpotify genres: ${spotifyInfo!.genres.join(", ")}`;
+    musicDataContext += `\nGenres: ${spotifyInfo!.genres.join(", ")}`;
   }
   if (hasLastFmTags) {
     musicDataContext += `\nGenre tags: ${lastFmTags!.join(", ")}`;
@@ -1606,7 +1803,10 @@ Use this to:
   if (spotifyInfo && spotifyInfo.albumNames.length > 0) {
     musicDataContext += `\nAlbums/Singles: ${spotifyInfo!.albumNames.join(", ")}`;
   }
-  if (spotifyInfo) {
+  // Omit the Followers line when the value is 0 — Apple Music has no direct
+  // follower count (fetchAppleArtistInfo returns 0), and sending
+  // "Followers: 0" to Gemini falsely signals the artist is brand-new/obscure.
+  if (spotifyInfo && spotifyInfo.followers > 0) {
     musicDataContext += `\nFollowers: ${spotifyInfo.followers.toLocaleString()}`;
   }
   // Similar artists from listener data — key data for discovery recommendations
@@ -2202,7 +2402,7 @@ serve(async (req) => {
 
   try {
     const body = await req.json();
-    const { artist, title, album, deepDive, context, sourceTitle, sourcePublisher, imageCaption, imageQuery, listenCount, previousNuggets, tier: rawTier, userTopArtists: rawTopArtists, userTopTracks: rawTopTracks, spotifyArtistImageUrl: rawSpotifyArtistImageUrl, spotifyTrackId: rawSpotifyTrackId } = body;
+    const { artist, title, album, deepDive, context, sourceTitle, sourcePublisher, imageCaption, imageQuery, listenCount, previousNuggets, tier: rawTier, userTopArtists: rawTopArtists, userTopTracks: rawTopTracks, spotifyArtistImageUrl: rawSpotifyArtistImageUrl, spotifyTrackId: rawSpotifyTrackId, appleTrackId: rawAppleTrackId } = body;
     const tier: Tier = (rawTier === "casual" || rawTier === "curious" || rawTier === "nerd") ? rawTier : "casual";
 
     // ── Input validation ────────────────────────────────────────────
@@ -2244,6 +2444,18 @@ serve(async (req) => {
     const safeSpotifyTrackId: string | undefined =
       typeof rawSpotifyTrackId === "string" && /^[a-zA-Z0-9]{22}$/.test(rawSpotifyTrackId)
         ? rawSpotifyTrackId
+        : undefined;
+    // Apple Music catalog ID for Apple users (e.g., "1109715168").
+    // Apple song catalog IDs are numeric strings 7-15 digits. Songs are
+    // typically 9-10; the upper bound accommodates longer IDs seen on some
+    // legacy/compilation tracks. Anything shorter than 7 is almost certainly
+    // an artist or album ID passed in error and would 404 the /songs/:id
+    // lookup, wasting a round-trip to Apple before falling through to
+    // name-search. When set, we route to fetchAppleArtistInfo instead of
+    // the Spotify enrichment path.
+    const safeAppleTrackId: string | undefined =
+      typeof rawAppleTrackId === "string" && /^\d{7,15}$/.test(rawAppleTrackId)
+        ? rawAppleTrackId
         : undefined;
 
     const GOOGLE_AI_API_KEY = Deno.env.get("GOOGLE_AI_API_KEY");
@@ -2356,9 +2568,21 @@ Return ONLY valid JSON:
     let trackSearchSkipped = false;
     let discoverySearchSkipped = false;
 
-    // Fetch Spotify + Last.fm artist info in parallel with Exa Phase 1
-    // Pass track ID for precise artist resolution (prevents name collisions)
-    const spotifyInfoPromise = fetchSpotifyArtistInfo(artist, safeSpotifyTrackId);
+    // Fetch artist info in parallel with Exa Phase 1. Apple users route
+    // through fetchAppleArtistInfo (which uses Apple's catalog API);
+    // everyone else falls through to the Spotify path. The returned shape
+    // is identical so downstream code (prompt building, Exa strategy
+    // selection via `followers`) doesn't need to branch on service.
+    //
+    // If the frontend ever sends BOTH a Spotify and Apple track ID, Apple
+    // takes priority — the track ID for the active service matches the
+    // running playback engine, so Apple winning is the correct default.
+    // The frontend currently sends only one URI per request (mutually
+    // exclusive in useAINuggets.ts), so this branch is never exercised in
+    // production, but the precedence is documented for future robustness.
+    const artistInfoPromise = safeAppleTrackId
+      ? fetchAppleArtistInfo(artist, safeAppleTrackId)
+      : fetchSpotifyArtistInfo(artist, safeSpotifyTrackId);
     const lastFmSimilarPromise = fetchLastFmSimilarArtists(artist);
     const lastFmTagsPromise = fetchLastFmArtistTags(artist);
 
@@ -2376,7 +2600,7 @@ Return ONLY valid JSON:
 
       const [artistSearchResult, phase1SpotifyInfo] = await Promise.all([
         artistSearchPromise,
-        spotifyInfoPromise,
+        artistInfoPromise,
       ]);
       console.timeEnd("[Timing] Exa Phase 1"); _te("exaPhase1");
       checkTimeout();
@@ -2566,7 +2790,7 @@ Return ONLY valid JSON:
     // Step 3: Generate nuggets with Gemini + Google Search grounding
     const [imageCandidates, resolvedSpotifyInfo, resolvedLastFmSimilar, resolvedLastFmTags] = await Promise.all([
       imageCandidatesPromise,
-      spotifyInfoPromise,
+      artistInfoPromise,
       lastFmSimilarPromise,
       lastFmTagsPromise,
     ]);

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1587,7 +1587,30 @@ const HALLUCINATED_PUBLISHERS = [
   "music data insights", "internal data", "musicdatainsights",
   "ai music database", "music insights", "artist database",
   "music analytics", "song insights", "track insights",
+  // Domain-pattern hallucinations: Gemini invents plausible-sounding
+  // music databases/platforms that don't exist.
+  "musicmetricsvault", "musicmetrics", "metricsvault",
+  "sonic scroll", "sonicscroll", "the sonic scroll",
+  "music vault", "musicvault", "artist vault",
+  "beat archive", "beatarchive", "sound archive",
+  "track vault", "trackvault", "music archive",
 ];
+
+// Known real music publications — used as a positive signal when deciding
+// whether a publisher is fabricated. NOT a whitelist (unlisted publishers
+// aren't rejected), but an unverified source from a known-real publisher
+// is more trustworthy than one from an unknown domain.
+const KNOWN_REAL_PUBLISHERS = new Set([
+  "spotify", "bandcamp", "soundcloud", "youtube", "apple music",
+  "pitchfork", "rolling stone", "nme", "billboard", "the guardian",
+  "stereogum", "consequence", "the fader", "complex", "xxl",
+  "genius", "allmusic", "discogs", "musicbrainz", "last.fm",
+  "wikipedia", "resident advisor", "ra", "mixmag", "dj mag",
+  "sound on sound", "tape op", "the quietus", "tiny mix tapes",
+  "the wire", "fact", "noisey", "vice", "vulture", "spin",
+  "exclaim", "paste", "under the radar", "clash", "diy",
+  "the line of best fit", "the needle drop", "fantano",
+]);
 
 function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { valid: boolean; issues: string[]; hallucinated: boolean; vagueHeadlines: boolean } {
   const issues: string[] = [];
@@ -1846,7 +1869,8 @@ Use this to:
 ACCURACY RULES (non-negotiable):
 - Do NOT fabricate a narrative. If you don't have verified facts, write about what you DO know (even if it's just genre, location, or catalog data).
 - Source type MUST be "youtube", "article", or "interview" — NEVER use "internal-data", "database", or invented types.
-- Publisher MUST be a real publication or platform (e.g., "Bandcamp", "Spotify", "SoundCloud", "YouTube"). NEVER invent publishers like "Music Data Insights".
+- Publisher MUST be a REAL, EXISTING publication or platform (e.g., "Bandcamp", "Spotify", "SoundCloud", "YouTube", "Pitchfork", "Rolling Stone"). NEVER invent publisher names or domains. If you cannot name a real publisher, use "Spotify" (you always have Spotify catalog data).
+- NEVER invent studio names, engineer names, collaborator names, or anecdotes. If you don't know the real studio, don't name one. If you don't know the engineer, don't name one. Fabricated specifics (fake names, fake studios, fake incidents) are worse than honest generality.
 - Do NOT frame lack of information as a deliberate artistic choice (e.g., "operates as a digital ghost", "deliberate anti-persona"). A small artist is not automatically mysterious.
 - For the track nugget: write about the artist's creative context, NOT the track's sound or mood.
 
@@ -2853,12 +2877,8 @@ Return ONLY valid JSON:
     console.timeEnd("[Timing] Gemini (Curator + Writer)"); _te("gemini");
     } else {
       // SSE path: rawNuggets populated inside the streaming IIFE below.
-      // groundingChunks stays empty on this path — the per-nugget Writer
-      // calls happen inside the IIFE and the resulting grounding metadata
-      // isn't aggregated here. assembleNugget's realChunks fallback
-      // therefore only resolves against Exa citations on SSE requests;
-      // the Google-search grounding fallback is batch-only. If this
-      // becomes load-bearing, thread chunks out of the IIFE.
+      // groundingChunks starts empty but is populated incrementally as
+      // each per-nugget Writer call returns grounding metadata.
       rawNuggets = [];
       groundingChunks = [];
     }
@@ -3329,6 +3349,14 @@ Return ONLY valid JSON:
                       }
                       throw new Error(`Empty Gemini response for ${def.kind}`);
                     }
+                    // Capture per-nugget grounding chunks so assembleNugget's
+                    // source-resolution chain can verify URLs against real
+                    // Google Search results (previously SSE-only gap).
+                    const perNuggetChunks = data.candidates?.[0]?.groundingMetadata?.groundingChunks || [];
+                    if (perNuggetChunks.length > 0) {
+                      groundingChunks.push(...perNuggetChunks);
+                      console.log(`[SSE] ${def.kind}: ${perNuggetChunks.length} grounding chunks captured`);
+                    }
                     const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
                     const parsed = JSON.parse(cleaned);
                     nuggetData = parsed.nugget || (parsed.nuggets?.[0]);
@@ -3383,6 +3411,17 @@ Return ONLY valid JSON:
                 if (HALLUCINATED_PUBLISHERS.some(hp => publisher.includes(hp))) {
                   console.log(`[SSE] Skipping hallucinated publisher: ${def.kind}`);
                   continue;
+                }
+                // Unverified source + unknown publisher = likely fabricated.
+                // assembleNugget sets verified=false when no Exa citation or
+                // grounding chunk matched — if the publisher also isn't a
+                // known real publication, Gemini almost certainly invented it.
+                if (isSparseData && assembled.source?.verified === false) {
+                  const pubNormalized = publisher.toLowerCase().replace(/^(the |www\.)/, "").replace(/\.(com|net|org|io|xyz)$/, "");
+                  if (!KNOWN_REAL_PUBLISHERS.has(pubNormalized) && !KNOWN_REAL_PUBLISHERS.has(publisher.toLowerCase())) {
+                    console.log(`[SSE] Skipping unverified source from unknown publisher "${assembled.source.publisher}" for sparse artist: ${def.kind}`);
+                    continue;
+                  }
                 }
 
                 // ── Stream immediately ──

--- a/supabase/migrations/20260416213446_drop_spotify_taste_from_profiles.sql
+++ b/supabase/migrations/20260416213446_drop_spotify_taste_from_profiles.sql
@@ -1,0 +1,8 @@
+-- Drop the legacy spotify_taste column from profiles.
+-- The dual-write pattern (spotify_taste + music_taste) shipped in
+-- 20260408200000_apple_music_support.sql. music_taste is now the sole
+-- source of truth for taste data, keyed by service ("spotify", "apple").
+-- The live DB has 0 rows at drop time — no data loss.
+
+ALTER TABLE public.profiles
+  DROP COLUMN IF EXISTS spotify_taste;


### PR DESCRIPTION
## Summary
Promotes 7 commits from staging to main:

- **#71** fix: nugget stacking, playback dead-end, and sparse-artist hallucination
- **#70** fix: move Companion useMemo hooks above the !trackInfo early return
- **#69** test: ArtistProfile + AlbumDetail catalog-routing tests
- **#68** refactor: extract Listen skip cascade + tests
- **#67** refactor: drop legacy spotify_taste column from profiles
- **#65** refactor: rename UserProfile spotify* taste fields to service-agnostic names
- **#57** feat: generate-nuggets reads appleTrackId for Apple Music enrichment

## Test plan
- [ ] Play a sparse/unknown artist — no fabricated studios, engineers, or fake domains
- [ ] Play 2+ tracks in sequence — nuggets reset between tracks (3 dots)
- [ ] Track auto-advance — playback starts within 5s
- [ ] Pause within 4s of track start — safety-net does NOT force-resume
- [ ] Apple Music playback — verify service-agnostic fields work
- [ ] Companion page — verify no hooks-before-return crash
- [ ] Skip cascade — next track resolves from album/recs/catalog