### PR TITLE
fix: remove raw Bearer header from seed-nuggets (new key format compat)

### DIFF
--- a/supabase/functions/seed-nuggets/index.ts
+++ b/supabase/functions/seed-nuggets/index.ts
@@ -211,11 +211,14 @@ serve(async (req) => {
 
       try {
         // Step 1: Generate nuggets via Gemini
+        // No Authorization header needed — generate-nuggets has
+        // verify_jwt = false and doesn't read the caller's auth.
+        // (The old Bearer header broke with the new sb_secret_* key
+        // format, which isn't a JWT.)
         const generateRes = await fetch(`${SUPABASE_URL}/functions/v1/generate-nuggets`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
           },
           body: JSON.stringify({
             artist: track.artist,


### PR DESCRIPTION
## Summary
Removes the `Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}` header from seed-nuggets' function-to-function call to generate-nuggets. 

generate-nuggets has `verify_jwt = false` and doesn't read the caller's auth header, so the token was dead weight. With Supabase's new `sb_secret_*` key format (not a JWT), passing it as a Bearer token is explicitly unsupported.

## Test plan
- [ ] Run seed-nuggets manually — verify generate-nuggets still responds