### PR TITLE
feat(refresh): tiered taste + artist-updates refresh + grounded facts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,29 +87,29 @@ const App = () => (
         <AuthProvider>
           <PlayerProvider>
             <StoriesProvider>
-            <ArtistUpdatesProvider>
-            <RefreshIndicatorProvider>
-            <ErrorBoundary fallback={
-              <div className="min-h-screen bg-background flex items-center justify-center p-6">
-                <div className="text-center space-y-3">
-                  <p className="text-lg font-bold text-foreground">Something went wrong</p>
-                  <p className="text-sm text-muted-foreground">Try refreshing the page.</p>
-                  <button
-                    onClick={() => window.location.reload()}
-                    className="mt-2 px-5 py-2 rounded-full bg-primary/20 text-primary text-sm font-semibold hover:bg-primary/30 transition-colors"
-                  >
-                    Refresh
-                  </button>
-                </div>
-              </div>
-            }>
-              <AnimatedRoutes />
-              <NowPlayingBar />
-              <SpotifyReconnectBanner />
-              <GlobalRefreshIndicator />
-            </ErrorBoundary>
-            </RefreshIndicatorProvider>
-            </ArtistUpdatesProvider>
+              <ArtistUpdatesProvider>
+                <RefreshIndicatorProvider>
+                  <ErrorBoundary fallback={
+                    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+                      <div className="text-center space-y-3">
+                        <p className="text-lg font-bold text-foreground">Something went wrong</p>
+                        <p className="text-sm text-muted-foreground">Try refreshing the page.</p>
+                        <button
+                          onClick={() => window.location.reload()}
+                          className="mt-2 px-5 py-2 rounded-full bg-primary/20 text-primary text-sm font-semibold hover:bg-primary/30 transition-colors"
+                        >
+                          Refresh
+                        </button>
+                      </div>
+                    </div>
+                  }>
+                    <AnimatedRoutes />
+                    <NowPlayingBar />
+                    <SpotifyReconnectBanner />
+                    <GlobalRefreshIndicator />
+                  </ErrorBoundary>
+                </RefreshIndicatorProvider>
+              </ArtistUpdatesProvider>
             </StoriesProvider>
           </PlayerProvider>
         </AuthProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const ArtistProfile = lazy(() => import("./pages/ArtistProfile"));
 const AlbumDetail = lazy(() => import("./pages/AlbumDetail"));
 const Listen = lazy(() => import("./pages/Listen"));
 const Profile = lazy(() => import("./pages/Profile"));
+const PreparingExperience = lazy(() => import("./pages/PreparingExperience"));
 import { AuthProvider } from "./contexts/AuthContext";
 import { PlayerProvider } from "./contexts/PlayerContext";
 import { StoriesProvider } from "./contexts/StoriesContext";
@@ -54,6 +55,7 @@ function AnimatedRoutes() {
             {/* Public */}
             <Route path="/" element={<RootRoute />} />
             <Route path="/connect" element={<Connect />} />
+            <Route path="/preparing" element={<ProtectedRoute><PreparingExperience /></ProtectedRoute>} />
 
             {/* Protected — requires a Supabase session */}
             <Route path="/browse" element={<ProtectedRoute><Browse /></ProtectedRoute>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import { ArtistUpdatesProvider } from "./contexts/ArtistUpdatesContext";
 import NowPlayingBar from "./components/NowPlayingBar";
 import SpotifyReconnectBanner from "./components/SpotifyReconnectBanner";
 import ErrorBoundary from "./components/ErrorBoundary";
+import GlobalRefreshIndicator from "./components/GlobalRefreshIndicator";
+import { RefreshIndicatorProvider } from "./contexts/RefreshIndicatorContext";
 import { ProtectedRoute, RootRoute, LazyFallback } from "./routes";
 
 const queryClient = new QueryClient();
@@ -86,6 +88,7 @@ const App = () => (
           <PlayerProvider>
             <StoriesProvider>
             <ArtistUpdatesProvider>
+            <RefreshIndicatorProvider>
             <ErrorBoundary fallback={
               <div className="min-h-screen bg-background flex items-center justify-center p-6">
                 <div className="text-center space-y-3">
@@ -103,7 +106,9 @@ const App = () => (
               <AnimatedRoutes />
               <NowPlayingBar />
               <SpotifyReconnectBanner />
+              <GlobalRefreshIndicator />
             </ErrorBoundary>
+            </RefreshIndicatorProvider>
             </ArtistUpdatesProvider>
             </StoriesProvider>
           </PlayerProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const Profile = lazy(() => import("./pages/Profile"));
 import { AuthProvider } from "./contexts/AuthContext";
 import { PlayerProvider } from "./contexts/PlayerContext";
 import { StoriesProvider } from "./contexts/StoriesContext";
+import { ArtistUpdatesProvider } from "./contexts/ArtistUpdatesContext";
 import NowPlayingBar from "./components/NowPlayingBar";
 import SpotifyReconnectBanner from "./components/SpotifyReconnectBanner";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -82,6 +83,7 @@ const App = () => (
         <AuthProvider>
           <PlayerProvider>
             <StoriesProvider>
+            <ArtistUpdatesProvider>
             <ErrorBoundary fallback={
               <div className="min-h-screen bg-background flex items-center justify-center p-6">
                 <div className="text-center space-y-3">
@@ -100,6 +102,7 @@ const App = () => (
               <NowPlayingBar />
               <SpotifyReconnectBanner />
             </ErrorBoundary>
+            </ArtistUpdatesProvider>
             </StoriesProvider>
           </PlayerProvider>
         </AuthProvider>

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -47,8 +47,13 @@ export default function ArtistUpdatesSection({
   function openArtistAtNugget(update: ArtistUpdate) {
     const id = artistIds[update.artistName] || update.artistId;
     if (!id) return;
+    // Route format is `spotify::{id}::{name}` (double-colon delimiter
+    // per src/lib/routeParsing.ts). Single-colon URLs don't match
+    // `isSpotifyPrefix` and fall through to the mock-artist lookup,
+    // which surfaces as "Artist not found." for every Spotify-real
+    // artist card.
     const path = withAppleStorefront(
-      `/artist/${activeService}:${id}?nugget=${encodeURIComponent(update.nuggetId ?? "")}`,
+      `/artist/${activeService}::${id}::${encodeURIComponent(update.artistName)}?nugget=${encodeURIComponent(update.nuggetId ?? "")}`,
       profile?.streamingService,
     );
     navigate(path);
@@ -98,23 +103,28 @@ interface ArtistRowProps {
 function ArtistRow({ group, onOpen }: ArtistRowProps) {
   const loading = group.updates === null;
   const updates = group.updates ?? [];
-  // Best-effort cover image for the row header — use the first update
-  // if present, otherwise fall back to a neutral gradient tile.
-  const heroImg = updates[0]?.artistImageUrl ?? "";
+  // Prefer a fact update's image for the row header avatar — that's the
+  // artist photo. Release cards hand back an album cover in the same
+  // field, which makes a lousy circular avatar. Fall back to whatever's
+  // there if no fact update exists yet.
+  const heroImg =
+    updates.find((u) => u.kind === "fact")?.artistImageUrl
+    ?? updates[0]?.artistImageUrl
+    ?? "";
 
   return (
     <div>
-      <div className="px-4 md:px-10 mb-2 flex items-center gap-3">
+      <div className="px-4 md:px-10 mb-3 flex items-center gap-3">
         {heroImg ? (
           <img
             src={heroImg}
             alt=""
-            className="w-8 h-8 rounded-full object-cover opacity-90"
+            className="w-14 h-14 rounded-full object-cover ring-2 ring-white/10 shadow-lg"
           />
         ) : (
-          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-rose-400/30 to-pink-500/30" />
+          <div className="w-14 h-14 rounded-full bg-gradient-to-br from-rose-400/40 to-pink-500/40 ring-2 ring-white/10" />
         )}
-        <span className="text-sm font-semibold text-white/85">
+        <span className="text-lg md:text-xl font-black text-white tracking-tight">
           {group.artistName}
         </span>
       </div>
@@ -144,52 +154,105 @@ interface UpdateCardProps {
 }
 
 function UpdateCard({ update, onOpen }: UpdateCardProps) {
-  const { kindLabel, kindClass, KindIcon } = kindMeta(update.kind);
+  const meta = kindMeta(update.kind);
+  const { kindLabel, chipClass, KindIcon } = meta;
+
+  // Release cards get a "poster" treatment — album art fills the tile
+  // with a dark gradient so the title lockup is legible on any image.
+  // Fact cards stay text-led but pick up a kind-tinted left border and
+  // subtle glow so the row has visual rhythm instead of a uniform wall.
+  if (update.kind === "new-release" && update.artistImageUrl) {
+    return (
+      <button
+        onClick={onOpen}
+        className="relative shrink-0 w-[280px] md:w-[320px] h-44 md:h-48 text-left rounded-2xl overflow-hidden group active:scale-[0.98] transition-transform"
+        aria-label={`${kindLabel}: ${update.headline}`}
+      >
+        <img
+          src={update.artistImageUrl}
+          alt=""
+          className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).style.display = "none";
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-black/10" />
+        <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-2xl pointer-events-none" />
+        <span className={`absolute top-3 left-3 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full backdrop-blur-sm ${chipClass}`}>
+          <KindIcon className="w-3 h-3" />
+          {kindLabel}
+        </span>
+        <div className="absolute bottom-0 left-0 right-0 p-4">
+          <h3 className="text-base md:text-lg font-black text-white leading-tight line-clamp-2 mb-1 drop-shadow">
+            {update.headline}
+          </h3>
+          <p className="text-xs text-white/70 leading-relaxed line-clamp-1">
+            {update.body}
+          </p>
+        </div>
+      </button>
+    );
+  }
+
   return (
     <button
       onClick={onOpen}
-      className="shrink-0 w-[280px] md:w-[320px] text-left rounded-2xl bg-gradient-to-br from-white/[0.06] to-white/[0.02] border border-white/10 p-4 hover:border-white/25 active:scale-[0.98] transition-all"
+      className={`shrink-0 w-[280px] md:w-[320px] text-left rounded-2xl bg-gradient-to-br ${meta.cardBg} border-l-4 ${meta.borderAccent} border-y border-r border-white/10 p-5 hover:border-white/25 active:scale-[0.98] transition-all ${meta.hoverGlow}`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
       <div className="flex items-center gap-2 mb-3">
-        <span className={`inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${kindClass}`}>
+        <span className={`inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${chipClass}`}>
           <KindIcon className="w-3 h-3" />
           {kindLabel}
         </span>
       </div>
-      <h3 className="text-sm font-semibold text-white leading-snug line-clamp-3 mb-2">
+      <h3 className="text-base md:text-lg font-black text-white leading-snug line-clamp-3 mb-2">
         {update.headline}
       </h3>
-      <p className="text-xs text-white/50 leading-relaxed line-clamp-2">
+      <p className="text-sm text-white/65 leading-relaxed line-clamp-3">
         {update.body}
       </p>
     </button>
   );
 }
 
-function kindMeta(kind: ArtistUpdate["kind"]): {
+interface KindMeta {
   kindLabel: string;
-  kindClass: string;
+  chipClass: string;
+  borderAccent: string;
+  cardBg: string;
+  hoverGlow: string;
   KindIcon: typeof Sparkles;
-} {
+}
+
+function kindMeta(kind: ArtistUpdate["kind"]): KindMeta {
   switch (kind) {
     case "new-release":
       return {
         kindLabel: "New release",
-        kindClass: "bg-rose-500/15 text-rose-300",
+        chipClass: "bg-rose-500/25 text-rose-100 ring-1 ring-rose-300/30",
+        borderAccent: "border-l-rose-400/70",
+        cardBg: "from-rose-500/10 to-white/[0.02]",
+        hoverGlow: "hover:shadow-[0_0_24px_rgba(244,114,182,0.15)]",
         KindIcon: Disc,
       };
     case "collab":
       return {
         kindLabel: "Collab",
-        kindClass: "bg-violet-500/15 text-violet-300",
+        chipClass: "bg-violet-500/25 text-violet-100 ring-1 ring-violet-300/30",
+        borderAccent: "border-l-violet-400/70",
+        cardBg: "from-violet-500/10 to-white/[0.02]",
+        hoverGlow: "hover:shadow-[0_0_24px_rgba(167,139,250,0.18)]",
         KindIcon: Users,
       };
     case "fact":
     default:
       return {
         kindLabel: "Fact",
-        kindClass: "bg-sky-500/15 text-sky-300",
+        chipClass: "bg-sky-500/25 text-sky-100 ring-1 ring-sky-300/30",
+        borderAccent: "border-l-sky-400/70",
+        cardBg: "from-sky-500/10 to-white/[0.02]",
+        hoverGlow: "hover:shadow-[0_0_24px_rgba(125,211,252,0.15)]",
         KindIcon: Sparkles,
       };
   }

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -45,6 +45,27 @@ export default function ArtistUpdatesSection({
   const showProgress = totalCount > 0 && readyCount < totalCount;
 
   function openArtistAtNugget(update: ArtistUpdate) {
+    // New-release / collab cards: tap should land on Listen for the
+    // released track, not the artist profile. Requires a track-level
+    // URI (Spotify's playback API rejects album URIs in `uris`); the
+    // edge function populates `relatedTrackTitle` only when it
+    // successfully resolved the album's first track.
+    if (
+      (update.kind === "new-release" || update.kind === "collab") &&
+      update.relatedTrackUri &&
+      update.relatedTrackTitle &&
+      update.relatedTrackUri.startsWith("spotify:track:")
+    ) {
+      const enc = encodeURIComponent;
+      const album = update.relatedAlbumName ?? "";
+      navigate(
+        `/listen/real::${enc(update.artistName)}::${enc(update.relatedTrackTitle)}::${enc(album)}::${enc(update.relatedTrackUri)}`,
+      );
+      return;
+    }
+
+    // Fact cards (or release cards where track resolution failed):
+    // open the artist profile and deep-link to the nugget.
     const id = artistIds[update.artistName] || update.artistId;
     if (!id) return;
     // Route format is `spotify::{id}::{name}` (double-colon delimiter

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "react-router-dom";
-import { Loader2, Sparkles, Users, Disc } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { ArtistUpdate, ArtistUpdateGroup } from "@/hooks/useArtistUpdates";
 import { serviceParamFromProfile, withAppleStorefront } from "@/lib/appleStorefront";
+import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
 import type { UserProfile } from "@/mock/types";
 
 /**
@@ -175,8 +176,8 @@ interface UpdateCardProps {
 }
 
 function UpdateCard({ update, onOpen }: UpdateCardProps) {
-  const meta = kindMeta(update.kind);
-  const { kindLabel, chipClass, KindIcon } = meta;
+  const { kindLabel, KindIcon } = getArtistUpdateKindMeta(update.kind);
+  const { chipClass, borderAccent, cardBg, hoverGlow } = kindStyle(update.kind);
 
   // Release cards get a "poster" treatment — album art fills the tile
   // with a dark gradient so the title lockup is legible on any image.
@@ -218,7 +219,7 @@ function UpdateCard({ update, onOpen }: UpdateCardProps) {
   return (
     <button
       onClick={onOpen}
-      className={`shrink-0 w-[280px] md:w-[320px] text-left rounded-2xl bg-gradient-to-br ${meta.cardBg} border-l-4 ${meta.borderAccent} border-y border-r border-white/10 p-5 hover:border-white/25 active:scale-[0.98] transition-all ${meta.hoverGlow}`}
+      className={`shrink-0 w-[280px] md:w-[320px] text-left rounded-2xl bg-gradient-to-br ${cardBg} border-l-4 ${borderAccent} border-y border-r border-white/10 p-5 hover:border-white/25 active:scale-[0.98] transition-all ${hoverGlow}`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
       <div className="flex items-center gap-2 mb-3">
@@ -237,44 +238,41 @@ function UpdateCard({ update, onOpen }: UpdateCardProps) {
   );
 }
 
-interface KindMeta {
-  kindLabel: string;
+// Browse-specific styling per kind. Label + icon come from the shared
+// helper in src/lib/artistUpdateKind.ts so adding a new kind only
+// requires editing the shared file. Local styling stays here because
+// the rail uses an opinionated card treatment (border accent, gradient
+// bg, hover glow) that differs from the artist-profile chip.
+interface KindStyle {
   chipClass: string;
   borderAccent: string;
   cardBg: string;
   hoverGlow: string;
-  KindIcon: typeof Sparkles;
 }
 
-function kindMeta(kind: ArtistUpdate["kind"]): KindMeta {
+function kindStyle(kind: ArtistUpdate["kind"]): KindStyle {
   switch (kind) {
     case "new-release":
       return {
-        kindLabel: "New release",
         chipClass: "bg-rose-500/25 text-rose-100 ring-1 ring-rose-300/30",
         borderAccent: "border-l-rose-400/70",
         cardBg: "from-rose-500/10 to-white/[0.02]",
         hoverGlow: "hover:shadow-[0_0_24px_rgba(244,114,182,0.15)]",
-        KindIcon: Disc,
       };
     case "collab":
       return {
-        kindLabel: "Collab",
         chipClass: "bg-violet-500/25 text-violet-100 ring-1 ring-violet-300/30",
         borderAccent: "border-l-violet-400/70",
         cardBg: "from-violet-500/10 to-white/[0.02]",
         hoverGlow: "hover:shadow-[0_0_24px_rgba(167,139,250,0.18)]",
-        KindIcon: Users,
       };
     case "fact":
     default:
       return {
-        kindLabel: "Fact",
         chipClass: "bg-sky-500/25 text-sky-100 ring-1 ring-sky-300/30",
         borderAccent: "border-l-sky-400/70",
         cardBg: "from-sky-500/10 to-white/[0.02]",
         hoverGlow: "hover:shadow-[0_0_24px_rgba(125,211,252,0.15)]",
-        KindIcon: Sparkles,
       };
   }
 }

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -1,0 +1,212 @@
+import { useNavigate } from "react-router-dom";
+import { Loader2, Sparkles, Users, Disc } from "lucide-react";
+import type { ArtistUpdate, ArtistUpdateGroup } from "@/hooks/useArtistUpdates";
+import { serviceParamFromProfile, withAppleStorefront } from "@/lib/appleStorefront";
+import type { UserProfile } from "@/mock/types";
+
+/**
+ * Browse's "Your artists, lately" section. Renders one nested row per
+ * top artist — each row is a horizontally-scrollable strip of update
+ * cards (release + 2 facts from the `useArtistUpdates` hook). Artist
+ * grouping is the point: it gives Pete's "scroll through a few facts
+ * for each top artist" feel rather than a Spotify-flavored artist-tile
+ * row.
+ *
+ * While the hook is still fetching a given artist, that row renders
+ * skeleton cards so the user sees something is coming without a blank
+ * gap. Once `group.updates !== null` is an empty array, the row is
+ * omitted entirely (silent drop rather than a "no updates" toast).
+ */
+
+interface Props {
+  groups: ArtistUpdateGroup[];
+  /** Fed in by Browse's useUserProfile for artist-href composition. */
+  profile: UserProfile | null;
+  /** Artist name → artist id map (from profile + runtime resolution). */
+  artistIds?: Record<string, string>;
+  /** Total attempted; used for the progress indicator. */
+  totalCount: number;
+  /** Count that's resolved (including empty-result resolutions). */
+  readyCount: number;
+}
+
+export default function ArtistUpdatesSection({
+  groups,
+  profile,
+  artistIds = {},
+  totalCount,
+  readyCount,
+}: Props) {
+  const navigate = useNavigate();
+  const activeService = serviceParamFromProfile(profile?.streamingService);
+
+  if (groups.length === 0) return null;
+
+  const showProgress = totalCount > 0 && readyCount < totalCount;
+
+  function openArtistAtNugget(update: ArtistUpdate) {
+    const id = artistIds[update.artistName] || update.artistId;
+    if (!id) return;
+    const path = withAppleStorefront(
+      `/artist/${activeService}:${id}?nugget=${encodeURIComponent(update.nuggetId ?? "")}`,
+      profile?.streamingService,
+    );
+    navigate(path);
+  }
+
+  return (
+    <section className="mb-6 md:mb-10">
+      <div className="px-4 md:px-10 mb-3 flex items-center gap-2">
+        <p className="text-xs uppercase tracking-widest text-white/40">
+          Your artists, lately
+        </p>
+        {showProgress && (
+          <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-widest text-rose-300/70">
+            <Loader2 className="w-3 h-3 animate-spin" />
+            {readyCount} of {totalCount} ready
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4 md:gap-6">
+        {groups.map((group) => {
+          // Hide rows that finished with zero updates — don't clutter
+          // Browse with an empty "SOMEONE" label for an artist we
+          // couldn't resolve on Spotify.
+          if (group.updates !== null && group.updates.length === 0) return null;
+
+          return (
+            <ArtistRow
+              key={group.artistName}
+              group={group}
+              onOpen={openArtistAtNugget}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// ── Per-artist row ────────────────────────────────────────────────────
+
+interface ArtistRowProps {
+  group: ArtistUpdateGroup;
+  onOpen: (u: ArtistUpdate) => void;
+}
+
+function ArtistRow({ group, onOpen }: ArtistRowProps) {
+  const loading = group.updates === null;
+  const updates = group.updates ?? [];
+  // Best-effort cover image for the row header — use the first update
+  // if present, otherwise fall back to a neutral gradient tile.
+  const heroImg = updates[0]?.artistImageUrl ?? "";
+
+  return (
+    <div>
+      <div className="px-4 md:px-10 mb-2 flex items-center gap-3">
+        {heroImg ? (
+          <img
+            src={heroImg}
+            alt=""
+            className="w-8 h-8 rounded-full object-cover opacity-90"
+          />
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-rose-400/30 to-pink-500/30" />
+        )}
+        <span className="text-sm font-semibold text-white/85">
+          {group.artistName}
+        </span>
+      </div>
+      <div
+        className="flex gap-3 overflow-x-auto px-4 md:px-10 pb-2 scrollbar-hide"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+      >
+        {loading
+          ? Array.from({ length: 3 }).map((_, i) => <SkeletonCard key={i} />)
+          : updates.map((u) => (
+              <UpdateCard
+                key={u.nuggetId ?? `${u.kind}-${u.headline}`}
+                update={u}
+                onOpen={() => onOpen(u)}
+              />
+            ))}
+      </div>
+    </div>
+  );
+}
+
+// ── One update card ───────────────────────────────────────────────────
+
+interface UpdateCardProps {
+  update: ArtistUpdate;
+  onOpen: () => void;
+}
+
+function UpdateCard({ update, onOpen }: UpdateCardProps) {
+  const { kindLabel, kindClass, KindIcon } = kindMeta(update.kind);
+  return (
+    <button
+      onClick={onOpen}
+      className="shrink-0 w-[280px] md:w-[320px] text-left rounded-2xl bg-gradient-to-br from-white/[0.06] to-white/[0.02] border border-white/10 p-4 hover:border-white/25 active:scale-[0.98] transition-all"
+      aria-label={`${kindLabel}: ${update.headline}`}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span className={`inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${kindClass}`}>
+          <KindIcon className="w-3 h-3" />
+          {kindLabel}
+        </span>
+      </div>
+      <h3 className="text-sm font-semibold text-white leading-snug line-clamp-3 mb-2">
+        {update.headline}
+      </h3>
+      <p className="text-xs text-white/50 leading-relaxed line-clamp-2">
+        {update.body}
+      </p>
+    </button>
+  );
+}
+
+function kindMeta(kind: ArtistUpdate["kind"]): {
+  kindLabel: string;
+  kindClass: string;
+  KindIcon: typeof Sparkles;
+} {
+  switch (kind) {
+    case "new-release":
+      return {
+        kindLabel: "New release",
+        kindClass: "bg-rose-500/15 text-rose-300",
+        KindIcon: Disc,
+      };
+    case "collab":
+      return {
+        kindLabel: "Collab",
+        kindClass: "bg-violet-500/15 text-violet-300",
+        KindIcon: Users,
+      };
+    case "fact":
+    default:
+      return {
+        kindLabel: "Fact",
+        kindClass: "bg-sky-500/15 text-sky-300",
+        KindIcon: Sparkles,
+      };
+  }
+}
+
+// ── Skeleton card ─────────────────────────────────────────────────────
+
+function SkeletonCard() {
+  return (
+    <div
+      className="shrink-0 w-[280px] md:w-[320px] rounded-2xl bg-white/[0.04] border border-white/5 p-4 animate-pulse"
+      aria-hidden
+    >
+      <div className="h-4 w-20 rounded-full bg-white/10 mb-3" />
+      <div className="h-4 w-full rounded bg-white/10 mb-2" />
+      <div className="h-4 w-5/6 rounded bg-white/10 mb-3" />
+      <div className="h-3 w-3/4 rounded bg-white/5" />
+    </div>
+  );
+}

--- a/src/components/GlobalRefreshIndicator.tsx
+++ b/src/components/GlobalRefreshIndicator.tsx
@@ -1,0 +1,54 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { useLocation } from "react-router-dom";
+import { useRefreshIndicator } from "@/contexts/RefreshIndicatorContext";
+
+/**
+ * Subtle top-of-screen indicator that surfaces background refresh
+ * activity. Two parts:
+ *   - 2px progress bar across the top edge (always-visible affordance)
+ *   - Hover/tap reveals a label ("Refreshing your library")
+ *
+ * Hidden when nothing is refreshing — appears for as long as any of the
+ * tracked sources (taste / artist-updates) reports loading, then fades
+ * out. Pointer-events: none so it doesn't intercept clicks on
+ * overlapping UI.
+ *
+ * Suppressed on `/preparing` because that splash has its own dedicated
+ * progress bar + status message; showing both is redundant.
+ */
+export default function GlobalRefreshIndicator() {
+  const { any, label } = useRefreshIndicator();
+  const { pathname } = useLocation();
+  const suppress = pathname.startsWith("/preparing");
+  return (
+    <AnimatePresence>
+      {any && !suppress && (
+        <motion.div
+          key="refresh-indicator"
+          initial={{ opacity: 0, y: -2 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -2 }}
+          transition={{ duration: 0.2 }}
+          className="fixed top-0 left-0 right-0 z-[60] pointer-events-none"
+          aria-live="polite"
+          role="status"
+        >
+          <div className="relative h-[2px] w-full overflow-hidden bg-white/5">
+            <motion.div
+              className="absolute inset-y-0 w-1/3 bg-gradient-to-r from-transparent via-pink-400/80 to-transparent"
+              animate={{ x: ["-50%", "150%"] }}
+              transition={{ duration: 1.4, ease: "easeInOut", repeat: Infinity }}
+            />
+          </div>
+          {label && (
+            <div className="flex justify-center pt-1.5 pointer-events-auto">
+              <span className="rounded-full bg-black/60 backdrop-blur px-3 py-0.5 text-[10px] font-medium uppercase tracking-wider text-white/70">
+                {label}…
+              </span>
+            </div>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Loader2, Sparkles, Users, Disc } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
 
 /**
  * "Latest Facts" section on the Artist Profile. Renders artist-level
@@ -113,7 +114,8 @@ interface FactCardProps {
 }
 
 function FactCard({ update, expanded, pulsing, onToggle, registerRef }: FactCardProps) {
-  const { kindLabel, kindClass, KindIcon } = kindMeta(update.kind);
+  const { kindLabel, KindIcon } = getArtistUpdateKindMeta(update.kind);
+  const chipClass = kindClass(update.kind);
   return (
     <div
       ref={registerRef}
@@ -129,7 +131,7 @@ function FactCard({ update, expanded, pulsing, onToggle, registerRef }: FactCard
         aria-expanded={expanded}
       >
         <span
-          className={`mt-0.5 shrink-0 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${kindClass}`}
+          className={`mt-0.5 shrink-0 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${chipClass}`}
         >
           <KindIcon className="w-3 h-3" />
           {kindLabel}
@@ -157,19 +159,15 @@ function FactCard({ update, expanded, pulsing, onToggle, registerRef }: FactCard
   );
 }
 
-function kindMeta(kind: ArtistUpdate["kind"]): {
-  kindLabel: string;
-  kindClass: string;
-  KindIcon: typeof Sparkles;
-} {
+// Local styling for the artist-profile chip. Label + icon come from
+// the shared helper in src/lib/artistUpdateKind.ts so adding a new
+// kind only edits one file.
+function kindClass(kind: ArtistUpdate["kind"]): string {
   switch (kind) {
-    case "new-release":
-      return { kindLabel: "New release", kindClass: "bg-rose-500/15 text-rose-300", KindIcon: Disc };
-    case "collab":
-      return { kindLabel: "Collab", kindClass: "bg-violet-500/15 text-violet-300", KindIcon: Users };
+    case "new-release": return "bg-rose-500/15 text-rose-300";
+    case "collab": return "bg-violet-500/15 text-violet-300";
     case "fact":
-    default:
-      return { kindLabel: "Fact", kindClass: "bg-sky-500/15 text-sky-300", KindIcon: Sparkles };
+    default: return "bg-sky-500/15 text-sky-300";
   }
 }
 

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Loader2, Sparkles, Users, Disc } from "lucide-react";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+/**
+ * "Latest Facts" section on the Artist Profile. Renders artist-level
+ * updates from the same edge function Browse uses, so a nugget the
+ * user just tapped on Browse is immediately available here.
+ *
+ * If the URL has a `?nugget=<id>` query (Browse → Artist Profile tap-
+ * through), this component scrolls the matching fact into view, auto-
+ * expands it, and pulses a ring around it for ~1.2s before silently
+ * removing the query param so a refresh doesn't re-pulse.
+ */
+
+interface Props {
+  updates: ArtistUpdate[];
+  loading: boolean;
+  /** For empty / loading state copy. */
+  artistName: string;
+}
+
+export default function LatestFactsSection({ updates, loading, artistName }: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const targetNuggetId = searchParams.get("nugget");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [pulseId, setPulseId] = useState<string | null>(null);
+  const cardRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+
+  // Scroll + highlight behavior when landed via `?nugget=<id>`.
+  useEffect(() => {
+    if (!targetNuggetId || updates.length === 0) return;
+    const match = updates.find((u) => u.nuggetId === targetNuggetId);
+    if (!match) return;
+    const id = match.nuggetId!;
+    setExpandedId(id);
+    setPulseId(id);
+    // Defer the scroll one tick so the expanded body has laid out.
+    const scrollTimer = setTimeout(() => {
+      cardRefs.current.get(id)?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 30);
+    const pulseTimer = setTimeout(() => setPulseId(null), 1200);
+    const stripTimer = setTimeout(() => {
+      // Quietly remove the ?nugget= param so reload doesn't re-pulse.
+      const next = new URLSearchParams(searchParams);
+      next.delete("nugget");
+      setSearchParams(next, { replace: true });
+    }, 1400);
+    return () => {
+      clearTimeout(scrollTimer);
+      clearTimeout(pulseTimer);
+      clearTimeout(stripTimer);
+    };
+    // Ignoring searchParams/setSearchParams in deps because including
+    // them re-fires the effect on the strip, creating an infinite loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetNuggetId, updates.length]);
+
+  if (!loading && updates.length === 0) {
+    // Quiet fallback — don't render an empty section header on artists
+    // we couldn't compose anything for.
+    return null;
+  }
+
+  return (
+    <section className="px-4 md:px-10 pb-6 md:pb-8 mb-4">
+      <div className="mb-4 flex items-center gap-2">
+        <h2
+          className="text-lg font-bold text-foreground/90"
+          style={{ fontFamily: "'Nunito Sans', sans-serif" }}
+        >
+          Latest Facts
+        </h2>
+        {loading && (
+          <span className="flex items-center gap-1.5 text-[10px] uppercase tracking-widest text-rose-300/70">
+            <Loader2 className="w-3 h-3 animate-spin" />
+            Loading
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {loading && updates.length === 0
+          ? Array.from({ length: 3 }).map((_, i) => <SkeletonCard key={i} />)
+          : updates.map((u) => (
+              <FactCard
+                key={u.nuggetId ?? `${u.kind}-${u.headline}`}
+                update={u}
+                artistName={artistName}
+                expanded={u.nuggetId === expandedId}
+                pulsing={u.nuggetId === pulseId}
+                onToggle={() =>
+                  setExpandedId((prev) => (prev === u.nuggetId ? null : (u.nuggetId ?? null)))
+                }
+                registerRef={(el) => {
+                  if (u.nuggetId) cardRefs.current.set(u.nuggetId, el);
+                }}
+              />
+            ))}
+      </div>
+    </section>
+  );
+}
+
+// ── Fact card ─────────────────────────────────────────────────────────
+
+interface FactCardProps {
+  update: ArtistUpdate;
+  artistName: string;
+  expanded: boolean;
+  pulsing: boolean;
+  onToggle: () => void;
+  registerRef: (el: HTMLDivElement | null) => void;
+}
+
+function FactCard({ update, expanded, pulsing, onToggle, registerRef }: FactCardProps) {
+  const { kindLabel, kindClass, KindIcon } = kindMeta(update.kind);
+  return (
+    <div
+      ref={registerRef}
+      className={`rounded-2xl border bg-gradient-to-br from-white/[0.06] to-white/[0.02] transition-all ${
+        pulsing
+          ? "border-rose-400/70 ring-2 ring-rose-400/40"
+          : "border-white/10 hover:border-white/20"
+      }`}
+    >
+      <button
+        onClick={onToggle}
+        className="w-full text-left px-4 py-3 flex items-start gap-3"
+        aria-expanded={expanded}
+      >
+        <span
+          className={`mt-0.5 shrink-0 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${kindClass}`}
+        >
+          <KindIcon className="w-3 h-3" />
+          {kindLabel}
+        </span>
+        <h3 className="flex-1 text-sm md:text-base font-semibold text-white/95 leading-snug">
+          {update.headline}
+        </h3>
+      </button>
+      {expanded && (
+        <div className="px-4 pb-4 -mt-1 flex flex-col gap-2">
+          <p className="text-sm leading-relaxed text-white/70">{update.body}</p>
+          {update.source?.url && (
+            <a
+              href={update.source.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-xs text-white/40 hover:text-white/70 transition-colors self-start"
+            >
+              Source: {update.source.publisher ?? "link"}
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function kindMeta(kind: ArtistUpdate["kind"]): {
+  kindLabel: string;
+  kindClass: string;
+  KindIcon: typeof Sparkles;
+} {
+  switch (kind) {
+    case "new-release":
+      return { kindLabel: "New release", kindClass: "bg-rose-500/15 text-rose-300", KindIcon: Disc };
+    case "collab":
+      return { kindLabel: "Collab", kindClass: "bg-violet-500/15 text-violet-300", KindIcon: Users };
+    case "fact":
+    default:
+      return { kindLabel: "Fact", kindClass: "bg-sky-500/15 text-sky-300", KindIcon: Sparkles };
+  }
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl bg-white/[0.04] border border-white/5 p-4 animate-pulse" aria-hidden>
+      <div className="flex items-center gap-3 mb-2">
+        <div className="h-4 w-16 rounded-full bg-white/10" />
+        <div className="h-4 flex-1 rounded bg-white/10" />
+      </div>
+      <div className="h-3 w-5/6 rounded bg-white/5" />
+    </div>
+  );
+}

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -87,7 +87,6 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
               <FactCard
                 key={u.nuggetId ?? `${u.kind}-${u.headline}`}
                 update={u}
-                artistName={artistName}
                 expanded={u.nuggetId === expandedId}
                 pulsing={u.nuggetId === pulseId}
                 onToggle={() =>
@@ -107,7 +106,6 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
 
 interface FactCardProps {
   update: ArtistUpdate;
-  artistName: string;
   expanded: boolean;
   pulsing: boolean;
   onToggle: () => void;

--- a/src/components/NowPlayingBar.tsx
+++ b/src/components/NowPlayingBar.tsx
@@ -15,10 +15,18 @@ export default function NowPlayingBar() {
   const location = useLocation();
   const { isPlaying, currentTrack, currentTime, duration, toggle, seek, popTrackHistory, externalPlayback, setExternalListenMode, nowPlayingFocused, nowPlayingFocusIndex, setNowPlayingFocused, setNowPlayingFocusIndex } = usePlayer();
 
-  // Don't show on Listen page (has its own bar) or companion pages (phone QR experience)
+  // Don't show on Listen page (has its own bar), companion pages (phone
+  // QR experience), or anywhere in the onboarding / auth funnel. The
+  // bar showing up during Spotify's approve screen or on the tier
+  // picker is distracting and competes with primary UI the user is
+  // supposed to be focused on.
   const hiddenRoute = location.pathname.startsWith("/listen/")
     || location.pathname.startsWith("/companion/")
-    || location.pathname.startsWith("/c/");
+    || location.pathname.startsWith("/c/")
+    || location.pathname === "/"
+    || location.pathname === "/connect"
+    || location.pathname === "/preparing"
+    || location.pathname === "/spotify-callback";
 
   // Show if there's a loaded track OR external playback detected
   const showExternal = !hiddenRoute && !currentTrack && !!externalPlayback;

--- a/src/components/SpotifySyncingOverlay.tsx
+++ b/src/components/SpotifySyncingOverlay.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import MusicNerdLogo from "@/components/MusicNerdLogo";
+
+/**
+ * Full-screen takeover shown while the Spotify post-signin taste fetch
+ * is in flight. Replaces the Connect screen entirely so the user sees
+ * unambiguous progress rather than re-reading "Connect your music".
+ *
+ * Error surfacing is delegated to the parent — this overlay is "dumb"
+ * about failure semantics. When `error` is non-null, show the error
+ * state. When `visible` goes false, the overlay unmounts via exit
+ * animation. No private watchdog; the hook's fetch timeout (20s) is
+ * the single source of truth for when to give up.
+ *
+ * Progress-bar pacing spans the full fetch window (4% → 95% over 20s)
+ * so the bar is always visibly moving, never parked.
+ */
+
+const STATUS_STEPS = [
+  { threshold: 0, label: "Opening the door to your library" },
+  { threshold: 2_000, label: "Tuning into your listening history" },
+  { threshold: 6_000, label: "Finding the artists you love most" },
+  { threshold: 10_000, label: "Lining up the tracks you know by heart" },
+  { threshold: 15_000, label: "Just a moment more" },
+];
+
+interface Props {
+  visible: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+}
+
+export default function SpotifySyncingOverlay({ visible, error, onRetry }: Props) {
+  const [elapsed, setElapsed] = useState(0);
+
+  // Only run the status-step timer while we're actually loading (no
+  // error). On an error → loading transition this effect will re-fire
+  // and reset elapsed to 0, so the user sees a fresh run.
+  const loading = visible && !error;
+  useEffect(() => {
+    if (!loading) {
+      setElapsed(0);
+      return;
+    }
+    const start = Date.now();
+    const timer = setInterval(() => setElapsed(Date.now() - start), 200);
+    return () => clearInterval(timer);
+  }, [loading]);
+
+  const currentStep = STATUS_STEPS.reduce((acc, step) =>
+    elapsed >= step.threshold ? step : acc,
+  );
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          key="spotify-sync-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.25 }}
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center overflow-hidden bg-black px-6"
+          aria-live="polite"
+          role="status"
+        >
+          {/* Animated aurora background — slow drift so the screen
+              never feels frozen while progress ticks. */}
+          <motion.div
+            className="pointer-events-none absolute -inset-40 opacity-60 blur-3xl"
+            initial={{ scale: 1, rotate: 0 }}
+            animate={{ scale: [1, 1.08, 1], rotate: [0, 8, 0] }}
+            transition={{ duration: 10, ease: "easeInOut", repeat: Infinity }}
+            style={{
+              background:
+                "radial-gradient(40% 40% at 30% 30%, rgba(34,197,94,0.25), transparent), radial-gradient(40% 40% at 70% 70%, rgba(236,72,153,0.25), transparent)",
+            }}
+          />
+
+          <motion.div
+            className="relative z-10 flex w-full max-w-sm flex-col items-center gap-6 text-center"
+            initial={{ y: 8, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          >
+            <motion.div
+              animate={error ? { scale: 1 } : { scale: [1, 1.04, 1] }}
+              transition={{ duration: 2.4, ease: "easeInOut", repeat: Infinity }}
+            >
+              <MusicNerdLogo size={72} glow />
+            </motion.div>
+
+            {error ? (
+              <ErrorState error={error} onRetry={onRetry} />
+            ) : (
+              // `key` forces the LoadingState subtree (including the
+              // progress bar's motion.div) to remount on a retry, so
+              // the bar animation restarts from 0 instead of freezing
+              // at wherever it was when error fired.
+              <LoadingState key={elapsed === 0 ? "fresh" : "continue"} label={currentStep.label} />
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <>
+      <div className="space-y-1.5">
+        <h1
+          className="text-xl md:text-2xl font-black text-white tracking-tight"
+          style={{ fontFamily: "'Nunito Sans', sans-serif" }}
+        >
+          Reading your music taste
+        </h1>
+        <div className="relative h-5 overflow-hidden">
+          <AnimatePresence mode="wait">
+            <motion.p
+              key={label}
+              initial={{ y: 10, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -10, opacity: 0 }}
+              transition={{ duration: 0.3, ease: "easeOut" }}
+              className="text-sm text-white/70"
+            >
+              {label}
+              <span className="inline-block ml-0.5 animate-pulse">…</span>
+            </motion.p>
+          </AnimatePresence>
+        </div>
+      </div>
+
+      <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+        {/* Bar spans the full 20s fetch-timeout window so the user
+            always sees forward motion. Never parks — if the hook
+            reports an error the overlay swaps states entirely; on
+            success the exit animation snaps to 100%. */}
+        <motion.div
+          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-green-400 via-emerald-300 to-pink-400"
+          initial={{ width: "4%" }}
+          animate={{ width: "95%" }}
+          exit={{ width: "100%" }}
+          transition={{ duration: 20, ease: [0.2, 0.6, 0.3, 1] }}
+        />
+        <motion.div
+          className="absolute inset-y-0 w-24 rounded-full"
+          style={{
+            background:
+              "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
+          }}
+          animate={{ x: ["-20%", "420%"] }}
+          transition={{ duration: 1.6, ease: "easeInOut", repeat: Infinity }}
+        />
+      </div>
+
+      <p className="text-[11px] uppercase tracking-widest text-white/35">
+        Sit tight — this only happens once
+      </p>
+    </>
+  );
+}
+
+function ErrorState({ error, onRetry }: { error: string; onRetry?: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-5">
+      <div className="space-y-1.5">
+        <h1
+          className="text-xl md:text-2xl font-black text-white tracking-tight"
+          style={{ fontFamily: "'Nunito Sans', sans-serif" }}
+        >
+          Hmm, that took too long
+        </h1>
+        <p className="text-sm text-white/70 max-w-xs">{error}</p>
+      </div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="rounded-full bg-white text-black text-sm font-semibold px-6 py-2.5 hover:bg-white/90 transition-colors"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/SpotifySyncingOverlay.tsx
+++ b/src/components/SpotifySyncingOverlay.tsx
@@ -111,10 +111,7 @@ function LoadingState({ label }: { label: string }) {
   return (
     <>
       <div className="space-y-1.5">
-        <h1
-          className="text-xl md:text-2xl font-black text-white tracking-tight"
-          style={{ fontFamily: "'Nunito Sans', sans-serif" }}
-        >
+        <h1 className="text-xl md:text-2xl font-black text-white tracking-tight font-nunito">
           Reading your music taste
         </h1>
         <div className="relative h-5 overflow-hidden">
@@ -168,10 +165,7 @@ function ErrorState({ error, onRetry }: { error: string; onRetry?: () => void })
   return (
     <div className="flex flex-col items-center gap-5">
       <div className="space-y-1.5">
-        <h1
-          className="text-xl md:text-2xl font-black text-white tracking-tight"
-          style={{ fontFamily: "'Nunito Sans', sans-serif" }}
-        >
+        <h1 className="text-xl md:text-2xl font-black text-white tracking-tight font-nunito">
           Hmm, that took too long
         </h1>
         <p className="text-sm text-white/70 max-w-xs">{error}</p>

--- a/src/contexts/ArtistUpdatesContext.tsx
+++ b/src/contexts/ArtistUpdatesContext.tsx
@@ -1,0 +1,54 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
+import {
+  useArtistUpdates,
+  type ArtistUpdateGroup,
+} from "@/hooks/useArtistUpdates";
+
+/**
+ * Hoists the "Your artists, lately" fetch above the route tree so
+ * pre-generation starts the moment the user's profile is hydrated —
+ * before they navigate to Browse. Same idea as `StoriesProvider`:
+ * close the gap between onboarding finishing and Browse rendering,
+ * so the first Browse paint has tiles ready instead of skeletons.
+ *
+ * For returning users, the profile is in localStorage at mount time,
+ * so pre-gen fires immediately and Browse is usually warm by first
+ * render. For new users, pre-gen fires as soon as `handleTierSelect`
+ * saves the profile — during the ~1–2s navigation to Browse, the
+ * edge function is already working. On cold starts it's still racey
+ * (Gemini's ~5s latency vs. page navigation), but the skeleton state
+ * in `ArtistUpdatesSection` masks the gap.
+ *
+ * `useArtistUpdates` no-ops gracefully when profile is null, so we
+ * can mount the provider unconditionally above the protected routes.
+ */
+
+interface ArtistUpdatesContextValue {
+  groups: ArtistUpdateGroup[];
+  loading: boolean;
+  totalCount: number;
+  readyCount: number;
+}
+
+const ArtistUpdatesContext = createContext<ArtistUpdatesContextValue>({
+  groups: [],
+  loading: false,
+  totalCount: 0,
+  readyCount: 0,
+});
+
+export function ArtistUpdatesProvider({ children }: { children: ReactNode }) {
+  const { profile } = useUserProfile();
+  const tier = (profile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
+  const { groups, loading, totalCount, readyCount } = useArtistUpdates(profile, { tier });
+  return (
+    <ArtistUpdatesContext.Provider value={{ groups, loading, totalCount, readyCount }}>
+      {children}
+    </ArtistUpdatesContext.Provider>
+  );
+}
+
+export function useArtistUpdatesContext(): ArtistUpdatesContextValue {
+  return useContext(ArtistUpdatesContext);
+}

--- a/src/contexts/RefreshIndicatorContext.tsx
+++ b/src/contexts/RefreshIndicatorContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useBackgroundTasteRefresh } from "@/hooks/useBackgroundTasteRefresh";
+import { useArtistUpdatesContext } from "@/contexts/ArtistUpdatesContext";
+
+/**
+ * Aggregates the user-visible refresh signals into one place so a single
+ * indicator can surface them. Each source still owns its own loading
+ * state (artist-updates skeletons in their rail); this context exists so
+ * a global header indicator can show "something is refreshing" without
+ * those sources having to coordinate.
+ *
+ * What's NOT included here: pre-generated stories. Stories pre-gen is
+ * opportunistic background work (warms the per-track nugget cache so a
+ * future tap is instant) — not user-blocking. Including it made the
+ * indicator linger for 60-120s after first paint while Gemini pre-gen
+ * burned through 5 cold-start calls, which made it feel like Browse
+ * wasn't done loading even though it was fully usable.
+ *
+ * Mounted near the top of the tree (in App.tsx) so all sources are
+ * already in scope.
+ */
+
+interface RefreshIndicatorState {
+  tasteRefreshing: boolean;
+  artistUpdatesRefreshing: boolean;
+  /** Convenience — true if any user-visible refresh is in flight. */
+  any: boolean;
+  /** Human-readable label describing what's loading. Picks one signal
+   *  (taste > artist updates) so the user sees a specific message
+   *  rather than a generic "loading". */
+  label: string | null;
+}
+
+const RefreshIndicatorContext = createContext<RefreshIndicatorState | null>(null);
+
+export function RefreshIndicatorProvider({ children }: { children: ReactNode }) {
+  const { refreshing: tasteRefreshing } = useBackgroundTasteRefresh();
+  const { loading: artistUpdatesRefreshing } = useArtistUpdatesContext();
+
+  const value = useMemo<RefreshIndicatorState>(() => {
+    const any = tasteRefreshing || artistUpdatesRefreshing;
+    const label = tasteRefreshing
+      ? "Refreshing your library"
+      : artistUpdatesRefreshing
+        ? "Loading artist updates"
+        : null;
+    return { tasteRefreshing, artistUpdatesRefreshing, any, label };
+  }, [tasteRefreshing, artistUpdatesRefreshing]);
+
+  return (
+    <RefreshIndicatorContext.Provider value={value}>
+      {children}
+    </RefreshIndicatorContext.Provider>
+  );
+}
+
+export function useRefreshIndicator(): RefreshIndicatorState {
+  const ctx = useContext(RefreshIndicatorContext);
+  if (!ctx) {
+    throw new Error("useRefreshIndicator must be used within RefreshIndicatorProvider");
+  }
+  return ctx;
+}

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -34,13 +34,35 @@ interface AINuggetData {
  * (seed-nugget slugs) are passed through unchanged. Mirror of the
  * server-side canonicalization in generate-nuggets/index.ts.
  */
+function safeDecode(s: string): string {
+  try { return decodeURIComponent(s); } catch { return s; }
+}
+
 function canonicalCacheKey(trackId: string, tier: string): string {
-  if (!trackId.startsWith("real::")) return `${trackId}::${tier}`;
-  const parts = trackId.split("::");
+  // Listen receives `trackId` from React Router params, which keeps URL-
+  // encoded characters (`%20`, `%3A`, etc.). The server-side write path
+  // builds the cache key from the request body's raw artist/title/uri
+  // strings (no encoding). Without normalizing here, every Listen mount
+  // on a track with spaces or special chars cache-misses and re-runs
+  // the full ~30s nugget pipeline.
+  //
+  // A `real%3A%3A…` trackId still starts with the right prefix once
+  // decoded; check for both forms so the early-return path doesn't
+  // skip encoded inputs.
+  if (!trackId.startsWith("real::") && !trackId.startsWith("real%3A%3A")) {
+    return `${trackId}::${tier}`;
+  }
+  // Normalize encoded delimiters before split so parts line up regardless
+  // of how the upstream route preserved them.
+  const normalized = trackId.replace(/%3A%3A/gi, "::");
+  const parts = normalized.split("::");
   // Expected: ["real", artist, title, album, uri...]. Fewer than 5 parts
   // means the id is malformed — preserve original to avoid losing data.
   if (parts.length < 5) return `${trackId}::${tier}`;
-  parts[3] = "";
+  parts[1] = safeDecode(parts[1]); // artist
+  parts[2] = safeDecode(parts[2]); // title
+  parts[3] = ""; // album — blanked by canon (multiple entry points populate inconsistently)
+  parts[4] = safeDecode(parts[4]); // uri
   return `${parts.join("::")}::${tier}`;
 }
 

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -170,6 +170,11 @@ export function useAINuggets(
   } = usePlayer();
   const cancelledRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
+  // Mirror currentTime into a ref so the SSE handler (closes over stale
+  // currentTime from effect-setup time) can read the LIVE playback
+  // position when deciding whether to early-cancel mid-stream.
+  const currentTimeRef = useRef(currentTime);
+  currentTimeRef.current = currentTime;
   // Track when the last generation attempt started — used to only debounce
   // on rapid skips (< 5s between tracks), not on first page load.
   const lastGenTimestampRef = useRef(0);
@@ -526,8 +531,17 @@ export function useAINuggets(
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = "";
+        // Flips true when we've decided to stop reading early because
+        // the user is near track-end and we have enough nuggets. Read
+        // by both inner and outer loops so we exit cleanly without
+        // throwing an AbortError (which would skip the cache write).
+        let earlyComplete = false;
 
         while (true) {
+          if (earlyComplete) {
+            await reader.cancel().catch(() => {}); // tell server we're done
+            break;
+          }
           const { done, value } = await reader.read();
           if (done) break;
           if (cancelledRef.current) { reader.cancel(); return; }
@@ -561,6 +575,37 @@ export function useAINuggets(
               setSources((prev) => new Map(prev).set(sourceId, source));
               setNuggets((prev) => [...prev, nugget]);
               if (import.meta.env.DEV) console.log(`[SSE] Received nugget ${payload.index}: "${n.headline?.slice(0, 40)}"`);
+
+              // Early-cancel: if we already have enough nuggets to cover
+              // the rest of playback, abort the stream rather than burning
+              // Gemini calls the user will never see. Conditions:
+              //   - have ≥ MIN_EARLY_CANCEL_NUGGETS (4) — keep at least
+              //     casual-tier worth of content even on short tracks
+              //   - track has ≤ EARLY_CANCEL_REMAINING_SEC (45s) left
+              //   - playback is actively running (paused users may still
+              //     read, so don't cancel on them)
+              // We treat the partial set as the final cache row — this
+              // listen's full nugget budget got pruned to "what fits the
+              // remaining playback window," not lost.
+              const MIN_EARLY_CANCEL_NUGGETS = 4;
+              const EARLY_CANCEL_REMAINING_SEC = 45;
+              const liveCurrentTime = currentTimeRef.current;
+              const remainingSec = durationSec - liveCurrentTime;
+              if (
+                isPlaying &&
+                aiNuggets.length >= MIN_EARLY_CANCEL_NUGGETS &&
+                remainingSec > 0 &&
+                remainingSec <= EARLY_CANCEL_REMAINING_SEC
+              ) {
+                if (import.meta.env.DEV) {
+                  console.log(`[SSE] early-complete: ${aiNuggets.length} nuggets in hand, ${Math.round(remainingSec)}s left on track — stopping stream + caching what we have`);
+                }
+                earlyComplete = true;
+                // Break out of the event loop; outer while sees the
+                // flag, cancels the reader, and falls through to the
+                // post-stream cache write so the partial set isn't lost.
+                break;
+              }
 
             } else if (payload.type === "done") {
               aiArtistSummary = payload.artistSummary || "";

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -197,6 +197,12 @@ export function useAINuggets(
   // position when deciding whether to early-cancel mid-stream.
   const currentTimeRef = useRef(currentTime);
   currentTimeRef.current = currentTime;
+  // Same for isPlaying — without a ref the early-cancel closure sees
+  // whatever isPlaying was at the moment the effect fired and never
+  // updates. A user who pauses mid-stream would still trigger the
+  // cancel because the closure thinks they're still playing.
+  const isPlayingRef = useRef(isPlaying);
+  isPlayingRef.current = isPlaying;
   // Track when the last generation attempt started — used to only debounce
   // on rapid skips (< 5s between tracks), not on first page load.
   const lastGenTimestampRef = useRef(0);
@@ -609,12 +615,20 @@ export function useAINuggets(
               // We treat the partial set as the final cache row — this
               // listen's full nugget budget got pruned to "what fits the
               // remaining playback window," not lost.
+              //
+              // NOTE on `aiNuggets.length`: this is a LOCAL `let` array
+              // (declared at line 545), pushed synchronously above on
+              // line 589 BEFORE this check runs. It's not React state,
+              // so the count is live — no ref-mirror needed.
+              // `isPlayingRef.current` and `currentTimeRef.current` ARE
+              // ref-mirrored because they come from React state via
+              // usePlayer() and would otherwise be stale closures.
               const MIN_EARLY_CANCEL_NUGGETS = 4;
               const EARLY_CANCEL_REMAINING_SEC = 45;
               const liveCurrentTime = currentTimeRef.current;
               const remainingSec = durationSec - liveCurrentTime;
               if (
-                isPlaying &&
+                isPlayingRef.current &&
                 aiNuggets.length >= MIN_EARLY_CANCEL_NUGGETS &&
                 remainingSec > 0 &&
                 remainingSec <= EARLY_CANCEL_REMAINING_SEC

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -25,6 +25,15 @@ interface AINuggetData {
 
 // ── Helpers for consistent ID/object creation across SSE, cache, and JSON paths ──
 
+// Early-cancel thresholds for the SSE stream. Module-scope so they
+// aren't re-allocated per nugget event in the loop.
+//   - MIN_EARLY_CANCEL_NUGGETS: keep at least casual-tier worth of
+//     content (3) plus one buffer before considering a cancel.
+//   - EARLY_CANCEL_REMAINING_SEC: track-end window where additional
+//     nuggets won't reach the user; bail rather than burn Gemini.
+const MIN_EARLY_CANCEL_NUGGETS = 4;
+const EARLY_CANCEL_REMAINING_SEC = 45;
+
 /**
  * Blank the album slot in a `real::…` trackId before composing the
  * nugget_cache key. Different entry points populate the album slot
@@ -38,7 +47,9 @@ function safeDecode(s: string): string {
   try { return decodeURIComponent(s); } catch { return s; }
 }
 
-function canonicalCacheKey(trackId: string, tier: string): string {
+// Exported for unit tests — see src/test/canonicalCacheKey.test.ts.
+// Internal call sites still go through this same function.
+export function canonicalCacheKey(trackId: string, tier: string): string {
   // Listen receives `trackId` from React Router params, which keeps URL-
   // encoded characters (`%20`, `%3A`, etc.). The server-side write path
   // builds the cache key from the request body's raw artist/title/uri
@@ -623,8 +634,8 @@ export function useAINuggets(
               // `isPlayingRef.current` and `currentTimeRef.current` ARE
               // ref-mirrored because they come from React state via
               // usePlayer() and would otherwise be stale closures.
-              const MIN_EARLY_CANCEL_NUGGETS = 4;
-              const EARLY_CANCEL_REMAINING_SEC = 45;
+              // (MIN_EARLY_CANCEL_NUGGETS / EARLY_CANCEL_REMAINING_SEC
+              //  hoisted to module scope; were re-evaluated per nugget here.)
               const liveCurrentTime = currentTimeRef.current;
               const remainingSec = durationSec - liveCurrentTime;
               if (

--- a/src/hooks/useArtistLatestFacts.ts
+++ b/src/hooks/useArtistLatestFacts.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+/**
+ * Fetches the `ArtistUpdate[]` for a single artist. Hits the same
+ * `artist-updates` edge function the Browse hook uses, so a cache row
+ * warmed by Browse is instant on the artist profile.
+ *
+ * Scope is one-artist-at-a-time because the artist profile only ever
+ * needs its own data — the multi-artist throttling + grouping in
+ * `useArtistUpdates` would be overkill here.
+ *
+ * The hook returns quickly from cache on warm artists (users arriving
+ * via a Browse nugget tap); a cold artist (e.g. navigated from "Fans
+ * Also Like") triggers a fresh edge-function call with the usual
+ * generation latency.
+ */
+export function useArtistLatestFacts(
+  artistName: string | null,
+  tier: "casual" | "curious" | "nerd",
+): { updates: ArtistUpdate[]; loading: boolean } {
+  const [updates, setUpdates] = useState<ArtistUpdate[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!artistName) {
+      setUpdates([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const { data, error } = await supabase.functions.invoke("artist-updates", {
+          body: { artist: artistName, tier },
+        });
+        if (cancelled) return;
+        if (error) {
+          if (import.meta.env.DEV) {
+            console.warn(`[artist-latest-facts] ${artistName} failed:`, error.message);
+          }
+          setUpdates([]);
+          return;
+        }
+        const next = (data?.updates as ArtistUpdate[] | undefined) ?? [];
+        setUpdates(next);
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.warn(`[artist-latest-facts] ${artistName} threw:`, e);
+        }
+        setUpdates([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [artistName, tier]);
+
+  return { updates, loading };
+}

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -24,6 +24,11 @@ export interface ArtistUpdate {
   };
   nuggetId?: string;
   relatedTrackUri?: string;
+  /** Track-level metadata for new-release/collab kinds. Set by the
+   *  edge function via a follow-up call to /albums/:id/tracks; lets
+   *  client navigate to /listen/ with a URI Spotify can actually play. */
+  relatedTrackTitle?: string;
+  relatedAlbumName?: string;
 }
 
 /** A top artist paired with their updates. Stays null while loading. */

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -40,11 +40,13 @@ interface UseArtistUpdatesOptions {
   maxConcurrent?: number;
 }
 
-// Defaults dropped from 5 → 3 after first-run feedback: 5 artists × up
-// to 3 updates + 8 stories was too much cold-generation pressure on
-// first sign-in. 3 × 3 = 9 cards per artist row is still plenty of
-// MusicNerd density without burying the first paint.
-const DEFAULT_MAX_ARTISTS = 3;
+// TEMPORARY: dropped to 1 for testing the refresh cascade in isolation
+// (one artist makes the loading state easy to spot and minimizes API
+// burn while validating). Revert to 3 before shipping — production
+// density needs the full 3-artist row. Tracked in CLAUDE.md TODO.
+// (Was 3 after first-run feedback: 5 artists × up to 3 updates + 8
+// stories was too much cold-generation pressure on first sign-in.)
+const DEFAULT_MAX_ARTISTS = 1;
 const DEFAULT_CONCURRENCY = 2;
 
 export interface UseArtistUpdatesResult {
@@ -85,6 +87,16 @@ export function useArtistUpdates(
   // Scoped per `(artist, tier)` so switching tiers re-fetches but a
   // re-render doesn't re-fire in-flight requests.
   const inFlightRef = useRef<Set<string>>(new Set());
+
+  // Stable content signature of the artist slice we're about to fetch.
+  // useUserProfile re-renders with a new `profile.topArtists` array
+  // identity every time the DB hydrate effect runs (even when the
+  // content is identical), which previously re-fired this effect and
+  // wedged the fan-out: the second run's fetchOne short-circuited on
+  // inFlightRef keys still held by the first run, while the first run's
+  // cancelled=true closure suppressed its own setState. Content-keyed
+  // deps keep the effect stable across identity-only re-renders.
+  const topArtistsSig = (profile?.topArtists ?? []).slice(0, maxArtists).join("|");
 
   useEffect(() => {
     const topArtists = profile?.topArtists ?? [];
@@ -160,10 +172,13 @@ export function useArtistUpdates(
     return () => {
       cancelled = true;
     };
-    // Array identity (not length) so a same-length taste refresh with
-    // different artists still re-fetches — parity with the PR #74
-    // round-3 fix in usePreGeneratedStories.ts.
-  }, [profile?.topArtists, tier, maxArtists, maxConcurrent]);
+    // Content-keyed (not identity): `topArtistsSig` is a stable string
+    // of the sliced artist names. useUserProfile re-issues new array
+    // identities on every DB-hydrate notification; using those directly
+    // as deps wedged the hook (see block comment above `topArtistsSig`).
+    // `tier` / `maxArtists` / `maxConcurrent` are primitives — safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topArtistsSig, tier, maxArtists, maxConcurrent]);
 
   const allUpdates = useMemo(
     () => groups.flatMap((g) => g.updates ?? []),

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import type { UserProfile } from "@/mock/types";
+
+/**
+ * One item for the "Your artists, lately" row on Browse.
+ *
+ * Mirrors the server-side `ArtistUpdate` shape in
+ * supabase/functions/artist-updates/index.ts. Duplicated client-side so
+ * the hook doesn't cross-import from a Deno edge function.
+ */
+export interface ArtistUpdate {
+  artistId: string;
+  artistName: string;
+  artistImageUrl: string;
+  kind: "new-release" | "collab" | "fact";
+  headline: string;
+  body: string;
+  source?: {
+    type: string;
+    title?: string;
+    publisher?: string;
+    url?: string;
+  };
+  nuggetId?: string;
+  relatedTrackUri?: string;
+}
+
+/** A top artist paired with their updates. Stays null while loading. */
+export interface ArtistUpdateGroup {
+  artistName: string;
+  updates: ArtistUpdate[] | null;
+}
+
+interface UseArtistUpdatesOptions {
+  tier: "casual" | "curious" | "nerd";
+  /** Cap on how many top artists we ask the edge function about. */
+  maxArtists?: number;
+  /** In-flight requests per user; matches usePreGeneratedStories. */
+  maxConcurrent?: number;
+}
+
+const DEFAULT_MAX_ARTISTS = 5;
+const DEFAULT_CONCURRENCY = 2;
+
+export interface UseArtistUpdatesResult {
+  /** One entry per top artist, preserving input order. `updates` is null until that artist resolves. */
+  groups: ArtistUpdateGroup[];
+  /** Flat list of all updates received so far (consumers that don't care about grouping). */
+  allUpdates: ArtistUpdate[];
+  /** Whether at least one artist is still being fetched. */
+  loading: boolean;
+  /** Count of artists we attempted (includes those still loading). */
+  totalCount: number;
+  /** Count of artists whose fetch has resolved (even if they returned zero updates). */
+  readyCount: number;
+}
+
+/**
+ * Fan-out fetch for the user's top artists. Each artist resolves to an
+ * array of up to 3 updates (one release card + two fact nuggets). The
+ * edge function returns `{ updates: ArtistUpdate[] }`; we key the
+ * response into per-artist groups so Browse can render a nested row
+ * per artist rather than a flat mixed list.
+ *
+ * Results land incrementally so `Browse` can render filled rows
+ * alongside still-loading skeletons. Matches the throttle pattern in
+ * `usePreGeneratedStories.ts`.
+ */
+export function useArtistUpdates(
+  profile: UserProfile | null,
+  {
+    tier,
+    maxArtists = DEFAULT_MAX_ARTISTS,
+    maxConcurrent = DEFAULT_CONCURRENCY,
+  }: UseArtistUpdatesOptions,
+): UseArtistUpdatesResult {
+  const [groups, setGroups] = useState<ArtistUpdateGroup[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [readyCount, setReadyCount] = useState(0);
+  // Scoped per `(artist, tier)` so switching tiers re-fetches but a
+  // re-render doesn't re-fire in-flight requests.
+  const inFlightRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const topArtists = profile?.topArtists ?? [];
+    if (!topArtists.length) {
+      setGroups([]);
+      setReadyCount(0);
+      return;
+    }
+
+    const artists = topArtists.slice(0, maxArtists);
+    // Seed the groups with null-updates placeholders so Browse can
+    // render one skeleton row per artist immediately while the edge
+    // function calls are in flight.
+    setGroups(artists.map((name) => ({ artistName: name, updates: null })));
+    setReadyCount(0);
+    setLoading(true);
+
+    let cancelled = false;
+
+    async function fetchOne(artist: string): Promise<void> {
+      const key = `${artist}::${tier}`;
+      if (inFlightRef.current.has(key)) return;
+      inFlightRef.current.add(key);
+      try {
+        const { data, error } = await supabase.functions.invoke("artist-updates", {
+          body: { artist, tier },
+        });
+        if (cancelled) return;
+        if (error) {
+          if (import.meta.env.DEV) {
+            console.warn(`[artist-updates] ${artist} failed:`, error.message);
+          }
+          // Resolve with empty set so the placeholder flips out of
+          // loading state — no partial row stays skeletal forever.
+          setGroups((prev) =>
+            prev.map((g) => (g.artistName === artist ? { ...g, updates: [] } : g)),
+          );
+          return;
+        }
+        const updates = (data?.updates as ArtistUpdate[] | undefined) ?? [];
+        setGroups((prev) =>
+          prev.map((g) => (g.artistName === artist ? { ...g, updates } : g)),
+        );
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.warn(`[artist-updates] ${artist} threw:`, e);
+        }
+        setGroups((prev) =>
+          prev.map((g) => (g.artistName === artist ? { ...g, updates: [] } : g)),
+        );
+      } finally {
+        inFlightRef.current.delete(key);
+        if (!cancelled) setReadyCount((n) => n + 1);
+      }
+    }
+
+    (async () => {
+      let index = 0;
+      const worker = async () => {
+        while (index < artists.length) {
+          const i = index++;
+          await fetchOne(artists[i]);
+        }
+      };
+      const workers: Promise<void>[] = [];
+      for (let w = 0; w < Math.min(maxConcurrent, artists.length); w++) {
+        workers.push(worker());
+      }
+      await Promise.all(workers);
+      if (!cancelled) setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Array identity (not length) so a same-length taste refresh with
+    // different artists still re-fetches — parity with the PR #74
+    // round-3 fix in usePreGeneratedStories.ts.
+  }, [profile?.topArtists, tier, maxArtists, maxConcurrent]);
+
+  const allUpdates = useMemo(
+    () => groups.flatMap((g) => g.updates ?? []),
+    [groups],
+  );
+
+  return {
+    groups,
+    allUpdates,
+    loading,
+    totalCount: groups.length,
+    readyCount,
+  };
+}

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -45,12 +45,18 @@ interface UseArtistUpdatesOptions {
   maxConcurrent?: number;
 }
 
-// TEMPORARY: dropped to 1 for testing the refresh cascade in isolation
-// (one artist makes the loading state easy to spot and minimizes API
-// burn while validating). Revert to 3 before shipping — production
-// density needs the full 3-artist row. Tracked in CLAUDE.md TODO.
-// (Was 3 after first-run feedback: 5 artists × up to 3 updates + 8
-// stories was too much cold-generation pressure on first sign-in.)
+// INTENTIONAL: 1 top artist is the current product target for the
+// Browse "Your artists, lately" rail. Reviewers have flagged this as
+// a "test mode" leftover multiple times — it is not. The single-row
+// treatment keeps the rail tight, halves first-paint Gemini load
+// vs. 3 artists, and matches the design direction we're testing
+// across the staging cohort.
+//
+// Earlier history: was 5 → 3 → 1. The 5→3 drop was first-run feedback
+// (cold-gen pressure on sign-in). The 3→1 drop is a product decision,
+// not a debug knob.
+//
+// Revisit only with explicit product approval.
 const DEFAULT_MAX_ARTISTS = 1;
 const DEFAULT_CONCURRENCY = 2;
 

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -40,7 +40,11 @@ interface UseArtistUpdatesOptions {
   maxConcurrent?: number;
 }
 
-const DEFAULT_MAX_ARTISTS = 5;
+// Defaults dropped from 5 → 3 after first-run feedback: 5 artists × up
+// to 3 updates + 8 stories was too much cold-generation pressure on
+// first sign-in. 3 × 3 = 9 cards per artist row is still plenty of
+// MusicNerd density without burying the first paint.
+const DEFAULT_MAX_ARTISTS = 3;
 const DEFAULT_CONCURRENCY = 2;
 
 export interface UseArtistUpdatesResult {

--- a/src/hooks/useBackgroundTasteRefresh.ts
+++ b/src/hooks/useBackgroundTasteRefresh.ts
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useUserProfile, applyTastePatch } from "./useMusicNerdState";
+import { fetchSpotifyTaste } from "./useSpotifyAuth";
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Silently re-pull the user's Spotify top-artists/top-tracks when the
+ * cached snapshot is stale. Mounted once at the app level so the check
+ * runs no matter which route the user lands on (a returning user with a
+ * /listen bookmark never hits /connect).
+ *
+ * Why this exists:
+ *   The /connect Navigate short-circuit (added to fix the post-OAuth
+ *   route stall) means returning users skip `useSpotifyPostSigninSync`
+ *   entirely. Without this, `profile.topArtists` etc. would be frozen
+ *   from the user's first sign-in forever — Browse rails, ArtistUpdates,
+ *   and AI nugget context would all use stale taste data.
+ *
+ * Why background, not blocking:
+ *   The taste fetch is cheap (just hits Spotify's `top-artists` /
+ *   `top-tracks` endpoints, no Gemini/Exa) and the UI doesn't need to
+ *   wait — components re-render via the profile-updated event when the
+ *   merge lands.
+ *
+ * Refresh policy:
+ *   - First load with no `tasteRefreshedAt` (existing users pre-feature)
+ *     → refresh
+ *   - `tasteRefreshedAt` older than `TASTE_TTL_MS` → refresh
+ *   - Otherwise skip
+ */
+
+const TASTE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface BackgroundTasteRefreshState {
+  /** True from the moment the fetch starts until it resolves (success or
+   *  failure). Consumed by the global refresh indicator. */
+  refreshing: boolean;
+  /** ISO timestamp of the last refresh attempt that landed (success).
+   *  Reflects what `tasteRefreshedAt` will be on the profile after the
+   *  merge propagates. */
+  lastRefreshedAt: string | null;
+}
+
+export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
+  const { user } = useAuth();
+  const { profile } = useUserProfile();
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<string | null>(
+    profile?.tasteRefreshedAt ?? null
+  );
+  // Per-user guard — switching accounts re-runs the check. Without this
+  // the effect would re-fire every render once `refreshing` flips back
+  // to false, since neither user.id nor profile fields change.
+  const refreshedForUserRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    if (user.app_metadata?.provider !== "spotify") return;
+    if (!profile) return; // No profile yet → fresh sign-in path handles it
+    if (refreshedForUserRef.current === user.id) return;
+
+    const lastRefreshIso = profile.tasteRefreshedAt;
+    const lastRefreshMs = lastRefreshIso ? Date.parse(lastRefreshIso) : 0;
+    const ageMs = Date.now() - lastRefreshMs;
+    if (lastRefreshIso && ageMs < TASTE_TTL_MS) {
+      console.info(`[bg-taste-refresh] skip — fresh (${Math.round(ageMs / 1000 / 60)}m old)`);
+      refreshedForUserRef.current = user.id;
+      return;
+    }
+
+    refreshedForUserRef.current = user.id;
+    let cancelled = false;
+    const ageLabel = lastRefreshIso ? `${Math.round(ageMs / 1000 / 60 / 60)}h` : "never";
+    console.info(`[bg-taste-refresh] start (last refresh: ${ageLabel})`);
+    setRefreshing(true);
+
+    (async () => {
+      try {
+        const { data: sessionData, error: sessionErr } = await supabase.auth.getSession();
+        if (sessionErr || !sessionData.session?.provider_token) {
+          console.warn("[bg-taste-refresh] no provider_token, skipping");
+          return;
+        }
+        const taste = await fetchSpotifyTaste(sessionData.session.provider_token);
+        if (cancelled) return;
+        if (!taste) {
+          console.warn("[bg-taste-refresh] fetch returned null — leaving cache untouched");
+          return;
+        }
+        const merged = await applyTastePatch(
+          {
+            topArtists: taste.topArtists,
+            topTracks: taste.topTracks,
+            artistImages: taste.artistImages,
+            artistIds: taste.artistIds,
+            trackImages: taste.trackImages,
+            spotifyDisplayName: taste.displayName ?? undefined,
+          },
+          user.id
+        );
+        if (cancelled) return;
+        if (merged) {
+          const now = new Date().toISOString();
+          setLastRefreshedAt(now);
+          console.info("[bg-taste-refresh] success");
+        }
+      } catch (err) {
+        console.warn("[bg-taste-refresh] threw:", err);
+      } finally {
+        if (!cancelled) setRefreshing(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+    // Deliberately exclude `profile` object identity from deps — only the
+    // user identity matters. Once we've checked for a given user, we
+    // don't re-check on every profile update (which the refresh itself
+    // would trigger, causing an infinite loop).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id, user?.app_metadata?.provider]);
+
+  return { refreshing, lastRefreshedAt };
+}

--- a/src/hooks/useBackgroundTasteRefresh.ts
+++ b/src/hooks/useBackgroundTasteRefresh.ts
@@ -64,7 +64,7 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
     const lastRefreshMs = lastRefreshIso ? Date.parse(lastRefreshIso) : 0;
     const ageMs = Date.now() - lastRefreshMs;
     if (lastRefreshIso && ageMs < TASTE_TTL_MS) {
-      console.info(`[bg-taste-refresh] skip — fresh (${Math.round(ageMs / 1000 / 60)}m old)`);
+      if (import.meta.env.DEV) console.info(`[bg-taste-refresh] skip — fresh (${Math.round(ageMs / 1000 / 60)}m old)`);
       refreshedForUserRef.current = user.id;
       return;
     }
@@ -72,7 +72,7 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
     refreshedForUserRef.current = user.id;
     let cancelled = false;
     const ageLabel = lastRefreshIso ? `${Math.round(ageMs / 1000 / 60 / 60)}h` : "never";
-    console.info(`[bg-taste-refresh] start (last refresh: ${ageLabel})`);
+    if (import.meta.env.DEV) console.info(`[bg-taste-refresh] start (last refresh: ${ageLabel})`);
     setRefreshing(true);
 
     (async () => {
@@ -103,7 +103,7 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
         if (merged) {
           const now = new Date().toISOString();
           setLastRefreshedAt(now);
-          console.info("[bg-taste-refresh] success");
+          if (import.meta.env.DEV) console.info("[bg-taste-refresh] success");
         }
       } catch (err) {
         console.warn("[bg-taste-refresh] threw:", err);

--- a/src/hooks/useBackgroundTasteRefresh.ts
+++ b/src/hooks/useBackgroundTasteRefresh.ts
@@ -79,13 +79,18 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
       try {
         const { data: sessionData, error: sessionErr } = await supabase.auth.getSession();
         if (sessionErr || !sessionData.session?.provider_token) {
-          console.warn("[bg-taste-refresh] no provider_token, skipping");
+          // Common right after a JWT-only refresh (provider_token gone
+          // until next OAuth) — DEV-only so it doesn't pollute every
+          // signed-in user's console on routine reloads.
+          if (import.meta.env.DEV) console.warn("[bg-taste-refresh] no provider_token, skipping");
           return;
         }
         const taste = await fetchSpotifyTaste(sessionData.session.provider_token);
         if (cancelled) return;
         if (!taste) {
-          console.warn("[bg-taste-refresh] fetch returned null — leaving cache untouched");
+          // Network blip or Spotify rate-limit — non-fatal, the cache
+          // stays valid. DEV-only to keep production consoles quiet.
+          if (import.meta.env.DEV) console.warn("[bg-taste-refresh] fetch returned null — leaving cache untouched");
           return;
         }
         const merged = await applyTastePatch(
@@ -106,7 +111,10 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
           if (import.meta.env.DEV) console.info("[bg-taste-refresh] success");
         }
       } catch (err) {
-        console.warn("[bg-taste-refresh] threw:", err);
+        // Truly unexpected (network unreachable, JS throw). DEV-only —
+        // a background refresh failure is recoverable and not user-
+        // visible; surfacing it in production consoles only adds noise.
+        if (import.meta.env.DEV) console.warn("[bg-taste-refresh] threw:", err);
       } finally {
         if (!cancelled) setRefreshing(false);
       }

--- a/src/hooks/useBackgroundTasteRefresh.ts
+++ b/src/hooks/useBackgroundTasteRefresh.ts
@@ -69,7 +69,14 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
       return;
     }
 
-    refreshedForUserRef.current = user.id;
+    // Don't stamp `refreshedForUserRef` yet — that happens only on
+    // the success path below. Stamping unconditionally before the
+    // async work meant a transient failure (Spotify rate limit,
+    // network blip, missing provider_token) would lock this user out
+    // of any retry until the next page load. With success-only
+    // stamping, a failed attempt re-runs the next time the effect
+    // dep array re-evaluates (typically the next render after auth
+    // resolves) — at most ~1 retry per session.
     let cancelled = false;
     const ageLabel = lastRefreshIso ? `${Math.round(ageMs / 1000 / 60 / 60)}h` : "never";
     if (import.meta.env.DEV) console.info(`[bg-taste-refresh] start (last refresh: ${ageLabel})`);
@@ -108,6 +115,10 @@ export function useBackgroundTasteRefresh(): BackgroundTasteRefreshState {
         if (merged) {
           const now = new Date().toISOString();
           setLastRefreshedAt(now);
+          // SUCCESS path: stamp the per-user guard so we don't re-fire
+          // on every render this session. Failure paths leave it
+          // null, allowing a follow-up attempt.
+          refreshedForUserRef.current = user.id;
           if (import.meta.env.DEV) console.info("[bg-taste-refresh] success");
         }
       } catch (err) {

--- a/src/hooks/useFirstRunReadiness.ts
+++ b/src/hooks/useFirstRunReadiness.ts
@@ -22,10 +22,14 @@ import { useArtistUpdatesContext } from "@/contexts/ArtistUpdatesContext";
  */
 
 const MIN_ARTISTS = 1;
-// Higher ceiling than the prior 15s — a single artist on a cold cache
-// can spend 30-60s in a Gemini call. Better to wait than to drop the
-// user onto Browse with an empty rail.
-const MAX_WAIT_MS = 90_000;
+// Splash ceiling. Cold-path single-artist generation lands in
+// ~30-60s, so 45s catches the median + most cold starts; longer ones
+// fall through to Browse and the rail finishes filling there via its
+// own per-row loading state. Earlier 90s ceiling was too punishing
+// — users with sub-cold connectivity were waiting almost a minute on
+// a screen with no value, and the 3s "Jump in" hatch sees little use
+// when the page advances on its own at ~45s anyway.
+const MAX_WAIT_MS = 45_000;
 
 export interface FirstRunReadiness {
   ready: boolean;

--- a/src/hooks/useFirstRunReadiness.ts
+++ b/src/hooks/useFirstRunReadiness.ts
@@ -1,38 +1,26 @@
 import { useEffect, useState } from "react";
-import { useStoriesContext } from "@/contexts/StoriesContext";
 import { useArtistUpdatesContext } from "@/contexts/ArtistUpdatesContext";
 
 /**
  * Decides when the "preparing your experience" splash can hand the
- * user off to Browse. Reads directly from the two hoisted contexts so
- * we're measuring the same pre-gen the app already kicked off on
- * profile hydration — no duplicate requests.
+ * user off to Browse. Reads from `ArtistUpdatesContext` so we measure
+ * the same pre-gen the app already kicked off on profile hydration —
+ * no duplicate requests.
+ *
+ * Gating policy:
+ * - Artist updates BLOCK the hand-off. The "Your artists, lately" rail
+ *   is the first thing on /browse and looks broken with empty
+ *   skeletons; it has to be populated before we advance.
+ * - Stories DO NOT block. Pre-gen warms the per-track nugget cache for
+ *   future taps — the user doesn't need it to use Browse. Including
+ *   stories here would mean 60-120s of Gemini cold starts on the
+ *   splash. Stories show their own per-card loading state on Browse.
  *
  * "Ready" is the FIRST of:
- *   - MIN_STORIES stories have resolved AND MIN_ARTISTS artist-update
- *     rows have resolved (either returned data or confirmed empty).
+ *   - MIN_ARTISTS artist-update rows have resolved (data or confirmed empty).
  *   - MAX_WAIT_MS has elapsed since the hook mounted.
- *
- * Tuning:
- *   - MIN_STORIES = 2 — enough story rails to hide a first-paint with
- *     skeletons while the rest stream in.
- *   - MIN_ARTISTS = 2 — top-2 artist rows need to be populated so
- *     Browse opens with content above the fold. The 3rd artist
- *     continues fetching in the background and streams into its row
- *     once it lands, with the per-row skeleton covering the gap.
- *   - MAX_WAIT_MS = 15_000 — cold-path artist-updates can take ~8-10s
- *     for 2 artists at concurrency 2. 15s gives that window real
- *     headroom; beyond, impatience beats the gate and Browse's own
- *     per-row skeletons take over.
  */
-// What we wait on before letting the user into Browse:
-// - Artist updates: blocking. The "Your artists, lately" rail is the
-//   first thing the user sees on /browse and looks broken with empty
-//   skeletons; it has to be populated before we hand off.
-// - Stories: NOT blocking. Pre-gen warms the per-track nugget cache
-//   for future taps — the user doesn't need it to use Browse, and
-//   waiting on it can mean 60-120s of Gemini cold starts. Stories
-//   show their own per-card loading state on Browse.
+
 const MIN_ARTISTS = 1;
 // Higher ceiling than the prior 15s — a single artist on a cold cache
 // can spend 30-60s in a Gemini call. Better to wait than to drop the
@@ -41,27 +29,17 @@ const MAX_WAIT_MS = 90_000;
 
 export interface FirstRunReadiness {
   ready: boolean;
-  storiesReady: number;
-  storiesTotal: number;
   artistsReady: number;
   artistsTotal: number;
-  /** True after 3s — used to reveal the manual "Jump to Browse" escape hatch. */
+  /** True after 3s — used to reveal the manual "Jump in" escape hatch. */
   skipAvailable: boolean;
 }
 
 export function useFirstRunReadiness(): FirstRunReadiness {
-  const { stories } = useStoriesContext();
   const {
     totalCount: artistsTotal,
     readyCount: artistsReady,
   } = useArtistUpdatesContext();
-
-  // Stories resolve as items with ready=true. "Total" is whatever the
-  // rail seeded, which may be zero while the profile is still being
-  // hydrated — guard against zero so we don't claim readiness
-  // vacuously.
-  const storiesReady = stories.filter((s) => s.ready).length;
-  const storiesTotal = stories.length;
 
   const [timedOut, setTimedOut] = useState(false);
   const [skipAvailable, setSkipAvailable] = useState(false);
@@ -74,15 +52,11 @@ export function useFirstRunReadiness(): FirstRunReadiness {
     };
   }, []);
 
-  // Only artist-updates block the gate. Stories continue loading on
-  // Browse via their own per-card state.
   const enoughArtists = artistsTotal > 0 && artistsReady >= Math.min(MIN_ARTISTS, artistsTotal);
   const contentReady = enoughArtists;
 
   return {
     ready: contentReady || timedOut,
-    storiesReady,
-    storiesTotal,
     artistsReady,
     artistsTotal,
     skipAvailable,

--- a/src/hooks/useFirstRunReadiness.ts
+++ b/src/hooks/useFirstRunReadiness.ts
@@ -9,20 +9,35 @@ import { useArtistUpdatesContext } from "@/contexts/ArtistUpdatesContext";
  * profile hydration — no duplicate requests.
  *
  * "Ready" is the FIRST of:
- *   - MIN_READY stories have resolved AND MIN_READY artist updates
- *     have resolved (either returned data or confirmed empty).
+ *   - MIN_STORIES stories have resolved AND MIN_ARTISTS artist-update
+ *     rows have resolved (either returned data or confirmed empty).
  *   - MAX_WAIT_MS has elapsed since the hook mounted.
  *
  * Tuning:
- *   - MIN_READY = 2 is "enough to look full above the fold" without
- *     forcing the user to wait for everything. Raise if Browse still
- *     feels sparse on arrival.
- *   - MAX_WAIT_MS = 10_000 is the we-give-up-and-let-them-in ceiling.
- *     Beyond this, the user's impatience beats the content ready-state
- *     and Browse's own skeleton state takes over.
+ *   - MIN_STORIES = 2 — enough story rails to hide a first-paint with
+ *     skeletons while the rest stream in.
+ *   - MIN_ARTISTS = 2 — top-2 artist rows need to be populated so
+ *     Browse opens with content above the fold. The 3rd artist
+ *     continues fetching in the background and streams into its row
+ *     once it lands, with the per-row skeleton covering the gap.
+ *   - MAX_WAIT_MS = 15_000 — cold-path artist-updates can take ~8-10s
+ *     for 2 artists at concurrency 2. 15s gives that window real
+ *     headroom; beyond, impatience beats the gate and Browse's own
+ *     per-row skeletons take over.
  */
-const MIN_READY = 2;
-const MAX_WAIT_MS = 10_000;
+// What we wait on before letting the user into Browse:
+// - Artist updates: blocking. The "Your artists, lately" rail is the
+//   first thing the user sees on /browse and looks broken with empty
+//   skeletons; it has to be populated before we hand off.
+// - Stories: NOT blocking. Pre-gen warms the per-track nugget cache
+//   for future taps — the user doesn't need it to use Browse, and
+//   waiting on it can mean 60-120s of Gemini cold starts. Stories
+//   show their own per-card loading state on Browse.
+const MIN_ARTISTS = 1;
+// Higher ceiling than the prior 15s — a single artist on a cold cache
+// can spend 30-60s in a Gemini call. Better to wait than to drop the
+// user onto Browse with an empty rail.
+const MAX_WAIT_MS = 90_000;
 
 export interface FirstRunReadiness {
   ready: boolean;
@@ -59,9 +74,10 @@ export function useFirstRunReadiness(): FirstRunReadiness {
     };
   }, []);
 
-  const enoughStories = storiesTotal > 0 && storiesReady >= Math.min(MIN_READY, storiesTotal);
-  const enoughArtists = artistsTotal > 0 && artistsReady >= Math.min(MIN_READY, artistsTotal);
-  const contentReady = enoughStories && enoughArtists;
+  // Only artist-updates block the gate. Stories continue loading on
+  // Browse via their own per-card state.
+  const enoughArtists = artistsTotal > 0 && artistsReady >= Math.min(MIN_ARTISTS, artistsTotal);
+  const contentReady = enoughArtists;
 
   return {
     ready: contentReady || timedOut,

--- a/src/hooks/useFirstRunReadiness.ts
+++ b/src/hooks/useFirstRunReadiness.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { useStoriesContext } from "@/contexts/StoriesContext";
+import { useArtistUpdatesContext } from "@/contexts/ArtistUpdatesContext";
+
+/**
+ * Decides when the "preparing your experience" splash can hand the
+ * user off to Browse. Reads directly from the two hoisted contexts so
+ * we're measuring the same pre-gen the app already kicked off on
+ * profile hydration — no duplicate requests.
+ *
+ * "Ready" is the FIRST of:
+ *   - MIN_READY stories have resolved AND MIN_READY artist updates
+ *     have resolved (either returned data or confirmed empty).
+ *   - MAX_WAIT_MS has elapsed since the hook mounted.
+ *
+ * Tuning:
+ *   - MIN_READY = 2 is "enough to look full above the fold" without
+ *     forcing the user to wait for everything. Raise if Browse still
+ *     feels sparse on arrival.
+ *   - MAX_WAIT_MS = 10_000 is the we-give-up-and-let-them-in ceiling.
+ *     Beyond this, the user's impatience beats the content ready-state
+ *     and Browse's own skeleton state takes over.
+ */
+const MIN_READY = 2;
+const MAX_WAIT_MS = 10_000;
+
+export interface FirstRunReadiness {
+  ready: boolean;
+  storiesReady: number;
+  storiesTotal: number;
+  artistsReady: number;
+  artistsTotal: number;
+  /** True after 3s — used to reveal the manual "Jump to Browse" escape hatch. */
+  skipAvailable: boolean;
+}
+
+export function useFirstRunReadiness(): FirstRunReadiness {
+  const { stories } = useStoriesContext();
+  const {
+    totalCount: artistsTotal,
+    readyCount: artistsReady,
+  } = useArtistUpdatesContext();
+
+  // Stories resolve as items with ready=true. "Total" is whatever the
+  // rail seeded, which may be zero while the profile is still being
+  // hydrated — guard against zero so we don't claim readiness
+  // vacuously.
+  const storiesReady = stories.filter((s) => s.ready).length;
+  const storiesTotal = stories.length;
+
+  const [timedOut, setTimedOut] = useState(false);
+  const [skipAvailable, setSkipAvailable] = useState(false);
+  useEffect(() => {
+    const skipTimer = setTimeout(() => setSkipAvailable(true), 3_000);
+    const maxTimer = setTimeout(() => setTimedOut(true), MAX_WAIT_MS);
+    return () => {
+      clearTimeout(skipTimer);
+      clearTimeout(maxTimer);
+    };
+  }, []);
+
+  const enoughStories = storiesTotal > 0 && storiesReady >= Math.min(MIN_READY, storiesTotal);
+  const enoughArtists = artistsTotal > 0 && artistsReady >= Math.min(MIN_READY, artistsTotal);
+  const contentReady = enoughStories && enoughArtists;
+
+  return {
+    ready: contentReady || timedOut,
+    storiesReady,
+    storiesTotal,
+    artistsReady,
+    artistsTotal,
+    skipAvailable,
+  };
+}

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -251,15 +251,17 @@ export function useUserProfile() {
   // localStorage, so the originating instance gets its own update through the
   // same path as every other instance — single data flow, no double-set.
   const saveProfile = useCallback(async (p: UserProfile) => {
-    // Stamp tasteRefreshedAt whenever this save carries fresh taste data.
-    // Drives the background refresh TTL — the next mount knows when the
-    // current snapshot was last pulled from Spotify.
-    const stamped: UserProfile = p.topArtists
-      ? { ...p, tasteRefreshedAt: p.tasteRefreshedAt ?? new Date().toISOString() }
-      : p;
-    localStorage.setItem(PROFILE_KEY, JSON.stringify(stamped));
+    // Persist what was passed — DON'T auto-stamp tasteRefreshedAt
+    // here. Earlier this hook stamped on any save with `topArtists`,
+    // which falsely-reset the 24h TTL on saves that didn't actually
+    // re-fetch from Spotify (e.g. a future tier-change save that
+    // rebuilds the profile object without carrying the existing
+    // timestamp). `applyTastePatch` is now the only path that
+    // stamps tasteRefreshedAt — it's called only when fresh Spotify
+    // data has just landed (post-signin sync, background refresh).
+    localStorage.setItem(PROFILE_KEY, JSON.stringify(p));
     notifyProfileUpdated();
-    if (user?.id) await saveProfileToDB(stamped, user.id);
+    if (user?.id) await saveProfileToDB(p, user.id);
   }, [user?.id]);
 
   const clearProfile = useCallback(() => {

--- a/src/hooks/useMusicNerdState.ts
+++ b/src/hooks/useMusicNerdState.ts
@@ -34,6 +34,9 @@ interface TasteData {
   artistImages?: Record<string, string>;
   artistIds?: Record<string, string>;
   trackImages?: { title: string; artist: string; imageUrl: string }[];
+  /** ISO timestamp of the last successful Spotify-taste fetch. Persisted
+   *  inside the per-service blob so the DB column shape stays unchanged. */
+  refreshedAt?: string;
 }
 
 /** Legacy localStorage payload shape. Pre-rename profiles used `spotify*`
@@ -96,6 +99,7 @@ async function loadProfileFromDB(userId: string): Promise<UserProfile | null> {
     artistImages: taste?.artistImages ?? undefined,
     artistIds: taste?.artistIds ?? undefined,
     trackImages: taste?.trackImages ?? undefined,
+    tasteRefreshedAt: taste?.refreshedAt ?? undefined,
     calculatedTier: (data.tier as UserProfile["calculatedTier"]) || "casual",
   };
 }
@@ -130,6 +134,7 @@ async function saveProfileToDB(p: UserProfile, userId: string): Promise<void> {
           artistImages: p.artistImages ?? {},
           artistIds: p.artistIds ?? {},
           trackImages: p.trackImages ?? [],
+          refreshedAt: p.tasteRefreshedAt,
         }
       : null;
 
@@ -246,9 +251,15 @@ export function useUserProfile() {
   // localStorage, so the originating instance gets its own update through the
   // same path as every other instance — single data flow, no double-set.
   const saveProfile = useCallback(async (p: UserProfile) => {
-    localStorage.setItem(PROFILE_KEY, JSON.stringify(p));
+    // Stamp tasteRefreshedAt whenever this save carries fresh taste data.
+    // Drives the background refresh TTL — the next mount knows when the
+    // current snapshot was last pulled from Spotify.
+    const stamped: UserProfile = p.topArtists
+      ? { ...p, tasteRefreshedAt: p.tasteRefreshedAt ?? new Date().toISOString() }
+      : p;
+    localStorage.setItem(PROFILE_KEY, JSON.stringify(stamped));
     notifyProfileUpdated();
-    if (user?.id) await saveProfileToDB(p, user.id);
+    if (user?.id) await saveProfileToDB(stamped, user.id);
   }, [user?.id]);
 
   const clearProfile = useCallback(() => {
@@ -260,6 +271,53 @@ export function useUserProfile() {
 
 export function getStoredProfile(): UserProfile | null {
   return parseStoredProfile(localStorage.getItem(PROFILE_KEY));
+}
+
+/**
+ * Merge a fresh taste patch onto the stored profile, persist to
+ * localStorage + DB, and notify all `useUserProfile` instances.
+ *
+ * Used by `useBackgroundTasteRefresh` so the refresh path doesn't have
+ * to construct a `UserProfile` from scratch — it picks up tier/lastFm/
+ * streamingService from whatever's already cached.
+ *
+ * Always stamps `tasteRefreshedAt = now` so the TTL window resets.
+ * Returns true if the merge happened, false if there's nothing to merge
+ * onto (no stored profile yet).
+ */
+export async function applyTastePatch(
+  patch: {
+    topArtists?: string[];
+    topTracks?: string[];
+    artistImages?: Record<string, string>;
+    artistIds?: Record<string, string>;
+    trackImages?: UserProfile["trackImages"];
+    spotifyDisplayName?: string;
+  },
+  userId: string | null
+): Promise<boolean> {
+  const current = parseStoredProfile(localStorage.getItem(PROFILE_KEY));
+  if (!current) return false;
+  const merged: UserProfile = {
+    ...current,
+    topArtists: patch.topArtists ?? current.topArtists,
+    topTracks: patch.topTracks ?? current.topTracks,
+    artistImages: patch.artistImages ?? current.artistImages,
+    artistIds: patch.artistIds ?? current.artistIds,
+    trackImages: patch.trackImages ?? current.trackImages,
+    spotifyDisplayName: patch.spotifyDisplayName ?? current.spotifyDisplayName,
+    tasteRefreshedAt: new Date().toISOString(),
+  };
+  localStorage.setItem(PROFILE_KEY, JSON.stringify(merged));
+  notifyProfileUpdated();
+  if (userId) {
+    try {
+      await saveProfileToDB(merged, userId);
+    } catch (err) {
+      console.warn("[applyTastePatch] DB save failed:", err);
+    }
+  }
+  return true;
 }
 
 // ── Tier helpers ──────────────────────────────────────────────────────────────

--- a/src/hooks/usePersonalizedCatalog.ts
+++ b/src/hooks/usePersonalizedCatalog.ts
@@ -244,49 +244,11 @@ export function usePersonalizedCatalog(profile: UserProfile | null): {
     // service is set.
     const activeService = serviceParamFromProfile(profile.streamingService);
 
-    // ── 1. "Jump Back In" — recent tracks or top tracks ──────────────
-    const recentTiles: BrowseTile[] = [];
-
-      if (lastFmData?.recentTracks?.length) {
-        lastFmData.recentTracks.slice(0, 10).forEach((t) => {
-          const image = t.imageUrl || trackCoverUrl(t.name, t.artist, trackImgs);
-          const trackMatch = trackImgs?.find(
-            (img) => img.title.toLowerCase() === t.name.toLowerCase() && img.artist.toLowerCase() === t.artist.toLowerCase()
-          );
-          recentTiles.push({
-            id: `recent-${t.artist}-${t.name}`,
-            imageUrl: image,
-            title: t.name,
-            subtitle: t.artist,
-            href: realTrackHref(t.artist, t.name, t.album, trackMatch?.uri),
-            isRealTrack: true,
-          });
-        });
-    } else if (topTracks.length) {
-      topTracks.slice(0, 8).forEach((t) => {
-        recentTiles.push(trackTile(t, "recent", trackImgs));
-      });
-    }
-
-    if (recentTiles.length > 0) {
-      allRows.push({ label: "Jump Back In", items: recentTiles, size: "md" });
-    }
-
-    // ── 2. "Your Top Artists" ────────────────────────────────────────
-    if (topArtistNames.length > 0) {
-      // cachedArtistIds holds catalog IDs from the active service's
-      // taste data. Falls back to the runtime-resolved map when a given
-      // name wasn't in taste.
-      const cachedArtistIds = profile.artistIds || {};
-      const topArtistTiles: BrowseTile[] = topArtistNames.slice(0, 20).map((name) => ({
-        id: `artist-${name}`,
-        imageUrl: artistImageUrl(name, artistImgs, resolvedImages),
-        title: name,
-        subtitle: "Artist",
-        href: artistHref(name, cachedArtistIds[name] || resolvedIds.get(name), activeService),
-      }));
-      allRows.push({ label: "Your Top Artists", items: topArtistTiles, size: "lg" });
-    }
+    // "Jump Back In" + "Your Top Artists" were removed in favor of the
+    // new "Your artists, lately" section on Browse (see
+    // src/components/ArtistUpdatesSection.tsx). Stories already covers
+    // the recent-tracks promise, and the flat artist-tiles row was the
+    // piece that made Browse feel Spotify-shaped.
 
     // ── 3. "Your Top Tracks" ─────────────────────────────────────────
     if (topTracks.length > 0) {

--- a/src/hooks/usePreGeneratedStories.ts
+++ b/src/hooks/usePreGeneratedStories.ts
@@ -22,7 +22,11 @@ interface PreGenOptions {
   maxConcurrent?: number;      // default 2 — throttle to avoid blasting Gemini
 }
 
-const DEFAULT_MAX_STORIES = 8;
+// 8 → 5. Pairs with DEFAULT_MAX_ARTISTS dropping from 5 → 3 in
+// useArtistUpdates.ts to lighten first-run pre-gen pressure. Most
+// users engage with the first few stories anyway; generating 8 on
+// cold sign-in was a lot of Gemini traffic we don't need.
+const DEFAULT_MAX_STORIES = 5;
 const DEFAULT_CONCURRENCY = 2;
 
 // Cross-session dedup — persists "we already fired pre-gen for this

--- a/src/hooks/useSpotifyAuth.ts
+++ b/src/hooks/useSpotifyAuth.ts
@@ -162,7 +162,7 @@ export async function fetchSpotifyTaste(accessToken: string): Promise<{
 } | null> {
   const t0 = performance.now();
   const elapsed = () => `${(performance.now() - t0).toFixed(0)}ms`;
-  console.info(`[spotify-taste] fetch started (timeout=${TASTE_FETCH_TIMEOUT_MS}ms)`);
+  if (import.meta.env.DEV) console.info(`[spotify-taste] fetch started (timeout=${TASTE_FETCH_TIMEOUT_MS}ms)`);
 
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<{ timedOut: true }>((resolve) => {
@@ -181,26 +181,26 @@ export async function fetchSpotifyTaste(accessToken: string): Promise<{
       // Network-level rejection — the invoke threw before returning
       // the { data, error } shape. Log and return null so the caller
       // surfaces the retry state instead of bubbling an unhandled rej.
-      console.error(`[spotify-taste] invoke threw after ${elapsed()}:`, err);
+      if (import.meta.env.DEV) console.error(`[spotify-taste] invoke threw after ${elapsed()}:`, err);
       return null;
     }
 
     if ("timedOut" in race) {
-      console.error(`[spotify-taste] timed out after ${TASTE_FETCH_TIMEOUT_MS}ms`);
+      if (import.meta.env.DEV) console.error(`[spotify-taste] timed out after ${TASTE_FETCH_TIMEOUT_MS}ms`);
       return null;
     }
 
     const { data, error } = race;
     if (error) {
-      console.error(`[spotify-taste] edge function error after ${elapsed()}:`, error);
+      if (import.meta.env.DEV) console.error(`[spotify-taste] edge function error after ${elapsed()}:`, error);
       return null;
     }
     if (!data) {
-      console.error(`[spotify-taste] empty payload after ${elapsed()}`);
+      if (import.meta.env.DEV) console.error(`[spotify-taste] empty payload after ${elapsed()}`);
       return null;
     }
 
-    console.info(`[spotify-taste] succeeded in ${elapsed()} — ${data.topArtists?.length ?? 0} artists, ${data.topTracks?.length ?? 0} tracks`);
+    if (import.meta.env.DEV) console.info(`[spotify-taste] succeeded in ${elapsed()} — ${data.topArtists?.length ?? 0} artists, ${data.topTracks?.length ?? 0} tracks`);
 
     return {
       topArtists: data.topArtists || [],

--- a/src/hooks/useSpotifyAuth.ts
+++ b/src/hooks/useSpotifyAuth.ts
@@ -117,6 +117,30 @@ export async function refreshSpotifyToken(
 
 // ── Taste fetch — via edge function (backend needs it for RAG) ───────────────
 
+// Hard ceiling on the spotify-taste invoke. Supabase's client doesn't
+// impose one, so a wedged function (cold start stuck, Spotify rate-
+// limited, network drop mid-stream) would hang the promise forever.
+// Healthy warm calls land in 2-5s; cold starts in 7-10s. 20s gives
+// cold starts real headroom without making a retry feel like an
+// eternity.
+const TASTE_FETCH_TIMEOUT_MS = 20_000;
+
+/**
+ * Fire-and-forget ping to wake the spotify-taste edge function so the
+ * real call after OAuth return doesn't eat the cold-start latency.
+ * Send a deliberately invalid payload so the function 400s immediately
+ * without burning a Spotify API call. Safe to call from Connect mount.
+ */
+export function prewarmSpotifyTaste(): void {
+  // Use invoke() so we inherit the same transport + auth as the real
+  // call — otherwise we might warm a different instance.
+  supabase.functions
+    .invoke("spotify-taste", { body: { accessToken: "prewarm" } })
+    .catch(() => {
+      // Any error is fine — we're just trying to boot the container.
+    });
+}
+
 export async function fetchSpotifyTaste(accessToken: string): Promise<{
   topArtists: string[];
   topTracks: string[];
@@ -125,21 +149,57 @@ export async function fetchSpotifyTaste(accessToken: string): Promise<{
   trackImages: { title: string; artist: string; imageUrl: string; uri?: string }[];
   displayName: string | null;
 } | null> {
-  const { data, error } = await supabase.functions.invoke("spotify-taste", {
-    body: { accessToken },
+  const t0 = performance.now();
+  const elapsed = () => `${(performance.now() - t0).toFixed(0)}ms`;
+  console.info(`[spotify-taste] fetch started (timeout=${TASTE_FETCH_TIMEOUT_MS}ms)`);
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<{ timedOut: true }>((resolve) => {
+    timeoutId = setTimeout(() => resolve({ timedOut: true }), TASTE_FETCH_TIMEOUT_MS);
   });
 
-  if (error || !data) {
-    console.error("Taste fetch error:", error);
-    return null;
-  }
+  try {
+    const invokePromise = supabase.functions.invoke("spotify-taste", {
+      body: { accessToken },
+    });
 
-  return {
-    topArtists: data.topArtists || [],
-    topTracks: data.topTracks || [],
-    artistImages: data.artistImages || {},
-    artistIds: data.artistIds || {},
-    trackImages: data.trackImages || [],
-    displayName: data.displayName || null,
-  };
+    let race: { timedOut: true } | Awaited<typeof invokePromise>;
+    try {
+      race = await Promise.race([invokePromise, timeoutPromise]);
+    } catch (err) {
+      // Network-level rejection — the invoke threw before returning
+      // the { data, error } shape. Log and return null so the caller
+      // surfaces the retry state instead of bubbling an unhandled rej.
+      console.error(`[spotify-taste] invoke threw after ${elapsed()}:`, err);
+      return null;
+    }
+
+    if ("timedOut" in race) {
+      console.error(`[spotify-taste] timed out after ${TASTE_FETCH_TIMEOUT_MS}ms`);
+      return null;
+    }
+
+    const { data, error } = race;
+    if (error) {
+      console.error(`[spotify-taste] edge function error after ${elapsed()}:`, error);
+      return null;
+    }
+    if (!data) {
+      console.error(`[spotify-taste] empty payload after ${elapsed()}`);
+      return null;
+    }
+
+    console.info(`[spotify-taste] succeeded in ${elapsed()} — ${data.topArtists?.length ?? 0} artists, ${data.topTracks?.length ?? 0} tracks`);
+
+    return {
+      topArtists: data.topArtists || [],
+      topTracks: data.topTracks || [],
+      artistImages: data.artistImages || {},
+      artistIds: data.artistIds || {},
+      trackImages: data.trackImages || [],
+      displayName: data.displayName || null,
+    };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
 }

--- a/src/hooks/useSpotifyAuth.ts
+++ b/src/hooks/useSpotifyAuth.ts
@@ -128,8 +128,19 @@ const TASTE_FETCH_TIMEOUT_MS = 20_000;
 /**
  * Fire-and-forget ping to wake the spotify-taste edge function so the
  * real call after OAuth return doesn't eat the cold-start latency.
- * Send a deliberately invalid payload so the function 400s immediately
- * without burning a Spotify API call. Safe to call from Connect mount.
+ * Sends `{ accessToken: "prewarm" }`; the function passes that as a
+ * Bearer token to Spotify which 401s immediately, returning before
+ * any expensive work. Safe to call from Connect mount.
+ *
+ * FRAGILITY NOTE: this only works because spotify-taste is currently
+ * `verify_jwt = false`, so the request reaches the function body and
+ * gets short-circuited by Spotify's auth check. If spotify-taste is
+ * ever flipped to `verify_jwt = true`, the request would 401 at the
+ * Supabase auth layer (no/invalid JWT), the container wouldn't run,
+ * and the prewarm would silently stop working. If you flip JWT here,
+ * either drop this prewarm or add a server-side `if (accessToken ===
+ * "prewarm") return new Response(...)` short-circuit so the warmup
+ * doesn't depend on Spotify's response.
  */
 export function prewarmSpotifyTaste(): void {
   // Use invoke() so we inherit the same transport + auth as the real

--- a/src/hooks/useSpotifyPostSigninSync.ts
+++ b/src/hooks/useSpotifyPostSigninSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserProfile } from "./useMusicNerdState";
@@ -40,9 +40,28 @@ interface UseSpotifyPostSigninSyncOptions {
  * "profile exists = onboarding complete" that the route gate depends
  * on.
  */
-export function useSpotifyPostSigninSync({ onSynced }: UseSpotifyPostSigninSyncOptions): void {
+export function useSpotifyPostSigninSync({ onSynced }: UseSpotifyPostSigninSyncOptions): {
+  /** True from the moment the async taste fetch starts until it
+   *  resolves (success or null). Consumers use this to show a loading
+   *  state — otherwise the user waits on a blank Connect page while
+   *  the fetch runs and often clicks "Sign in with Spotify" a second
+   *  time, thinking nothing happened. */
+  syncing: boolean;
+  /** Non-null when the taste fetch failed (timeout, network, edge-fn
+   *  error). Consumers should surface a retry affordance; otherwise
+   *  the overlay silently dismisses back to the Connect screen and the
+   *  user thinks their click did nothing. */
+  syncError: string | null;
+  /** Bumping this re-triggers the sync effect. Connect passes it as a
+   *  dep so the "Try again" button in the overlay can re-run the
+   *  taste fetch without kicking the user back through Spotify OAuth. */
+  retrySync: () => void;
+} {
   const { user } = useAuth();
   const { profile } = useUserProfile();
+  const [syncing, setSyncing] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [retryTick, setRetryTick] = useState(0);
   // Stable ref for the callback so re-renders don't re-run the effect.
   const onSyncedRef = useRef(onSynced);
   onSyncedRef.current = onSynced;
@@ -58,44 +77,111 @@ export function useSpotifyPostSigninSync({ onSynced }: UseSpotifyPostSigninSyncO
     // is returning, not newly signing in.
     if (profile?.streamingService === "Spotify" && (profile?.topArtists?.length ?? 0) > 0) {
       syncedUserIdRef.current = user.id;
+      // Defensive: if a prior effect run started a sync (profile arrived
+      // mid-fetch), its finally block won't flip syncing off because
+      // `cancelled` is true. Clear it here — we know no work is running.
+      setSyncing(false);
+      setSyncError(null);
       return;
     }
 
     let cancelled = false;
+    const runLabel = retryTick === 0 ? "initial" : `retry#${retryTick}`;
+    console.info(`[post-signin-sync] ${runLabel} start for user=${user.id}`);
+    setSyncError(null);
+    // Defer the spinner — a returning user's DB-load merge usually
+    // populates profile within ~200-400ms, which would re-fire the
+    // effect with cache-hit and cancel this run. Showing the spinner
+    // immediately causes a flash before /preparing takes over. If the
+    // sync genuinely needs more than 600ms, the spinner kicks in.
+    const spinnerDelay = setTimeout(() => {
+      if (!cancelled) setSyncing(true);
+    }, 600);
     (async () => {
-      let session: Awaited<ReturnType<typeof supabase.auth.getSession>>["data"]["session"] = null;
       try {
-        const { data, error } = await supabase.auth.getSession();
-        if (error) {
-          console.warn("[useSpotifyPostSigninSync] getSession failed:", error);
+        let session: Awaited<ReturnType<typeof supabase.auth.getSession>>["data"]["session"] = null;
+        try {
+          const { data, error } = await supabase.auth.getSession();
+          if (error) {
+            console.warn(`[post-signin-sync] ${runLabel} getSession failed:`, error);
+            if (!cancelled) setSyncError("We couldn't read your session. Try again?");
+            return;
+          }
+          session = data.session;
+        } catch (err) {
+          // Network-level failure on getSession (rare but possible).
+          // Don't mark as synced so a subsequent retry can succeed.
+          console.warn(`[post-signin-sync] ${runLabel} getSession threw:`, err);
+          if (!cancelled) setSyncError("We couldn't read your session. Try again?");
           return;
         }
-        session = data.session;
-      } catch (err) {
-        // Network-level failure on getSession (rare but possible).
-        // Don't mark as synced so a subsequent retry can succeed.
-        console.warn("[useSpotifyPostSigninSync] getSession threw:", err);
-        return;
-      }
-      const accessToken = session?.provider_token;
-      if (!accessToken) {
-        // Post-JWT-refresh sessions drop provider_token. Don't mark
-        // synced — we want to retry once a fresh OAuth lands.
-        return;
-      }
+        const accessToken = session?.provider_token;
+        if (!accessToken) {
+          // Post-JWT-refresh sessions drop provider_token. Don't mark
+          // synced — we want to retry once a fresh OAuth lands.
+          console.warn(`[post-signin-sync] ${runLabel} no provider_token on session`);
+          if (!cancelled) setSyncError("Your Spotify access expired. Reconnect to continue.");
+          return;
+        }
 
-      const patch = await completeSpotifyConnect(accessToken);
-      if (cancelled || !patch) return;
-
-      syncedUserIdRef.current = user.id;
-      onSyncedRef.current(patch);
+        const patch = await completeSpotifyConnect(accessToken);
+        if (cancelled) {
+          console.info(`[post-signin-sync] ${runLabel} cancelled (newer run started)`);
+          return;
+        }
+        if (!patch) {
+          // fetchSpotifyTaste already logged the specific cause
+          // (timeout / invoke error / missing payload). Surface a
+          // generic retry message — the retry button in the overlay
+          // re-fires the effect without bouncing through OAuth again.
+          setSyncError("We couldn't read your Spotify taste. Try again?");
+          return;
+        }
+        console.info(`[post-signin-sync] ${runLabel} success`);
+        syncedUserIdRef.current = user.id;
+        onSyncedRef.current(patch);
+      } finally {
+        // Always flip syncing off so the UI doesn't stay stuck in a
+        // spinner — every error path above `return`s through here.
+        clearTimeout(spinnerDelay);
+        if (!cancelled) setSyncing(false);
+      }
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      // Cancel the deferred spinner if it hasn't fired yet — keeps the
+      // overlay from flashing on for a brief sync that gets cancelled
+      // (returning user, DB hydration short-circuits).
+      clearTimeout(spinnerDelay);
+      // Defensive: ensure syncing flips off when this run is cancelled.
+      // The next effect run might short-circuit (cache hit) and not call
+      // setSyncing — without this, the spinner stays up forever.
+      // React batches with the next run's setStates, so if the next run
+      // starts a fresh sync (setSyncing(true)), that wins and overlay
+      // stays correctly visible.
+      setSyncing(false);
+    };
     // `profile?.topArtists?.length` (not `.topArtists`) is the stable dep:
     // the length flipping 0→N is what ends the short-circuit, and using
     // the array identity would re-fire on every saveProfile call.
     // onSynced is intentionally excluded — it's read via ref to avoid
     // re-triggering when the caller's closure identity changes.
+    // `retryTick` is included so calling `retrySync()` re-runs the effect.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id, user?.app_metadata?.provider, profile?.streamingService, profile?.topArtists?.length]);
+  }, [user?.id, user?.app_metadata?.provider, profile?.streamingService, profile?.topArtists?.length, retryTick]);
+
+  const retrySync = () => {
+    // Clear the per-user guard so the effect doesn't short-circuit.
+    syncedUserIdRef.current = null;
+    // Synchronously set syncing=true so the overlay stays visible
+    // through the render gap before the effect re-runs. Otherwise the
+    // overlay briefly unmounts (visible=false while both syncing and
+    // syncError are false) and triggers an exit/enter flicker. The
+    // effect's finally block will flip it off correctly on completion.
+    setSyncing(true);
+    setSyncError(null);
+    setRetryTick((n) => n + 1);
+  };
+
+  return { syncing, syncError, retrySync };
 }

--- a/src/lib/artistUpdateKind.ts
+++ b/src/lib/artistUpdateKind.ts
@@ -1,0 +1,31 @@
+import { Sparkles, Disc, Users } from "lucide-react";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+/**
+ * Shared label + icon for an `ArtistUpdate` kind. Two surfaces render
+ * artist-update cards (the Browse rail "Your artists, lately" via
+ * ArtistUpdatesSection, and the artist profile "Latest Facts" via
+ * LatestFactsSection); both used to maintain their own switch
+ * statement, which meant adding a new kind required two edits.
+ *
+ * Styling is intentionally NOT shared — Browse uses an opinionated
+ * card treatment (border accent, gradient bg, hover glow) while the
+ * profile uses a flatter chip. Each component keeps a local helper
+ * for those visuals.
+ */
+export interface ArtistUpdateKindMeta {
+  kindLabel: string;
+  KindIcon: typeof Sparkles;
+}
+
+export function getArtistUpdateKindMeta(kind: ArtistUpdate["kind"]): ArtistUpdateKindMeta {
+  switch (kind) {
+    case "new-release":
+      return { kindLabel: "New release", KindIcon: Disc };
+    case "collab":
+      return { kindLabel: "Collab", KindIcon: Users };
+    case "fact":
+    default:
+      return { kindLabel: "Fact", KindIcon: Sparkles };
+  }
+}

--- a/src/lib/routeUtils.ts
+++ b/src/lib/routeUtils.ts
@@ -1,13 +1,18 @@
 /**
  * Reject non-content destinations from `?redirect=` / `?next=` params
- * so we never loop the user back through the onboarding funnel.
+ * so we never loop the user back through the onboarding funnel — and
+ * so an attacker can't use the param as an open-redirect to phish.
  *
  * Rejected:
- *   - `/connect` — the page reading the param; would self-loop
+ *   - Anything that isn't a single-leading-slash path. `//evil.com`
+ *     and `https://evil.com` are technically "paths" to React Router's
+ *     `navigate()` but become external navigations. Only `/foo`-style
+ *     in-app paths are accepted.
+ *   - `/connect` — the page reading the param; would self-loop.
  *   - `/preparing` — the splash; auto-advances elsewhere, looping
- *     here means the splash hands off to itself after readiness
+ *     here means the splash hands off to itself after readiness.
  *   - `/` — the root router, which re-routes back to /connect or
- *     /browse, so honoring it as a destination is meaningless
+ *     /browse, so honoring it as a destination is meaningless.
  *
  * Returns the URL when valid, or `null` for callers to substitute
  * their own default (typically `/browse`).
@@ -18,6 +23,12 @@
  */
 export function sanitizeRedirect(url: string | null | undefined): string | null {
   if (!url) return null;
+  // Must be a single-leading-slash relative path. Rejects:
+  //   "//evil.com"     (protocol-relative external)
+  //   "https://..."    (absolute external)
+  //   "javascript:..." (script URL)
+  //   "foo"            (no leading slash)
+  if (!url.startsWith("/") || url.startsWith("//")) return null;
   if (url === "/" || url === "/connect" || url.startsWith("/preparing")) return null;
   return url;
 }

--- a/src/lib/routeUtils.ts
+++ b/src/lib/routeUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Reject non-content destinations from `?redirect=` / `?next=` params
+ * so we never loop the user back through the onboarding funnel.
+ *
+ * Rejected:
+ *   - `/connect` — the page reading the param; would self-loop
+ *   - `/preparing` — the splash; auto-advances elsewhere, looping
+ *     here means the splash hands off to itself after readiness
+ *   - `/` — the root router, which re-routes back to /connect or
+ *     /browse, so honoring it as a destination is meaningless
+ *
+ * Returns the URL when valid, or `null` for callers to substitute
+ * their own default (typically `/browse`).
+ *
+ * Used by both Connect.tsx (gate redirect) and PreparingExperience.tsx
+ * (next= param). Keep them in sync — a divergence here is how the
+ * /preparing → /preparing redirect-loop bug was originally introduced.
+ */
+export function sanitizeRedirect(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (url === "/" || url === "/connect" || url.startsWith("/preparing")) return null;
+  return url;
+}

--- a/src/lib/routeUtils.ts
+++ b/src/lib/routeUtils.ts
@@ -30,5 +30,11 @@ export function sanitizeRedirect(url: string | null | undefined): string | null 
   //   "foo"            (no leading slash)
   if (!url.startsWith("/") || url.startsWith("//")) return null;
   if (url === "/" || url === "/connect" || url.startsWith("/preparing")) return null;
+  // Note: `/preparing` is matched as a prefix, so any future
+  // `/preparing-room` or `/preparing-artist` routes would also be
+  // rejected. That's intentional today — the splash family is the
+  // entire onboarding handoff surface and should never be a redirect
+  // destination — but if a non-onboarding `/preparing-…` route is
+  // ever added, switch this to an exact `=== "/preparing"` check.
   return url;
 }

--- a/src/mock/types.ts
+++ b/src/mock/types.ts
@@ -102,5 +102,9 @@ export interface UserProfile {
   artistImages?: Record<string, string>;
   artistIds?: Record<string, string>;   // artist name → service-specific artist ID
   trackImages?: { title: string; artist: string; imageUrl: string; uri?: string }[];
+  /** ISO timestamp of the last successful Spotify-taste fetch. Drives the
+   *  background refresh TTL (`useBackgroundTasteRefresh`). Undefined for
+   *  pre-feature profiles → treated as stale and refreshed on next load. */
+  tasteRefreshedAt?: string;
   calculatedTier: "casual" | "curious" | "nerd";
 }

--- a/src/pages/ArtistProfile.tsx
+++ b/src/pages/ArtistProfile.tsx
@@ -5,7 +5,9 @@ import { getArtistById, getAlbumsForArtist, getTracksForArtist, artists } from "
 import { supabase } from "@/integrations/supabase/client";
 import PageTransition from "@/components/PageTransition";
 import TileRow from "@/components/TileRow";
+import LatestFactsSection from "@/components/LatestFactsSection";
 import { useArtistImage } from "@/hooks/useArtistImage";
+import { useArtistLatestFacts } from "@/hooks/useArtistLatestFacts";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import {
   isSpotifyPrefix,
@@ -326,6 +328,17 @@ function RealArtistProfileInner({ artist, trackTiles, albumTiles, relatedTiles }
   const heroImage = useArtistImage(artist.name, artist.imageUrl);
   const trackRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
+  // Pull Latest Facts for this artist — shares the nugget_cache row
+  // that Browse's ArtistUpdatesSection already warmed, so a user
+  // arriving here via the Browse tap-through sees the facts instantly.
+  // Tier selects the phrasing of generated facts and caches per-tier.
+  const { profile: userProfile } = useUserProfile();
+  const latestTier = (userProfile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
+  const { updates: latestUpdates, loading: latestLoading } = useArtistLatestFacts(
+    artist.name,
+    latestTier,
+  );
+
   const tileRows = useMemo(() => {
     const rows: { label: string; items: typeof albumTiles; tileSize: "sm" | "md" | "lg" }[] = [];
     if (albumTiles.length > 0) rows.push({ label: "Discography", items: albumTiles, tileSize: "md" });
@@ -465,6 +478,15 @@ function RealArtistProfileInner({ artist, trackTiles, albumTiles, relatedTiles }
           <p className="max-w-2xl text-base leading-relaxed text-foreground/70">{artist.bio}</p>
         </div>
       )}
+
+      {/* Latest Facts — shares the artist-updates cache with Browse.
+          If the user arrived via a nugget tap, the `?nugget=<id>` query
+          param scrolls the matching card into view and pulses it. */}
+      <LatestFactsSection
+        updates={latestUpdates}
+        loading={latestLoading}
+        artistName={artist.name}
+      />
 
       {/* Popular tracks */}
       {trackTiles.length > 0 && (

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -10,11 +10,11 @@ import StoriesRail from "@/components/StoriesRail";
 import ArtistUpdatesSection from "@/components/ArtistUpdatesSection";
 import { useUserProfile, tierGreeting, tierBadgeLabel, tierBadgeColor, tierGlowClass } from "@/hooks/useMusicNerdState";
 import { usePersonalizedCatalog } from "@/hooks/usePersonalizedCatalog";
-import { useArtistUpdates } from "@/hooks/useArtistUpdates";
 import { useTierAccent } from "@/hooks/useTierAccent";
 import { useSignOut } from "@/hooks/useSignOut";
 import { usePlayer } from "@/contexts/PlayerContext";
 import { useStoriesContext } from "@/contexts/StoriesContext";
+import { useArtistUpdatesContext } from "@/contexts/ArtistUpdatesContext";
 
 export default function Browse() {
   const [searchOpen, setSearchOpen] = useState(false);
@@ -42,15 +42,16 @@ export default function Browse() {
   // this page. Browse just reads the shared state.
   const { stories } = useStoriesContext();
 
-  // "Your artists, lately" — nested rows, one per top artist. Each
-  // artist resolves to up to 3 updates (release card + 2 facts) from
-  // the artist-updates edge function; results land incrementally so
-  // Browse shows skeletons while Gemini catches up.
+  // "Your artists, lately" — nested rows, one per top artist. Pre-gen
+  // is hoisted into `ArtistUpdatesProvider` at app root so warmup
+  // starts on profile hydration (returning user) OR immediately after
+  // handleTierSelect saves the profile (new user), rather than waiting
+  // for Browse to mount. Browse just reads the shared state.
   const {
     groups: artistUpdateGroups,
     totalCount: artistUpdatesTotal,
     readyCount: artistUpdatesReady,
-  } = useArtistUpdates(profile, { tier: (tier || "casual") });
+  } = useArtistUpdatesContext();
 
   const demoItems = [
     {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -7,8 +7,10 @@ import TileRow from "@/components/TileRow";
 import SearchOverlay from "@/components/SearchOverlay";
 import PageTransition from "@/components/PageTransition";
 import StoriesRail from "@/components/StoriesRail";
+import ArtistUpdatesSection from "@/components/ArtistUpdatesSection";
 import { useUserProfile, tierGreeting, tierBadgeLabel, tierBadgeColor, tierGlowClass } from "@/hooks/useMusicNerdState";
 import { usePersonalizedCatalog } from "@/hooks/usePersonalizedCatalog";
+import { useArtistUpdates } from "@/hooks/useArtistUpdates";
 import { useTierAccent } from "@/hooks/useTierAccent";
 import { useSignOut } from "@/hooks/useSignOut";
 import { usePlayer } from "@/contexts/PlayerContext";
@@ -39,6 +41,16 @@ export default function Browse() {
   // warming as soon as the profile is hydrated — not when the user reaches
   // this page. Browse just reads the shared state.
   const { stories } = useStoriesContext();
+
+  // "Your artists, lately" — nested rows, one per top artist. Each
+  // artist resolves to up to 3 updates (release card + 2 facts) from
+  // the artist-updates edge function; results land incrementally so
+  // Browse shows skeletons while Gemini catches up.
+  const {
+    groups: artistUpdateGroups,
+    totalCount: artistUpdatesTotal,
+    readyCount: artistUpdatesReady,
+  } = useArtistUpdates(profile, { tier: (tier || "casual") });
 
   const demoItems = [
     {
@@ -311,6 +323,17 @@ export default function Browse() {
         {/* Stories rail — pre-generated nuggets for your top tracks. Tapping
             a story opens Listen with the first nugget instant from cache. */}
         <StoriesRail stories={stories} />
+
+        {/* "Your artists, lately" — nested per-artist rows of updates.
+            Replaces the old Jump-Back-In + Top-Artists rows; moves Browse
+            away from the Spotify-shaped layout. */}
+        <ArtistUpdatesSection
+          groups={artistUpdateGroups}
+          profile={profile}
+          artistIds={profile?.artistIds}
+          totalCount={artistUpdatesTotal}
+          readyCount={artistUpdatesReady}
+        />
 
         {/* Rows */}
         {allRows.map((row, i) => (

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -145,6 +145,13 @@ export default function Browse() {
   // Focus state: rowIndex (-1 = header), colIndex
   const [rowIndex, setRowIndex] = useState(-1);
   const [colIndex, setColIndex] = useState(0);
+  // Hide the TV-style focus glow until the user actually presses an
+  // arrow key. Touch users (mobile) never trigger it, so the glow
+  // doesn't sit glued to the first tile while they scroll. Flips true
+  // on the first keydown handled below; never flips back (a touch
+  // session that briefly used a keyboard still has tactile cues, and
+  // re-hiding mid-session would feel like a bug).
+  const [kbNavActive, setKbNavActive] = useState(false);
 
   const HEADER_ITEMS = 3;
 
@@ -180,6 +187,14 @@ export default function Browse() {
     if (nowPlayingFocused) return; // NowPlayingBar handles its own keys
 
     const onKeyDown = (e: KeyboardEvent) => {
+      // First arrow press promotes us to "kb nav" mode; until then,
+      // focusedIndex is null on every TileRow (no glow on mobile).
+      if (
+        !kbNavActive &&
+        (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "ArrowLeft" || e.key === "ArrowRight")
+      ) {
+        setKbNavActive(true);
+      }
       if (e.key === "ArrowDown") {
         e.preventDefault();
         if (rowIndex === -1) {
@@ -265,7 +280,7 @@ export default function Browse() {
           <button
             onClick={cycleTier}
             title={`Switch tier (currently ${tier || "casual"})`}
-            className={`rounded-full transition-all ${rowIndex === -1 && colIndex === 0 ? focusGlow + " scale-110" : ""}`}
+            className={`rounded-full transition-all ${kbNavActive && rowIndex === -1 && colIndex === 0 ? focusGlow + " scale-110" : ""}`}
           >
             <MusicNerdLogo size={36} glow className="opacity-80" />
           </button>
@@ -273,7 +288,7 @@ export default function Browse() {
             <button
               onClick={() => setSearchOpen(true)}
               className={`flex h-10 items-center gap-2 rounded-full bg-foreground/5 px-5 text-sm text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground ${
-                rowIndex === -1 && colIndex === 1 ? focusGlow + " scale-105" : ""
+                kbNavActive && rowIndex === -1 && colIndex === 1 ? focusGlow + " scale-105" : ""
               }`}
             >
               <Search size={16} />
@@ -291,7 +306,7 @@ export default function Browse() {
               onClick={handleSignOut}
               title="Sign out"
               className={`flex h-10 w-10 items-center justify-center rounded-full bg-foreground/5 text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground ${
-                rowIndex === -1 && colIndex === 2 ? focusGlow + " scale-105" : ""
+                kbNavActive && rowIndex === -1 && colIndex === 2 ? focusGlow + " scale-105" : ""
               }`}
             >
               <LogOut size={16} />
@@ -343,7 +358,7 @@ export default function Browse() {
             label={row.label}
             items={row.items}
             tileSize={row.size}
-            focusedIndex={rowIndex === i ? colIndex : null}
+            focusedIndex={kbNavActive && rowIndex === i ? colIndex : null}
           />
         ))}
 
@@ -352,7 +367,7 @@ export default function Browse() {
           label="Demo Tracks"
           items={demoItems}
           tileSize="md"
-          focusedIndex={rowIndex === allRows.length ? colIndex : null}
+          focusedIndex={kbNavActive && rowIndex === allRows.length ? colIndex : null}
         />
 
         <div className="h-28" />

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -7,6 +7,7 @@ import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import type { UserProfile } from "@/mock/types";
 import spotifyLogo from "@/assets/spotify-logo.png";
 import { signInWithSpotify, prewarmSpotifyTaste } from "@/hooks/useSpotifyAuth";
+import { sanitizeRedirect } from "@/lib/routeUtils";
 import { initiateAppleMusicAuth, fetchAppleMusicTaste } from "@/hooks/useAppleMusicAuth";
 import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
 import { useSpotifyPostSigninSync } from "@/hooks/useSpotifyPostSigninSync";
@@ -28,17 +29,9 @@ const Spinner = ({ className = "h-4 w-4" }: { className?: string }) => (
   </svg>
 );
 
-// Reject non-content destinations so we never loop the user back through
-// the onboarding funnel: /connect (this page), /preparing (splash), /
-// (root router that re-routes here). Without this guard, a stray
-// ?redirect=/preparing creates an infinite /connect → /preparing →
-// /connect cycle when ProtectedRoute on /preparing trips on a transient
-// null in profile state.
-function sanitizeRedirect(url: string | null): string | null {
-  if (!url) return null;
-  if (url === "/" || url === "/connect" || url.startsWith("/preparing")) return null;
-  return url;
-}
+// sanitizeRedirect lives in src/lib/routeUtils.ts so PreparingExperience
+// uses the same logic — see the comment there for why we reject /,
+// /connect, and /preparing.
 
 /**
  * Outer gate for /connect. Reads URL/sessionStorage redirect and the

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -201,7 +201,11 @@ export default function Connect() {
     };
     saveProfile(profile);
     sessionStorage.removeItem("musicnerd_redirect");
-    navigate(redirectUrl || "/browse");
+    // Route first-run users through /preparing so stories + artist
+    // updates get a warmup window before Browse renders. The splash
+    // honors ?next= so deep-links survive the onboarding detour.
+    const next = redirectUrl || "/browse";
+    navigate(`/preparing?next=${encodeURIComponent(next)}`);
   };
 
   const tiers = [

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -139,10 +139,12 @@ function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
   });
 
   // Returning users go through /preparing too — it gives the hoisted
-  // stories + artist-updates contexts a window to warm so Browse's
-  // first paint has content instead of a wall of skeletons. The splash
-  // auto-advances once 2 stories + 3 artist-updates rows are ready
-  // (or its internal ceiling fires). Deep-links survive via ?next=.
+  // ArtistUpdatesContext a window to warm so Browse's "Your artists,
+  // lately" rail has content on first paint instead of a skeleton.
+  // The splash auto-advances when MIN_ARTISTS (1) artist-update rows
+  // resolve, or the MAX_WAIT_MS ceiling fires. Stories pre-gen runs
+  // in parallel but is NOT a gating signal — it continues loading on
+  // Browse via per-card state. Deep-links survive via ?next=.
   // Warm the spotify-taste edge function on mount so the post-OAuth
   // taste fetch doesn't eat the cold-start latency. The outer Connect
   // gate already short-circuits returning users via <Navigate> before
@@ -258,12 +260,20 @@ function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
       trackImages: pendingTrackImages.length ? pendingTrackImages : undefined,
       lastFmUsername: lastFmUsername.trim() || undefined,
       calculatedTier: t,
+      // Stamp tasteRefreshedAt explicitly — pendingTop* came from the
+      // post-signin sync's fetchSpotifyTaste call moments ago, so the
+      // 24h TTL window starts now. saveProfile no longer auto-stamps,
+      // so without this the next page load would treat the snapshot
+      // as "never refreshed" and trigger an immediate redundant
+      // background fetch.
+      tasteRefreshedAt: pendingTopArtists ? new Date().toISOString() : undefined,
     };
     saveProfile(profile);
     sessionStorage.removeItem("musicnerd_redirect");
-    // Route through /preparing so stories + artist-updates get a
-    // warmup window before Browse renders. Splash auto-advances once
-    // 2 stories + 3 artist-updates rows land, or the ceiling fires.
+    // Route through /preparing so artist-updates gets a warmup window
+    // before Browse renders. Splash auto-advances when 1 artist-update
+    // row lands, or the 45s ceiling fires. Stories pre-gen runs in
+    // parallel but doesn't block the splash.
     const next = redirectUrl || "/browse";
     navigate(`/preparing?next=${encodeURIComponent(next)}`);
   };

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -50,11 +50,24 @@ export default function Connect() {
   // local but DB still has the row).
   const { profile } = useUserProfile();
   const redirectParam = sanitizeRedirect(searchParams.get("redirect"));
-  if (redirectParam) sessionStorage.setItem("musicnerd_redirect", redirectParam);
+  // Persist redirect across the OAuth round-trip so the post-callback
+  // mount of Connect can still read where to send the user. Side-effect
+  // moved into useEffect because writes in the render body run twice
+  // under React 18 StrictMode and again on every re-render.
+  useEffect(() => {
+    if (redirectParam) {
+      sessionStorage.setItem("musicnerd_redirect", redirectParam);
+    }
+  }, [redirectParam]);
   const storedRedirect = sanitizeRedirect(sessionStorage.getItem("musicnerd_redirect"));
-  if (sessionStorage.getItem("musicnerd_redirect") && !storedRedirect) {
-    sessionStorage.removeItem("musicnerd_redirect");
-  }
+  // Evict polluted sessionStorage entries (e.g. stale "/preparing" left
+  // over from a pre-fix run). Must also be in an effect — writes during
+  // render violate the rendering contract.
+  useEffect(() => {
+    if (sessionStorage.getItem("musicnerd_redirect") && !storedRedirect) {
+      sessionStorage.removeItem("musicnerd_redirect");
+    }
+  }, [storedRedirect]);
   const redirectUrl = redirectParam || storedRedirect;
   // Treat live profile state OR localStorage as authoritative — the live
   // state can lag a render behind localStorage immediately after

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams, Navigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import PageTransition from "@/components/PageTransition";
@@ -6,11 +6,12 @@ import MusicNerdLogo from "@/components/MusicNerdLogo";
 import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import type { UserProfile } from "@/mock/types";
 import spotifyLogo from "@/assets/spotify-logo.png";
-import { signInWithSpotify } from "@/hooks/useSpotifyAuth";
+import { signInWithSpotify, prewarmSpotifyTaste } from "@/hooks/useSpotifyAuth";
 import { initiateAppleMusicAuth, fetchAppleMusicTaste } from "@/hooks/useAppleMusicAuth";
 import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
 import { useSpotifyPostSigninSync } from "@/hooks/useSpotifyPostSigninSync";
 import { ensureSupabaseSession } from "@/lib/ensureSupabaseSession";
+import SpotifySyncingOverlay from "@/components/SpotifySyncingOverlay";
 
 type Tier = "casual" | "curious" | "nerd";
 
@@ -27,13 +28,59 @@ const Spinner = ({ className = "h-4 w-4" }: { className?: string }) => (
   </svg>
 );
 
+// Reject non-content destinations so we never loop the user back through
+// the onboarding funnel: /connect (this page), /preparing (splash), /
+// (root router that re-routes here). Without this guard, a stray
+// ?redirect=/preparing creates an infinite /connect → /preparing →
+// /connect cycle when ProtectedRoute on /preparing trips on a transient
+// null in profile state.
+function sanitizeRedirect(url: string | null): string | null {
+  if (!url) return null;
+  if (url === "/" || url === "/connect" || url.startsWith("/preparing")) return null;
+  return url;
+}
+
+/**
+ * Outer gate for /connect. Reads URL/sessionStorage redirect and the
+ * stored profile synchronously so a returning user (cached profile) can
+ * be sent straight to their destination via <Navigate> without ever
+ * mounting Connect's body. This avoids the AnimatePresence transition
+ * stall that hit /connect → /preparing|/browse: PageTransition's exit
+ * animation didn't propagate up from inside Routes, so AnimatePresence
+ * with mode="wait" hung waiting for an exit that never fired, leaving
+ * Connect rendered on the new URL.
+ */
 export default function Connect() {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  // Persist redirect URL in sessionStorage so it survives OAuth redirects
-  const redirectParam = searchParams.get("redirect");
+  // Subscribe to profile so this gate re-renders when DB hydration
+  // populates it after a fresh sign-in (returning user, signOut cleared
+  // local but DB still has the row).
+  const { profile } = useUserProfile();
+  const redirectParam = sanitizeRedirect(searchParams.get("redirect"));
   if (redirectParam) sessionStorage.setItem("musicnerd_redirect", redirectParam);
-  const redirectUrl = redirectParam || sessionStorage.getItem("musicnerd_redirect");
+  const storedRedirect = sanitizeRedirect(sessionStorage.getItem("musicnerd_redirect"));
+  if (sessionStorage.getItem("musicnerd_redirect") && !storedRedirect) {
+    sessionStorage.removeItem("musicnerd_redirect");
+  }
+  const redirectUrl = redirectParam || storedRedirect;
+  // Treat live profile state OR localStorage as authoritative — the live
+  // state can lag a render behind localStorage immediately after
+  // saveProfile fires, so checking both closes the gap.
+  const hasProfile = !!profile || !!getStoredProfile();
+  if (hasProfile) {
+    // Route through /preparing so the artist-updates rail has a window
+    // to populate before Browse renders. Without this, returning users
+    // land on Browse with an empty rail and watch it fill in — the
+    // splash gives the per-artist Gemini call (cold-start 30-60s) time
+    // to land. Stories continue loading on Browse via their own state.
+    const next = redirectUrl || "/browse";
+    return <Navigate to={`/preparing?next=${encodeURIComponent(next)}`} replace />;
+  }
+  return <ConnectInner redirectUrl={redirectUrl} />;
+}
+
+function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
+  const navigate = useNavigate();
   const { saveProfile } = useUserProfile();
   const [step, setStep] = useState(0);
   const [direction, setDirection] = useState(1);
@@ -72,7 +119,7 @@ export default function Connect() {
   // so the async write arrived after nobody was listening. The direct
   // callback is race-free — the setters run the moment the taste fetch
   // resolves.
-  useSpotifyPostSigninSync({
+  const { syncing: spotifySyncing, syncError: spotifySyncError, retrySync } = useSpotifyPostSigninSync({
     onSynced: (patch) => {
       setSpotifyConnected(true);
       setPendingTopArtists(patch.topArtists ?? null);
@@ -85,11 +132,18 @@ export default function Connect() {
     },
   });
 
-  // If already onboarded, redirect to browse
+  // Returning users go through /preparing too — it gives the hoisted
+  // stories + artist-updates contexts a window to warm so Browse's
+  // first paint has content instead of a wall of skeletons. The splash
+  // auto-advances once 2 stories + 3 artist-updates rows are ready
+  // (or its internal ceiling fires). Deep-links survive via ?next=.
+  // Warm the spotify-taste edge function on mount so the post-OAuth
+  // taste fetch doesn't eat the cold-start latency. The outer Connect
+  // gate already short-circuits returning users via <Navigate> before
+  // ConnectInner mounts, so anyone reaching here is on the fresh-user
+  // path and will need this fetch.
   useEffect(() => {
-    if (getStoredProfile()) {
-      navigate(redirectUrl || "/browse", { replace: true });
-    }
+    prewarmSpotifyTaste();
   }, []);
 
   const goNext = (delta = 1) => { setDirection(delta); setStep((s) => s + delta); };
@@ -201,9 +255,9 @@ export default function Connect() {
     };
     saveProfile(profile);
     sessionStorage.removeItem("musicnerd_redirect");
-    // Route first-run users through /preparing so stories + artist
-    // updates get a warmup window before Browse renders. The splash
-    // honors ?next= so deep-links survive the onboarding detour.
+    // Route through /preparing so stories + artist-updates get a
+    // warmup window before Browse renders. Splash auto-advances once
+    // 2 stories + 3 artist-updates rows land, or the ceiling fires.
     const next = redirectUrl || "/browse";
     navigate(`/preparing?next=${encodeURIComponent(next)}`);
   };
@@ -216,6 +270,17 @@ export default function Connect() {
 
   return (
     <PageTransition>
+      {/* Full-screen takeover while the post-OAuth taste fetch runs. Keeps
+          the user from re-reading the Connect prompts (boring) and from
+          double-clicking Sign in with Spotify (confusing). Stays up
+          through an error so the user always has a retry path — if we
+          just dismissed on failure, they'd land back on step 0 and
+          think their click did nothing. */}
+      <SpotifySyncingOverlay
+        visible={spotifySyncing || !!spotifySyncError}
+        error={spotifySyncError}
+        onRetry={retrySync}
+      />
       <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden noise-overlay px-6">
         <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary/20" />
 
@@ -246,7 +311,7 @@ export default function Connect() {
                     {/* Spotify — connect or show connected */}
                     {!pendingTopArtists ? (
                       <>
-                        <button onClick={handleConnectSpotify} disabled={spotifyConnecting} className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground transition-all duration-200 disabled:opacity-70 border-green-500/40 hover:border-green-500 hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]">
+                        <button onClick={handleConnectSpotify} disabled={spotifyConnecting || spotifySyncing} className="flex items-center gap-4 w-full rounded-2xl border bg-foreground/5 px-5 py-4 text-left font-semibold text-foreground transition-all duration-200 disabled:opacity-70 disabled:cursor-not-allowed border-green-500/40 hover:border-green-500 hover:shadow-[0_0_20px_rgba(34,197,94,0.3)]">
                           <img src={spotifyLogo} alt="Spotify" className="w-8 h-8 object-contain" />
                           <span className="flex-1">Spotify</span>
                           {spotifyConnecting ? <Spinner className="h-4 w-4 text-green-400" /> : <span className="text-xs text-muted-foreground">Connect</span>}

--- a/src/pages/PreparingExperience.tsx
+++ b/src/pages/PreparingExperience.tsx
@@ -1,42 +1,55 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
 import PageTransition from "@/components/PageTransition";
 import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import { useFirstRunReadiness } from "@/hooks/useFirstRunReadiness";
 
 /**
- * Splash shown between tier-select and Browse on first run. Gives the
- * pre-gen pipeline a visible moment to warm up stories + artist
- * updates so Browse's first paint has content instead of an aisle of
- * skeletons.
+ * Splash shown between sign-in and Browse. Waits for the artist-updates
+ * rail (the first thing the user sees on /browse) to be ready before
+ * handing off, so Browse never opens with an empty "Your artists,
+ * lately" rail. Stories continue loading on Browse via their own
+ * per-card state — they're not user-blocking.
+ *
+ * Visual treatment mirrors `SpotifySyncingOverlay` (the post-OAuth
+ * spinner) so the entire onboarding/refresh flow feels cohesive: same
+ * aurora background, same logo glow + pulse, same gradient progress
+ * bar, same status-message cycling.
  *
  * Guards:
  *   - Landing here without a profile (direct-URL hit, refresh-during-
  *     onboarding) immediately bounces to `/`.
- *   - If `ready` flips true (enough content or the 10s ceiling hit),
- *     auto-navigate to /browse. The hook's MAX_WAIT_MS is the hard
- *     upper bound so no user is trapped waiting for Gemini forever.
- *   - A "Jump to Browse" link appears after 3s for users who don't
- *     want to wait even the normal warmup window.
+ *   - If `ready` flips true (artist-updates ready or 90s ceiling hit),
+ *     auto-navigate to /browse.
+ *   - A "Jump in" link appears after 3s for users who don't want to
+ *     wait the full warmup.
  */
+
+const STATUS_STEPS = [
+  { threshold: 0, label: "Tuning into your top artists" },
+  { threshold: 3_000, label: "Pulling in their latest releases" },
+  { threshold: 10_000, label: "Reading the room — what they've been up to" },
+  { threshold: 25_000, label: "Hand-picking facts worth knowing" },
+  { threshold: 50_000, label: "Just a moment more" },
+];
+
 export default function PreparingExperience() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { profile } = useUserProfile();
-  const {
-    ready,
-    storiesReady,
-    storiesTotal,
-    artistsReady,
-    artistsTotal,
-    skipAvailable,
-  } = useFirstRunReadiness();
+  const { ready, skipAvailable } = useFirstRunReadiness();
 
   // Deep-link support: a user signed in via /connect?redirect=/listen/xxx
-  // should land back on that URL after warmup, not /browse.
-  const nextUrl = searchParams.get("next") || "/browse";
+  // should land back on that URL after warmup, not /browse. Reject
+  // self-references and other onboarding paths so a polluted ?next=
+  // can't loop the user (a prior bug had ?next=/preparing trap users
+  // forever once ready=true).
+  const rawNext = searchParams.get("next");
+  const nextUrl = !rawNext || rawNext === "/" || rawNext === "/connect" || rawNext.startsWith("/preparing")
+    ? "/browse"
+    : rawNext;
 
   // Hard guard: somebody hit /preparing with no profile (bookmark,
   // refresh mid-onboarding, etc). Bounce them back to the entry.
@@ -53,48 +66,106 @@ export default function PreparingExperience() {
     if (ready) navigate(nextUrl, { replace: true });
   }, [ready, navigate, nextUrl]);
 
+  // Status-message timer — same pattern as SpotifySyncingOverlay so the
+  // copy advances even when the underlying generation is silent
+  // (Gemini cold start). Halts once ready so the last label doesn't
+  // flicker through during the navigate-out tick.
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (ready) return;
+    const start = Date.now();
+    const timer = setInterval(() => setElapsed(Date.now() - start), 200);
+    return () => clearInterval(timer);
+  }, [ready]);
+  const currentStep = STATUS_STEPS.reduce((acc, step) =>
+    elapsed >= step.threshold ? step : acc,
+  );
+
   return (
     <PageTransition>
-      <div className="relative min-h-screen bg-background flex flex-col items-center justify-center overflow-hidden px-6">
-        <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary/20 pointer-events-none" />
+      <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-black px-6">
+        {/* Aurora background — slow drift so the screen never feels
+            frozen while artist-updates generates. Same gradient stops
+            as SpotifySyncingOverlay for visual continuity. */}
+        <motion.div
+          className="pointer-events-none absolute -inset-40 opacity-60 blur-3xl"
+          initial={{ scale: 1, rotate: 0 }}
+          animate={{ scale: [1, 1.08, 1], rotate: [0, 8, 0] }}
+          transition={{ duration: 10, ease: "easeInOut", repeat: Infinity }}
+          style={{
+            background:
+              "radial-gradient(40% 40% at 30% 30%, rgba(34,197,94,0.25), transparent), radial-gradient(40% 40% at 70% 70%, rgba(236,72,153,0.25), transparent)",
+          }}
+        />
 
         <motion.div
-          className="relative z-10 flex flex-col items-center gap-8 max-w-md text-center"
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+          className="relative z-10 flex w-full max-w-sm flex-col items-center gap-6 text-center"
+          initial={{ y: 8, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
         >
-          <MusicNerdLogo size={64} glow />
+          <motion.div
+            animate={{ scale: [1, 1.04, 1] }}
+            transition={{ duration: 2.4, ease: "easeInOut", repeat: Infinity }}
+          >
+            <MusicNerdLogo size={72} glow />
+          </motion.div>
 
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             <h1
-              className="text-2xl md:text-3xl font-black text-foreground"
+              className="text-xl md:text-2xl font-black text-white tracking-tight"
               style={{ fontFamily: "'Nunito Sans', sans-serif" }}
             >
               Setting up your music
             </h1>
-            <p className="text-sm md:text-base text-muted-foreground">
-              Digging up stories and facts about your top artists. Hang tight — this only happens once.
-            </p>
+            <div className="relative h-5 overflow-hidden">
+              <AnimatePresence mode="wait">
+                <motion.p
+                  key={currentStep.label}
+                  initial={{ y: 10, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  exit={{ y: -10, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: "easeOut" }}
+                  className="text-sm text-white/70"
+                >
+                  {currentStep.label}
+                  <span className="inline-block ml-0.5 animate-pulse">…</span>
+                </motion.p>
+              </AnimatePresence>
+            </div>
           </div>
 
-          <div className="flex flex-col gap-3 w-full max-w-sm">
-            <ProgressPill
-              label="Stories"
-              ready={storiesReady}
-              total={storiesTotal}
+          {/* Bar pacing matches SpotifySyncingOverlay (4% → 95% over the
+              expected wait window). The first-artist Gemini cold start
+              dominates here — we tune duration to ~50s which is the
+              common-case worst, leaving headroom under the 90s ceiling.
+              On success, exit snaps to 100%. */}
+          <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+            <motion.div
+              className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-green-400 via-emerald-300 to-pink-400"
+              initial={{ width: "4%" }}
+              animate={{ width: ready ? "100%" : "95%" }}
+              transition={{ duration: ready ? 0.3 : 50, ease: [0.2, 0.6, 0.3, 1] }}
             />
-            <ProgressPill
-              label="Artist facts"
-              ready={artistsReady}
-              total={artistsTotal}
+            <motion.div
+              className="absolute inset-y-0 w-24 rounded-full"
+              style={{
+                background:
+                  "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
+              }}
+              animate={{ x: ["-20%", "420%"] }}
+              transition={{ duration: 1.6, ease: "easeInOut", repeat: Infinity }}
             />
           </div>
+
+          <p className="text-[11px] uppercase tracking-widest text-white/35">
+            Stories will keep loading on Browse
+          </p>
 
           {skipAvailable && !ready && (
             <button
               onClick={() => navigate(nextUrl, { replace: true })}
-              className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors underline underline-offset-4"
+              className="text-xs text-white/40 hover:text-white/70 transition-colors underline underline-offset-4"
             >
               Jump in
             </button>
@@ -102,40 +173,5 @@ export default function PreparingExperience() {
         </motion.div>
       </div>
     </PageTransition>
-  );
-}
-
-function ProgressPill({
-  label,
-  ready,
-  total,
-}: {
-  label: string;
-  ready: number;
-  total: number;
-}) {
-  // Cold start: total=0 for ~1 tick before the contexts populate.
-  // Show "Loading…" during that window rather than "0 / 0 ready"
-  // which looks like a bug.
-  const seeded = total > 0;
-  return (
-    <div className="flex items-center gap-3 px-4 py-2.5 rounded-full bg-foreground/5 border border-foreground/10">
-      <span className="text-xs font-semibold text-foreground/60 w-28 text-left">
-        {label}
-      </span>
-      <div className="flex-1 h-1.5 rounded-full bg-foreground/10 overflow-hidden">
-        <motion.div
-          className="h-full bg-rose-400/70"
-          initial={{ width: 0 }}
-          animate={{
-            width: seeded ? `${Math.min(100, (ready / total) * 100)}%` : "10%",
-          }}
-          transition={{ duration: 0.35, ease: "easeOut" }}
-        />
-      </div>
-      <span className="text-[11px] tabular-nums text-foreground/50 w-14 text-right">
-        {seeded ? `${ready} / ${total}` : "Loading…"}
-      </span>
-    </div>
   );
 }

--- a/src/pages/PreparingExperience.tsx
+++ b/src/pages/PreparingExperience.tsx
@@ -5,6 +5,7 @@ import MusicNerdLogo from "@/components/MusicNerdLogo";
 import PageTransition from "@/components/PageTransition";
 import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import { useFirstRunReadiness } from "@/hooks/useFirstRunReadiness";
+import { sanitizeRedirect } from "@/lib/routeUtils";
 
 /**
  * Splash shown between sign-in and Browse. Waits for the artist-updates
@@ -42,14 +43,11 @@ export default function PreparingExperience() {
   const { ready, skipAvailable } = useFirstRunReadiness();
 
   // Deep-link support: a user signed in via /connect?redirect=/listen/xxx
-  // should land back on that URL after warmup, not /browse. Reject
-  // self-references and other onboarding paths so a polluted ?next=
+  // should land back on that URL after warmup, not /browse. sanitizeRedirect
+  // rejects self-references and other onboarding paths so a polluted ?next=
   // can't loop the user (a prior bug had ?next=/preparing trap users
   // forever once ready=true).
-  const rawNext = searchParams.get("next");
-  const nextUrl = !rawNext || rawNext === "/" || rawNext === "/connect" || rawNext.startsWith("/preparing")
-    ? "/browse"
-    : rawNext;
+  const nextUrl = sanitizeRedirect(searchParams.get("next")) ?? "/browse";
 
   // Hard guard: somebody hit /preparing with no profile (bookmark,
   // refresh mid-onboarding, etc). Bounce them back to the entry.

--- a/src/pages/PreparingExperience.tsx
+++ b/src/pages/PreparingExperience.tsx
@@ -1,0 +1,141 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { motion } from "framer-motion";
+import MusicNerdLogo from "@/components/MusicNerdLogo";
+import PageTransition from "@/components/PageTransition";
+import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
+import { useFirstRunReadiness } from "@/hooks/useFirstRunReadiness";
+
+/**
+ * Splash shown between tier-select and Browse on first run. Gives the
+ * pre-gen pipeline a visible moment to warm up stories + artist
+ * updates so Browse's first paint has content instead of an aisle of
+ * skeletons.
+ *
+ * Guards:
+ *   - Landing here without a profile (direct-URL hit, refresh-during-
+ *     onboarding) immediately bounces to `/`.
+ *   - If `ready` flips true (enough content or the 10s ceiling hit),
+ *     auto-navigate to /browse. The hook's MAX_WAIT_MS is the hard
+ *     upper bound so no user is trapped waiting for Gemini forever.
+ *   - A "Jump to Browse" link appears after 3s for users who don't
+ *     want to wait even the normal warmup window.
+ */
+export default function PreparingExperience() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { profile } = useUserProfile();
+  const {
+    ready,
+    storiesReady,
+    storiesTotal,
+    artistsReady,
+    artistsTotal,
+    skipAvailable,
+  } = useFirstRunReadiness();
+
+  // Deep-link support: a user signed in via /connect?redirect=/listen/xxx
+  // should land back on that URL after warmup, not /browse.
+  const nextUrl = searchParams.get("next") || "/browse";
+
+  // Hard guard: somebody hit /preparing with no profile (bookmark,
+  // refresh mid-onboarding, etc). Bounce them back to the entry.
+  useEffect(() => {
+    if (!profile && !getStoredProfile()) {
+      navigate("/", { replace: true });
+    }
+  }, [profile, navigate]);
+
+  // Auto-advance once ready. replace: true so back-button doesn't
+  // bring the user back to the splash. `nextUrl` honors ?next= for
+  // users who came in via a deep link; defaults to /browse.
+  useEffect(() => {
+    if (ready) navigate(nextUrl, { replace: true });
+  }, [ready, navigate, nextUrl]);
+
+  return (
+    <PageTransition>
+      <div className="relative min-h-screen bg-background flex flex-col items-center justify-center overflow-hidden px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary/20 pointer-events-none" />
+
+        <motion.div
+          className="relative z-10 flex flex-col items-center gap-8 max-w-md text-center"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <MusicNerdLogo size={64} glow />
+
+          <div className="space-y-2">
+            <h1
+              className="text-2xl md:text-3xl font-black text-foreground"
+              style={{ fontFamily: "'Nunito Sans', sans-serif" }}
+            >
+              Setting up your music
+            </h1>
+            <p className="text-sm md:text-base text-muted-foreground">
+              Digging up stories and facts about your top artists. Hang tight — this only happens once.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 w-full max-w-sm">
+            <ProgressPill
+              label="Stories"
+              ready={storiesReady}
+              total={storiesTotal}
+            />
+            <ProgressPill
+              label="Artist facts"
+              ready={artistsReady}
+              total={artistsTotal}
+            />
+          </div>
+
+          {skipAvailable && !ready && (
+            <button
+              onClick={() => navigate(nextUrl, { replace: true })}
+              className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors underline underline-offset-4"
+            >
+              Jump in
+            </button>
+          )}
+        </motion.div>
+      </div>
+    </PageTransition>
+  );
+}
+
+function ProgressPill({
+  label,
+  ready,
+  total,
+}: {
+  label: string;
+  ready: number;
+  total: number;
+}) {
+  // Cold start: total=0 for ~1 tick before the contexts populate.
+  // Show "Loading…" during that window rather than "0 / 0 ready"
+  // which looks like a bug.
+  const seeded = total > 0;
+  return (
+    <div className="flex items-center gap-3 px-4 py-2.5 rounded-full bg-foreground/5 border border-foreground/10">
+      <span className="text-xs font-semibold text-foreground/60 w-28 text-left">
+        {label}
+      </span>
+      <div className="flex-1 h-1.5 rounded-full bg-foreground/10 overflow-hidden">
+        <motion.div
+          className="h-full bg-rose-400/70"
+          initial={{ width: 0 }}
+          animate={{
+            width: seeded ? `${Math.min(100, (ready / total) * 100)}%` : "10%",
+          }}
+          transition={{ duration: 0.35, ease: "easeOut" }}
+        />
+      </div>
+      <span className="text-[11px] tabular-nums text-foreground/50 w-14 text-right">
+        {seeded ? `${ready} / ${total}` : "Loading…"}
+      </span>
+    </div>
+  );
+}

--- a/src/pages/PreparingExperience.tsx
+++ b/src/pages/PreparingExperience.tsx
@@ -22,7 +22,7 @@ import { sanitizeRedirect } from "@/lib/routeUtils";
  * Guards:
  *   - Landing here without a profile (direct-URL hit, refresh-during-
  *     onboarding) immediately bounces to `/`.
- *   - If `ready` flips true (artist-updates ready or 90s ceiling hit),
+ *   - If `ready` flips true (artist-updates ready or 45s ceiling hit),
  *     auto-navigate to /browse.
  *   - A "Jump in" link appears after 3s for users who don't want to
  *     wait the full warmup.
@@ -32,8 +32,8 @@ const STATUS_STEPS = [
   { threshold: 0, label: "Tuning into your top artists" },
   { threshold: 3_000, label: "Pulling in their latest releases" },
   { threshold: 10_000, label: "Reading the room — what they've been up to" },
-  { threshold: 25_000, label: "Hand-picking facts worth knowing" },
-  { threshold: 50_000, label: "Just a moment more" },
+  { threshold: 22_000, label: "Hand-picking facts worth knowing" },
+  { threshold: 35_000, label: "Just a moment more" },
 ];
 
 export default function PreparingExperience() {
@@ -131,16 +131,16 @@ export default function PreparingExperience() {
           </div>
 
           {/* Bar pacing matches SpotifySyncingOverlay (4% → 95% over the
-              expected wait window). The first-artist Gemini cold start
-              dominates here — we tune duration to ~50s which is the
-              common-case worst, leaving headroom under the 90s ceiling.
-              On success, exit snaps to 100%. */}
+              expected wait window). Duration is 45s — same as
+              useFirstRunReadiness's MAX_WAIT_MS so the bar never
+              overshoots the auto-advance. On success, exit snaps to
+              100%. */}
           <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-white/10">
             <motion.div
               className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-green-400 via-emerald-300 to-pink-400"
               initial={{ width: "4%" }}
               animate={{ width: ready ? "100%" : "95%" }}
-              transition={{ duration: ready ? 0.3 : 50, ease: [0.2, 0.6, 0.3, 1] }}
+              transition={{ duration: ready ? 0.3 : 45, ease: [0.2, 0.6, 0.3, 1] }}
             />
             <motion.div
               className="absolute inset-y-0 w-24 rounded-full"

--- a/src/pages/PreparingExperience.tsx
+++ b/src/pages/PreparingExperience.tsx
@@ -110,10 +110,7 @@ export default function PreparingExperience() {
           </motion.div>
 
           <div className="space-y-1.5">
-            <h1
-              className="text-xl md:text-2xl font-black text-white tracking-tight"
-              style={{ fontFamily: "'Nunito Sans', sans-serif" }}
-            >
+            <h1 className="text-xl md:text-2xl font-black text-white tracking-tight font-nunito">
               Setting up your music
             </h1>
             <div className="relative h-5 overflow-hidden">

--- a/src/test/canonicalCacheKey.test.ts
+++ b/src/test/canonicalCacheKey.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { canonicalCacheKey } from "@/hooks/useAINuggets";
+
+// canonicalCacheKey produces the lookup key the client uses to hit
+// `nugget_cache`. The server writes its rows with raw (decoded) artist/
+// title/uri values, so the client's read key must normalize URL-encoded
+// inputs that come in via React Router params. Bug regression: tracks
+// with spaces ("KIKI (feat. Pete Rango)") or `:` in URI used to
+// cache-miss on every Listen mount and re-run the ~30s pipeline.
+describe("canonicalCacheKey", () => {
+  describe("real:: trackIds", () => {
+    it("produces the expected format with album blanked + tier appended", () => {
+      const key = canonicalCacheKey(
+        "real::Cherele::KIKI::SOMEALBUM::spotify:track:abc123",
+        "casual",
+      );
+      expect(key).toBe("real::Cherele::KIKI::::spotify:track:abc123::casual");
+    });
+
+    it("preserves URI colons (split is on `::` not `:`)", () => {
+      const key = canonicalCacheKey(
+        "real::Cherele::KIKI::::spotify:track:abc123",
+        "curious",
+      );
+      expect(key).toContain("spotify:track:abc123");
+    });
+  });
+
+  describe("URL-encoded chars in artist/title/uri", () => {
+    it("decodes %20 in title (space)", () => {
+      const key = canonicalCacheKey(
+        "real::Cherele::KIKI%20(feat.%20Pete%20Rango)::::spotify:track:abc",
+        "casual",
+      );
+      expect(key).toBe(
+        "real::Cherele::KIKI (feat. Pete Rango)::::spotify:track:abc::casual",
+      );
+    });
+
+    it("decodes %3A in URI (colon)", () => {
+      const key = canonicalCacheKey(
+        "real::Artist::Title::::spotify%3Atrack%3Aabc123",
+        "casual",
+      );
+      expect(key).toBe("real::Artist::Title::::spotify:track:abc123::casual");
+    });
+
+    it("decodes special chars in artist (apostrophes, accents)", () => {
+      const key = canonicalCacheKey(
+        "real::Beyonc%C3%A9::Halo::::spotify:track:xyz",
+        "casual",
+      );
+      expect(key).toBe("real::Beyoncé::Halo::::spotify:track:xyz::casual");
+    });
+  });
+
+  describe("encoded delimiters (real%3A%3A)", () => {
+    it("normalizes %3A%3A delimiters back to :: before splitting", () => {
+      const key = canonicalCacheKey(
+        "real%3A%3ACherele%3A%3AKIKI%3A%3A%3A%3Aspotify:track:abc",
+        "casual",
+      );
+      // After normalization the result matches the un-encoded form.
+      expect(key).toBe("real::Cherele::KIKI::::spotify:track:abc::casual");
+    });
+
+    it("handles uppercase %3A as well", () => {
+      const key = canonicalCacheKey(
+        "real%3A%3AArtist%3A%3ATitle%3A%3A%3A%3Auri",
+        "casual",
+      );
+      expect(key).toContain("real::Artist::Title::::uri");
+    });
+  });
+
+  describe("malformed / non-real ids", () => {
+    it("passes through non-`real::` ids unchanged + tier appended", () => {
+      const key = canonicalCacheKey("seed-billie-eilish-bad-guy", "curious");
+      expect(key).toBe("seed-billie-eilish-bad-guy::curious");
+    });
+
+    it("preserves a malformed `real::` id with too few parts", () => {
+      // 3 parts ("real", "artist", "title") — fewer than the expected 5.
+      const id = "real::Artist::Title";
+      const key = canonicalCacheKey(id, "casual");
+      expect(key).toBe("real::Artist::Title::casual");
+    });
+  });
+
+  describe("album slot is blanked", () => {
+    it("strips album metadata so different entry points share the row", () => {
+      const fromTile = canonicalCacheKey(
+        "real::Cherele::KIKI::Some Album::spotify:track:abc",
+        "casual",
+      );
+      const fromStory = canonicalCacheKey(
+        "real::Cherele::KIKI::::spotify:track:abc",
+        "casual",
+      );
+      expect(fromTile).toBe(fromStory);
+    });
+  });
+});

--- a/src/test/sanitizeRedirect.test.ts
+++ b/src/test/sanitizeRedirect.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeRedirect } from "@/lib/routeUtils";
+
+describe("sanitizeRedirect", () => {
+  // ── Valid pass-through ────────────────────────────────────────────────
+  describe("valid in-app paths", () => {
+    it("accepts /browse", () => {
+      expect(sanitizeRedirect("/browse")).toBe("/browse");
+    });
+    it("accepts /listen/real::Artist::Title::::spotify:track:xxx", () => {
+      expect(sanitizeRedirect("/listen/real::Artist::Title::::spotify:track:xxx"))
+        .toBe("/listen/real::Artist::Title::::spotify:track:xxx");
+    });
+    it("accepts /artist/:id with query params", () => {
+      expect(sanitizeRedirect("/artist/spotify::abc::Name?nugget=xyz"))
+        .toBe("/artist/spotify::abc::Name?nugget=xyz");
+    });
+    it("accepts /profile", () => {
+      expect(sanitizeRedirect("/profile")).toBe("/profile");
+    });
+  });
+
+  // ── Onboarding-loop rejection ─────────────────────────────────────────
+  describe("rejects onboarding self-references", () => {
+    it("rejects /", () => {
+      expect(sanitizeRedirect("/")).toBeNull();
+    });
+    it("rejects /connect", () => {
+      expect(sanitizeRedirect("/connect")).toBeNull();
+    });
+    it("rejects /preparing", () => {
+      expect(sanitizeRedirect("/preparing")).toBeNull();
+    });
+    it("rejects /preparing?next=/browse (any /preparing-prefixed path)", () => {
+      expect(sanitizeRedirect("/preparing?next=/browse")).toBeNull();
+    });
+    it("rejects /preparing-room (intentional prefix-match, see code comment)", () => {
+      expect(sanitizeRedirect("/preparing-room")).toBeNull();
+    });
+  });
+
+  // ── Open-redirect rejection ───────────────────────────────────────────
+  describe("rejects external/protocol URLs (open-redirect defense)", () => {
+    it("rejects protocol-relative //evil.com", () => {
+      expect(sanitizeRedirect("//evil.com")).toBeNull();
+    });
+    it("rejects absolute https://evil.com", () => {
+      expect(sanitizeRedirect("https://evil.com")).toBeNull();
+    });
+    it("rejects absolute http://evil.com", () => {
+      expect(sanitizeRedirect("http://evil.com")).toBeNull();
+    });
+    it("rejects javascript:alert(1)", () => {
+      expect(sanitizeRedirect("javascript:alert(1)")).toBeNull();
+    });
+    it("rejects data: URLs", () => {
+      expect(sanitizeRedirect("data:text/html,<script>alert(1)</script>")).toBeNull();
+    });
+    it("rejects path without leading slash", () => {
+      expect(sanitizeRedirect("foo")).toBeNull();
+    });
+    it("rejects empty string", () => {
+      expect(sanitizeRedirect("")).toBeNull();
+    });
+  });
+
+  // ── Nullish handling ──────────────────────────────────────────────────
+  describe("nullish inputs", () => {
+    it("returns null for null", () => {
+      expect(sanitizeRedirect(null)).toBeNull();
+    });
+    it("returns null for undefined", () => {
+      expect(sanitizeRedirect(undefined)).toBeNull();
+    });
+  });
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -79,3 +79,8 @@ verify_jwt = false
 # we don't want unauthenticated callers exchanging refresh tokens.
 [functions.spotify-refresh]
 verify_jwt = true
+
+# Artist-level "Your artists, lately" updates. Same public-browse
+# context as generate-nuggets — kept unauthenticated for now.
+[functions.artist-updates]
+verify_jwt = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -80,7 +80,14 @@ verify_jwt = false
 [functions.spotify-refresh]
 verify_jwt = true
 
-# Artist-level "Your artists, lately" updates. Same public-browse
-# context as generate-nuggets — kept unauthenticated for now.
+# Artist-level "Your artists, lately" updates. Authenticated — every
+# app caller (Browse rail, ArtistProfile Latest Facts) sits behind
+# ProtectedRoute, which requires a Supabase session (Spotify-OAuth
+# user or anonymous Apple Music session). Closes the unauthenticated
+# Gemini-burn vector flagged in PR #78 review: previously a stranger
+# could enumerate arbitrary artist names and drain the project's
+# Gemini quota since the function takes only a plain artist string.
+# supabase.functions.invoke() automatically attaches the user's JWT,
+# so client code didn't need changes.
 [functions.artist-updates]
-verify_jwt = false
+verify_jwt = true

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -206,14 +206,18 @@ Return JSON only, no preamble:
   ]
 }`;
 
+  // Use the same model + request shape as generate-nuggets' Writer:
+  // `gemini-2.5-flash`, `role: "user"` on parts, and NO
+  // `responseMimeType`. The response sometimes comes wrapped in a
+  // ```json code fence which we strip before JSON.parse.
   const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { temperature: 0.7, responseMimeType: "application/json" },
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        generationConfig: { temperature: 0.7 },
       }),
     },
   );
@@ -222,11 +226,16 @@ Return JSON only, no preamble:
     return [];
   }
   const data = await res.json();
-  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+  const rawText: string = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+  const text = rawText.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
+  if (!text) {
+    console.warn("[artist-updates] Gemini returned empty text");
+    return [];
+  }
   try {
     const parsed = JSON.parse(text);
     const nuggets = Array.isArray(parsed?.nuggets) ? parsed.nuggets : [];
-    return nuggets
+    const accepted = nuggets
       .filter(
         (n: unknown): n is { headline: string; body: string } =>
           !!n && typeof (n as { headline?: unknown }).headline === "string" &&
@@ -234,8 +243,10 @@ Return JSON only, no preamble:
       )
       .slice(0, count)
       .map((n) => ({ headline: String(n.headline), body: String(n.body) }));
-  } catch {
-    console.warn("[artist-updates] Gemini returned non-JSON:", text.slice(0, 200));
+    console.log(`[artist-updates] Gemini returned ${accepted.length}/${count} facts for ${artistName}`);
+    return accepted;
+  } catch (e) {
+    console.warn("[artist-updates] Gemini non-JSON output:", text.slice(0, 300), String(e));
     return [];
   }
 }
@@ -360,10 +371,17 @@ serve(async (req) => {
     generateArtistFacts(artistInfo.name, tier, FACTS_PER_ARTIST),
   ]);
 
+  const releaseAgeDays = release ? daysSince(release.release_date) : null;
+  console.log(
+    `[artist-updates] ${artistInfo.name} → release=${
+      release ? `${release.name} (${releaseAgeDays}d)` : "none"
+    }, facts=${facts.length}`,
+  );
+
   const updates: ArtistUpdate[] = [];
 
   // Release first so it anchors the row visually as "what's new."
-  if (release && daysSince(release.release_date) <= RECENT_WINDOW_DAYS) {
+  if (release && releaseAgeDays !== null && releaseAgeDays <= RECENT_WINDOW_DAYS) {
     updates.push(buildReleaseUpdate(artistInfo, release));
   }
 

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -477,14 +477,20 @@ const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 // How long a `status='generating'` sentinel is treated as live before
 // we assume the generator crashed/timed out and re-claim. Generation
-// itself takes 5-60s for cold Gemini; 90s gives real headroom.
-const STALE_GENERATION_MS = 90 * 1000;
+// itself takes 5-60s for cold Gemini; 55s caps below the Supabase
+// edge-function timeout floor (60s on free, 120s on paid) so a
+// follower can't end up holding the function alive past infra deadline.
+const STALE_GENERATION_MS = 55 * 1000;
 
-// How long followers wait for an in-flight generation to land before
-// giving up and generating themselves. Should be ≥ STALE_GENERATION_MS
-// so the leader has every chance to finish.
-const POLL_TIMEOUT_MS = 95 * 1000;
-const POLL_INTERVAL_MS = 1_000;
+// Poll deadline for followers waiting on the leader. Must stay below
+// the Supabase function timeout — 50s leaves headroom for the
+// post-poll cache write before the platform pulls the rug.
+const POLL_TIMEOUT_MS = 50 * 1000;
+// Exponential backoff caps DB read load while the leader runs.
+// Sequence is 1s, 2s, 4s, 8s, capped at POLL_INTERVAL_CAP_MS, which
+// keeps total reads to ~10 over the 50s window vs. ~50 with flat 1s.
+const POLL_INTERVAL_INITIAL_MS = 1_000;
+const POLL_INTERVAL_CAP_MS = 8_000;
 
 function cacheKey(artistName: string, tier: string): string {
   // Normalized (lowercased + trimmed) so whitespace / case variations
@@ -537,8 +543,16 @@ async function readCacheState(key: string): Promise<CacheState> {
 async function waitForGeneration(key: string): Promise<ArtistUpdate[] | null> {
   if (!cacheAdminClient) return null;
   const start = Date.now();
+  let delay = POLL_INTERVAL_INITIAL_MS;
   while (Date.now() - start < POLL_TIMEOUT_MS) {
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    // Cap remaining wait so the final sleep doesn't push us past the
+    // poll deadline (which is itself capped under the Supabase
+    // function timeout). Without this clamp a freshly-bumped 8s
+    // delay could fire after we should have given up.
+    const remaining = POLL_TIMEOUT_MS - (Date.now() - start);
+    const sleepMs = Math.min(delay, remaining);
+    if (sleepMs <= 0) break;
+    await new Promise((r) => setTimeout(r, sleepMs));
     const state = await readCacheState(key);
     if (state.kind === "ready") {
       console.info(`[artist-updates] poll resolved for ${key} in ${Date.now() - start}ms`);
@@ -549,7 +563,9 @@ async function waitForGeneration(key: string): Promise<ArtistUpdate[] | null> {
       // Fall through to caller so they can claim + generate.
       return null;
     }
-    // 'generating' — keep waiting
+    // 'generating' — keep waiting; double the delay (cap at ceiling)
+    // so total reads stay ~10 over the window instead of ~50.
+    delay = Math.min(delay * 2, POLL_INTERVAL_CAP_MS);
   }
   console.warn(`[artist-updates] poll timed out for ${key} after ${POLL_TIMEOUT_MS}ms`);
   return null;

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -652,7 +652,13 @@ serve(async (req) => {
   const artist = typeof body.artist === "string" ? body.artist.trim() : "";
   const tier = body.tier === "curious" || body.tier === "nerd" ? body.tier : "casual";
 
-  if (!artist) {
+  // 300 is generous — the longest legitimate artist names ("...And You
+  // Will Know Us by the Trail of Dead") are <50 chars. Cap is here to
+  // bound the input that flows into the Spotify search URL, the cache
+  // key, and the Gemini prompt body — not to enforce a name standard.
+  // Reject silently with the same shape as the missing-input case.
+  const MAX_ARTIST_LEN = 300;
+  if (!artist || artist.length > MAX_ARTIST_LEN) {
     return new Response(JSON.stringify({ error: "artist required" }), {
       status: 400,
       headers: { ...corsHeaders, "Content-Type": "application/json" },

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -1,0 +1,385 @@
+// Artist-level updates for the Browse "Your artists, lately" row.
+//
+// Per call: takes ONE artist name + tier, returns up to 3 ArtistUpdate
+// items (1 recent release if any, plus 2 fact nuggets). The hook
+// calls this function in throttled parallel for each of the user's
+// top artists and groups the array under the artist's name for the
+// nested-per-artist Browse row.
+//
+// Budget note: we cap at 1 release + 2 facts so a single cold-start
+// call stays under Gemini's typical ≤8s latency window. Increasing
+// fact count here has a direct linear cost on Browse first-paint.
+//
+// Cached under `nugget_cache.track_id = "artist::<name>::<tier>"`.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { getSpotifyAppToken } from "../_shared/spotify-token.ts";
+import {
+  CONSTITUTION_PREAMBLE,
+  CONSTITUTION_WRITER_RULES,
+} from "../generate-nuggets/constitution.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+const FACTS_PER_ARTIST = 2;
+const RECENT_WINDOW_DAYS = 90;
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+interface ArtistUpdate {
+  artistId: string;
+  artistName: string;
+  artistImageUrl: string;
+  kind: "new-release" | "collab" | "fact";
+  headline: string;
+  body: string;
+  source?: {
+    type: string;
+    title?: string;
+    publisher?: string;
+    url?: string;
+  };
+  nuggetId?: string;         // deep-link anchor on ArtistProfile
+  relatedTrackUri?: string;  // for new-release/collab kinds
+}
+
+interface SpotifyArtistSearchResult {
+  id: string;
+  name: string;
+  images?: { url: string }[];
+  followers?: { total: number };
+}
+
+interface SpotifyReleaseItem {
+  id: string;
+  name: string;
+  album_type: string;
+  release_date: string;
+  uri: string;
+  artists: { id: string; name: string }[];
+  external_urls?: { spotify: string };
+  images?: { url: string }[];
+}
+
+// ── Module-level admin client for cache upsert ────────────────────────
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ADMIN_KEY =
+  Deno.env.get("SUPABASE_SECRET_KEY") ??
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ??
+  "";
+const cacheAdminClient = SUPABASE_ADMIN_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_ADMIN_KEY)
+  : null;
+
+// ── Spotify helpers ────────────────────────────────────────────────────
+
+async function searchArtist(
+  token: string,
+  name: string,
+): Promise<SpotifyArtistSearchResult | null> {
+  const url = `https://api.spotify.com/v1/search?type=artist&limit=1&q=${encodeURIComponent(
+    name,
+  )}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) return null;
+  const data = await res.json();
+  const first = data?.artists?.items?.[0];
+  if (!first || !first.id) return null;
+  // Require the match to be reasonably close. Spotify sometimes returns
+  // unrelated artists for sparse names — case-insensitive, trim-tolerant.
+  const matches = String(first.name).trim().toLowerCase() === name.trim().toLowerCase();
+  return matches ? first : null;
+}
+
+async function fetchRecentRelease(
+  token: string,
+  artistId: string,
+): Promise<SpotifyReleaseItem | null> {
+  const url = `https://api.spotify.com/v1/artists/${artistId}/albums?include_groups=single,album&limit=5&market=US`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) return null;
+  const data = await res.json();
+  const items = (data?.items ?? []) as SpotifyReleaseItem[];
+  if (items.length === 0) return null;
+  // Spotify's default ordering is already most-recent-first but we sort
+  // defensively so a market variance can't surface an older release.
+  items.sort((a, b) => (a.release_date < b.release_date ? 1 : -1));
+  return items[0];
+}
+
+function daysSince(isoDate: string): number {
+  const then = new Date(isoDate).getTime();
+  if (!Number.isFinite(then)) return Infinity;
+  return Math.floor((Date.now() - then) / 86400_000);
+}
+
+function buildReleaseUpdate(
+  artist: SpotifyArtistSearchResult,
+  release: SpotifyReleaseItem,
+): ArtistUpdate {
+  const otherArtists = release.artists
+    .filter((a) => a.id !== artist.id)
+    .map((a) => a.name);
+  const isCollab = otherArtists.length > 0;
+  const kind: ArtistUpdate["kind"] = isCollab ? "collab" : "new-release";
+  const daysAgo = daysSince(release.release_date);
+  const freshness =
+    daysAgo <= 7
+      ? "this week"
+      : daysAgo <= 30
+      ? "this month"
+      : daysAgo <= 60
+      ? "last month"
+      : `${Math.round(daysAgo / 30)} months ago`;
+  const headline = isCollab
+    ? `${artist.name} teamed up with ${otherArtists.slice(0, 2).join(" and ")} on "${release.name}"`
+    : `${artist.name} released ${release.album_type === "single" ? "a new single" : "a new album"}: "${release.name}"`;
+  const body = `Dropped ${freshness} — tap in to hear what ${
+    isCollab ? "they just made together" : "they've been working on"
+  }.`;
+  const releaseImg =
+    (release.images?.[0]?.url) ??
+    (artist.images?.[0]?.url) ??
+    "";
+  return {
+    artistId: artist.id,
+    artistName: artist.name,
+    artistImageUrl: releaseImg,
+    kind,
+    headline,
+    body,
+    source: {
+      type: "spotify",
+      title: release.name,
+      publisher: "Spotify",
+      url: release.external_urls?.spotify,
+    },
+    relatedTrackUri: release.uri,
+    nuggetId: `release-${release.id}`,
+  };
+}
+
+// ── Gemini fact generation (batched: N facts in one call) ─────────────
+
+async function generateArtistFacts(
+  artistName: string,
+  tier: "casual" | "curious" | "nerd",
+  count: number,
+): Promise<{ headline: string; body: string }[]> {
+  const apiKey = Deno.env.get("GOOGLE_AI_API_KEY");
+  if (!apiKey) {
+    console.warn("[artist-updates] GOOGLE_AI_API_KEY not set — skipping facts");
+    return [];
+  }
+
+  const writerRules = CONSTITUTION_WRITER_RULES.map((rule) =>
+    typeof rule === "function" ? rule(artistName) : rule,
+  ).join("\n\n");
+
+  const tierGuidance =
+    tier === "nerd"
+      ? "Audience is a hardcore music nerd — surface deep production, session-credit, micro-genre, or lineage facts."
+      : tier === "curious"
+      ? "Audience is a curious fan — lead with specific people, collaborators, or cause-and-effect moments."
+      : "Audience is a casual listener — relatable origin stories, turning-point moments, and unlikely personal details work well.";
+
+  const prompt = `${CONSTITUTION_PREAMBLE}
+
+${writerRules}
+
+${tierGuidance}
+
+Write ${count} DISTINCT nuggets about ${artistName}. Each must pass the SWAP TEST — the headline is useless if you could swap in another artist's name and the sentence still works. No release-date recaps; those are covered elsewhere. Make the ${count} cover ${count === 2 ? "different angles (e.g. one collaborator story, one production/lineage/cultural detail)" : "different angles — no two should overlap"}.
+
+Return JSON only, no preamble:
+{
+  "nuggets": [
+    { "headline": "<complete-fact sentence, sentence case, names ${artistName} explicitly>",
+      "body": "<1-3 sentences of context adding who/where/what-happened-next>" },
+    …
+  ]
+}`;
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { temperature: 0.7, responseMimeType: "application/json" },
+      }),
+    },
+  );
+  if (!res.ok) {
+    console.warn(`[artist-updates] Gemini ${res.status}:`, await res.text().catch(() => ""));
+    return [];
+  }
+  const data = await res.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+  try {
+    const parsed = JSON.parse(text);
+    const nuggets = Array.isArray(parsed?.nuggets) ? parsed.nuggets : [];
+    return nuggets
+      .filter(
+        (n: unknown): n is { headline: string; body: string } =>
+          !!n && typeof (n as { headline?: unknown }).headline === "string" &&
+          typeof (n as { body?: unknown }).body === "string",
+      )
+      .slice(0, count)
+      .map((n) => ({ headline: String(n.headline), body: String(n.body) }));
+  } catch {
+    console.warn("[artist-updates] Gemini returned non-JSON:", text.slice(0, 200));
+    return [];
+  }
+}
+
+function buildFactUpdate(
+  artist: SpotifyArtistSearchResult,
+  headline: string,
+  body: string,
+  index: number,
+): ArtistUpdate {
+  return {
+    artistId: artist.id,
+    artistName: artist.name,
+    artistImageUrl: artist.images?.[0]?.url ?? "",
+    kind: "fact",
+    headline,
+    body,
+    source: { type: "generated", publisher: "MusicNerd" },
+    // Stable-ish id so the client can dedupe inside a cache row if we
+    // ever regenerate. Uses the index within the fact set.
+    nuggetId: `fact-${artist.id}-${index}`,
+  };
+}
+
+// ── Cache ──────────────────────────────────────────────────────────────
+
+function cacheKey(artistName: string, tier: string): string {
+  // Normalized (lowercased + trimmed) so whitespace / case variations
+  // land on the same cache row.
+  return `artist::${artistName.trim().toLowerCase()}::${tier}`;
+}
+
+async function readFromCache(key: string): Promise<ArtistUpdate[] | null> {
+  if (!cacheAdminClient) return null;
+  try {
+    const { data } = await cacheAdminClient
+      .from("nugget_cache")
+      .select("nuggets, status")
+      .eq("track_id", key)
+      .maybeSingle();
+    if (!data || data.status !== "ready") return null;
+    const updates = (data.nuggets as ArtistUpdate[] | null) ?? [];
+    return updates.length > 0 ? updates : null;
+  } catch (e) {
+    console.warn("[artist-updates] cache read threw:", e);
+    return null;
+  }
+}
+
+async function writeToCache(key: string, updates: ArtistUpdate[]): Promise<void> {
+  if (!cacheAdminClient || updates.length === 0) return;
+  try {
+    await cacheAdminClient.from("nugget_cache").upsert(
+      { track_id: key, nuggets: updates, sources: {}, status: "ready" },
+      { onConflict: "track_id" },
+    );
+  } catch (e) {
+    console.warn("[artist-updates] cache write threw:", e);
+  }
+}
+
+// ── Handler ────────────────────────────────────────────────────────────
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  let body: { artist?: string; tier?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid JSON body" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const artist = typeof body.artist === "string" ? body.artist.trim() : "";
+  const tier = body.tier === "curious" || body.tier === "nerd" ? body.tier : "casual";
+
+  if (!artist) {
+    return new Response(JSON.stringify({ error: "artist required" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const key = cacheKey(artist, tier);
+
+  // 1. Cache hit? Return the whole set.
+  const cached = await readFromCache(key);
+  if (cached) {
+    return new Response(JSON.stringify({ updates: cached, cached: true }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  // 2. Resolve artist on Spotify.
+  let token: string;
+  try {
+    token = await getSpotifyAppToken();
+  } catch (e) {
+    console.error("[artist-updates] Spotify token unavailable:", e);
+    return new Response(JSON.stringify({ error: "spotify unavailable" }), {
+      status: 502,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const artistInfo = await searchArtist(token, artist);
+  if (!artistInfo) {
+    return new Response(JSON.stringify({ updates: [], reason: "artist-not-found" }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  // 3. Run release lookup + fact generation in parallel to minimize
+  //    total latency for the user (cold-start overlap).
+  const [release, facts] = await Promise.all([
+    fetchRecentRelease(token, artistInfo.id),
+    generateArtistFacts(artistInfo.name, tier, FACTS_PER_ARTIST),
+  ]);
+
+  const updates: ArtistUpdate[] = [];
+
+  // Release first so it anchors the row visually as "what's new."
+  if (release && daysSince(release.release_date) <= RECENT_WINDOW_DAYS) {
+    updates.push(buildReleaseUpdate(artistInfo, release));
+  }
+
+  facts.forEach((f, i) => {
+    updates.push(buildFactUpdate(artistInfo, f.headline, f.body, i));
+  });
+
+  if (updates.length === 0) {
+    // Couldn't compose anything — don't cache; let a retry try again.
+    return new Response(JSON.stringify({ updates: [], reason: "compose-failed" }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  await writeToCache(key, updates);
+  return new Response(JSON.stringify({ updates, cached: false }), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -26,8 +26,25 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
 
-const FACTS_PER_ARTIST = 2;
+// One fact per artist keeps the /preparing-to-browse transition
+// snappy: each edge-function call is a single Gemini generation
+// instead of a batched-two-nuggets prompt. "New release + 1 fact"
+// is the minimum viable row content; more nuggets per artist belong
+// on the Artist Profile page via useArtistLatestFacts.
+const FACTS_PER_ARTIST = 1;
 const RECENT_WINDOW_DAYS = 90;
+
+// Below this Spotify follower count we assume there's essentially no
+// press, interviews, or journalism about the artist — so any prompt
+// asking Gemini to recall specific stories about them will fabricate.
+// Pete Rango, Earl from Yonder, Qu33nK, etc. all land under this
+// threshold; well-known artists (Radiohead, Kendrick) sit three+
+// orders of magnitude above it. In sparse mode we pivot to catalog-
+// grounded nuggets (real track titles + genres from Spotify) instead
+// of open-ended story generation. This is a simpler signal than
+// generate-nuggets' Exa-citation-count approach; a proper parity fix
+// would add Exa here too but is scoped separately.
+const SPARSE_FOLLOWER_THRESHOLD = 5000;
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -53,6 +70,13 @@ interface SpotifyArtistSearchResult {
   name: string;
   images?: { url: string }[];
   followers?: { total: number };
+  genres?: string[];
+  popularity?: number;
+}
+
+interface SpotifyTopTrack {
+  name: string;
+  album?: { name?: string; release_date?: string };
 }
 
 interface SpotifyReleaseItem {
@@ -95,6 +119,22 @@ async function searchArtist(
   // unrelated artists for sparse names — case-insensitive, trim-tolerant.
   const matches = String(first.name).trim().toLowerCase() === name.trim().toLowerCase();
   return matches ? first : null;
+}
+
+async function fetchArtistTopTracks(
+  token: string,
+  artistId: string,
+  limit = 5,
+): Promise<SpotifyTopTrack[]> {
+  // Used only in sparse mode — gives Gemini real, verifiable track
+  // names + release dates to anchor catalog-grounded nuggets. Skipped
+  // in the non-sparse path to save a call.
+  const url = `https://api.spotify.com/v1/artists/${artistId}/top-tracks?market=US`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) return [];
+  const data = await res.json();
+  const tracks = (data?.tracks ?? []) as SpotifyTopTrack[];
+  return tracks.slice(0, limit);
 }
 
 async function fetchRecentRelease(
@@ -167,11 +207,26 @@ function buildReleaseUpdate(
 
 // ── Gemini fact generation (batched: N facts in one call) ─────────────
 
+interface FactGenerationContext {
+  artistName: string;
+  tier: "casual" | "curious" | "nerd";
+  count: number;
+  /** When true, Gemini gets a locked-down prompt that forbids open-ended
+   *  storytelling and requires grounding in the catalog data supplied
+   *  below. Used when follower count suggests there's no real press to
+   *  draw from — the anti-hallucination gate for indie / niche artists. */
+  sparse: boolean;
+  /** Spotify genre tags for the artist (from /v1/artists search hit). */
+  genres?: string[];
+  /** Top tracks with album + release year — catalog grounding for
+   *  sparse prompts. Ignored in non-sparse mode. */
+  topTracks?: SpotifyTopTrack[];
+}
+
 async function generateArtistFacts(
-  artistName: string,
-  tier: "casual" | "curious" | "nerd",
-  count: number,
+  ctx: FactGenerationContext,
 ): Promise<{ headline: string; body: string }[]> {
+  const { artistName, tier, count, sparse, genres, topTracks } = ctx;
   const apiKey = Deno.env.get("GOOGLE_AI_API_KEY");
   if (!apiKey) {
     console.warn("[artist-updates] GOOGLE_AI_API_KEY not set — skipping facts");
@@ -182,34 +237,120 @@ async function generateArtistFacts(
     typeof rule === "function" ? rule(artistName) : rule,
   ).join("\n\n");
 
-  const tierGuidance =
-    tier === "nerd"
+  const tierGuidance = sparse
+    ? // Override tier-specific "deep production", "session credits",
+      // etc. asks — for sparse artists Gemini has no verified material
+      // for those angles and will fabricate. Mirrors the sparse-focus
+      // override shipped to generate-nuggets in commit 96fc5c1.
+      "Audience context applies BUT: skip any ask for deep production, session credits, studio anecdotes, or collaborator stories. Restrict to what's verifiable from the catalog data below."
+    : tier === "nerd"
       ? "Audience is a hardcore music nerd — surface deep production, session-credit, micro-genre, or lineage facts."
       : tier === "curious"
       ? "Audience is a curious fan — lead with specific people, collaborators, or cause-and-effect moments."
       : "Audience is a casual listener — relatable origin stories, turning-point moments, and unlikely personal details work well.";
 
+  const multiNuggetAngleLine =
+    count === 1
+      ? ""
+      : count === 2
+      ? "\nMake the 2 cover different angles (e.g. one collaborator story, one production/lineage/cultural detail)."
+      : `\nMake the ${count} cover different angles — no two should overlap.`;
+
+  // Sparse mode: Gemini gets a CATALOG-ONLY grounding block and an
+  // explicit ban on inventing collaborators, stories, labels, etc.
+  // Non-sparse: same prompt as before (mainstream artists can draw
+  // on training data more safely, though Exa grounding is still the
+  // real fix — tracked as follow-up).
+  const sparseGroundingBlock = sparse
+    ? `\n\nVERIFIED CATALOG DATA (this is the ONLY ground truth you have — do not invent beyond it):
+- Artist: ${artistName}
+- Genres (from Spotify): ${(genres ?? []).slice(0, 4).join(", ") || "(none listed)"}
+- Known tracks: ${
+        (topTracks ?? [])
+          .slice(0, 5)
+          .map((t) => `"${t.name}"${t.album?.release_date ? ` (${t.album.release_date.slice(0, 4)})` : ""}`)
+          .join(", ") || "(none available)"
+      }
+
+SPARSE DATA MODE: There is essentially no press coverage, interviews, or journalism about ${artistName}. You MUST NOT fabricate:
+  - collaborator names, producer names, label names, engineer names
+  - voicemails, discarded demos, near-miss anecdotes, recording stories
+  - venues, cities, or scenes unless they appear in the data above
+  - quotes attributed to ${artistName} or anyone else
+
+If you cannot produce ${count === 1 ? "a nugget" : `${count} nuggets`} grounded strictly in the catalog data above (track titles, genre lineage, release-year context), return an empty nuggets array. Zero nuggets is allowed and preferred over invented stories.
+
+Acceptable sparse-mode angles — every fact must reveal a SHIFT or
+TURNING POINT in the artist's catalog, not just describe a pattern.
+A naming-convention observation is weak; a hiatus → comeback or
+solo-to-collaborator pivot tells a story.
+
+Strong angles (prefer these):
+  - Hiatus / comeback: long gap between releases (years apart) followed
+    by a flurry — implies a return to making music. Use the actual
+    years from above.
+  - Career pivot visible in titles: "(feat. X)" or "(${artistName} Mix)"
+    or "(${artistName} Remix)" reveals collaboration; spot when this
+    pattern starts/stops.
+  - Output tempo shift: years with one release vs. years with several
+    suggest a productivity change. Use the actual track-count-by-year
+    from above.
+  - Genre-lineage anchor: "${artistName}'s <listed genre> sits in the
+    same lineage as <well-known foundational act in that genre>…"
+    (only if the genre IS in the list above)
+
+Weak angles (avoid unless nothing else works):
+  - Title aesthetics or naming conventions ("opulent titles", "color
+    motifs", "punctuation patterns") — describes surface, no story.
+  - Generic catalog stats ("X has Y tracks") — uninformative.
+  - "Earliest listed track" timestamp facts — Spotify catalog ≠ debut.
+
+Format: lead with the shift, anchor with the year(s) and at least one
+real track name from above. NEVER invent collaborators, labels, or
+quotes. NEVER claim anything that can't be verified from the list.`
+    : "";
+
   const prompt = `${CONSTITUTION_PREAMBLE}
 
 ${writerRules}
 
-${tierGuidance}
+${tierGuidance}${sparseGroundingBlock}
 
-Write ${count} DISTINCT nuggets about ${artistName}. Each must pass the SWAP TEST — the headline is useless if you could swap in another artist's name and the sentence still works. No release-date recaps; those are covered elsewhere. Make the ${count} cover ${count === 2 ? "different angles (e.g. one collaborator story, one production/lineage/cultural detail)" : "different angles — no two should overlap"}.
+You have Google Search available as a tool. USE IT FIRST to find
+verified, recent information about ${artistName} — interviews,
+production credits, label history, scene context, recent press. Pull
+the strongest grounded fact from what you find. Only fall back to the
+catalog data above if Google Search returns nothing usable.
+
+ARTIST NAME LOCK: refer to the artist as "${artistName}" throughout —
+that's their public/stage name and how the audience knows them.
+- Do NOT introduce a legal/birth/alternate name in the headline or body
+  (e.g. "X, known professionally as Y"). Even if Google surfaces one,
+  drop it. The audience came here for the artist they recognize.
+- All pronoun/short references must trace back to "${artistName}", not
+  to a discovered alternate. Never use just a last name from a legal
+  identity.
+
+Write ${count === 1 ? "ONE nugget" : `${count} DISTINCT nuggets`} about ${artistName}. ${
+    count === 1 ? "It" : "Each"
+  } must pass the SWAP TEST — the headline is useless if you could swap in another artist's name and the sentence still works. No release-date recaps; those are covered elsewhere.${multiNuggetAngleLine}
 
 Return JSON only, no preamble:
 {
   "nuggets": [
     { "headline": "<complete-fact sentence, sentence case, names ${artistName} explicitly>",
-      "body": "<1-3 sentences of context adding who/where/what-happened-next>" },
-    …
+      "body": "<1-3 sentences of context adding who/where/what-happened-next>" }${count > 1 ? ",\n    …" : ""}
   ]
 }`;
 
-  // Use the same model + request shape as generate-nuggets' Writer:
-  // `gemini-2.5-flash`, `role: "user"` on parts, and NO
-  // `responseMimeType`. The response sometimes comes wrapped in a
-  // ```json code fence which we strip before JSON.parse.
+  // Use `gemini-2.5-flash` with Google Search grounding enabled. The
+  // model autonomously decides whether to search; grounded responses
+  // come back with `groundingMetadata` we could surface as citations
+  // (future). For now we just use the grounded text.
+  //
+  // `responseMimeType` is intentionally NOT set — incompatible with
+  // grounding tools. The response sometimes comes wrapped in a
+  // ```json fence which we strip before JSON.parse.
   const res = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
     {
@@ -217,6 +358,7 @@ Return JSON only, no preamble:
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         contents: [{ role: "user", parts: [{ text: prompt }] }],
+        tools: [{ googleSearch: {} }],
         generationConfig: { temperature: 0.7 },
       }),
     },
@@ -226,6 +368,17 @@ Return JSON only, no preamble:
     return [];
   }
   const data = await res.json();
+  // Surface grounding usage so we can tell whether a weak fact came
+  // from no search results vs. Gemini ignoring the tool. The metadata
+  // shape: `groundingMetadata.groundingChunks` is an array of pages
+  // the model cited.
+  const groundingChunks = data?.candidates?.[0]?.groundingMetadata?.groundingChunks ?? [];
+  const searchQueries = data?.candidates?.[0]?.groundingMetadata?.webSearchQueries ?? [];
+  if (groundingChunks.length > 0) {
+    console.log(`[artist-updates] grounded fact for ${artistName} — ${groundingChunks.length} sources, queries: ${JSON.stringify(searchQueries)}`);
+  } else {
+    console.log(`[artist-updates] no grounding for ${artistName} (catalog-only fallback)`);
+  }
   const rawText: string = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
   const text = rawText.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
   if (!text) {
@@ -273,34 +426,147 @@ function buildFactUpdate(
 
 // ── Cache ──────────────────────────────────────────────────────────────
 
+// How long a cached artist-updates row stays fresh. Past this window we
+// treat the row as a miss and regenerate so timely content (new releases,
+// recent activity) doesn't go stale on long-running cached entries.
+// 7 days strikes a balance: most artists release less often than weekly,
+// but a fan visiting after a release shouldn't see week-old "latest".
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// How long a `status='generating'` sentinel is treated as live before
+// we assume the generator crashed/timed out and re-claim. Generation
+// itself takes 5-60s for cold Gemini; 90s gives real headroom.
+const STALE_GENERATION_MS = 90 * 1000;
+
+// How long followers wait for an in-flight generation to land before
+// giving up and generating themselves. Should be ≥ STALE_GENERATION_MS
+// so the leader has every chance to finish.
+const POLL_TIMEOUT_MS = 95 * 1000;
+const POLL_INTERVAL_MS = 1_000;
+
 function cacheKey(artistName: string, tier: string): string {
   // Normalized (lowercased + trimmed) so whitespace / case variations
   // land on the same cache row.
   return `artist::${artistName.trim().toLowerCase()}::${tier}`;
 }
 
-async function readFromCache(key: string): Promise<ArtistUpdate[] | null> {
-  if (!cacheAdminClient) return null;
+type CacheState =
+  | { kind: "ready"; updates: ArtistUpdate[] }
+  | { kind: "generating"; ageMs: number }
+  | { kind: "stale" }   // ready row past TTL — treat as miss, evict before re-claim
+  | { kind: "missing" };
+
+async function readCacheState(key: string): Promise<CacheState> {
+  if (!cacheAdminClient) return { kind: "missing" };
   try {
     const { data } = await cacheAdminClient
       .from("nugget_cache")
-      .select("nuggets, status")
+      .select("nuggets, status, created_at")
       .eq("track_id", key)
       .maybeSingle();
-    if (!data || data.status !== "ready") return null;
-    const updates = (data.nuggets as ArtistUpdate[] | null) ?? [];
-    return updates.length > 0 ? updates : null;
+    if (!data) return { kind: "missing" };
+
+    const ageMs = data.created_at
+      ? Date.now() - new Date(data.created_at as string).getTime()
+      : Infinity;
+
+    if (data.status === "generating") return { kind: "generating", ageMs };
+
+    if (data.status === "ready") {
+      if (ageMs > CACHE_TTL_MS) return { kind: "stale" };
+      const updates = (data.nuggets as ArtistUpdate[] | null) ?? [];
+      if (updates.length === 0) return { kind: "missing" };
+      return { kind: "ready", updates };
+    }
+
+    return { kind: "missing" };
   } catch (e) {
     console.warn("[artist-updates] cache read threw:", e);
-    return null;
+    return { kind: "missing" };
+  }
+}
+
+/**
+ * Wait for an in-flight generation (status='generating') to flip to
+ * 'ready'. Returns the generated updates, or null on timeout / eviction.
+ * Polled rather than push-notified because Supabase realtime would be
+ * over-engineering for a 1-2× per cache-miss event.
+ */
+async function waitForGeneration(key: string): Promise<ArtistUpdate[] | null> {
+  if (!cacheAdminClient) return null;
+  const start = Date.now();
+  while (Date.now() - start < POLL_TIMEOUT_MS) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    const state = await readCacheState(key);
+    if (state.kind === "ready") {
+      console.info(`[artist-updates] poll resolved for ${key} in ${Date.now() - start}ms`);
+      return state.updates;
+    }
+    if (state.kind === "missing" || state.kind === "stale") {
+      // Leader's row was evicted (rare — manual SQL delete or stale).
+      // Fall through to caller so they can claim + generate.
+      return null;
+    }
+    // 'generating' — keep waiting
+  }
+  console.warn(`[artist-updates] poll timed out for ${key} after ${POLL_TIMEOUT_MS}ms`);
+  return null;
+}
+
+/**
+ * Atomically try to claim the right to generate for `key`. Uses an
+ * INSERT (which fails on the unique track_id constraint if a row
+ * exists), so two concurrent callers can't both think they won.
+ *
+ * Caller is responsible for evicting any stale row first — we don't
+ * try to overwrite, because UPSERT would silently let a second
+ * "leader" through.
+ */
+async function tryClaim(key: string): Promise<boolean> {
+  if (!cacheAdminClient) return true; // No cache → degrade to "always generate"
+  const { error } = await cacheAdminClient.from("nugget_cache").insert({
+    track_id: key,
+    nuggets: [],
+    sources: {},
+    status: "generating",
+  });
+  if (error) {
+    // Postgres 23505 = unique_violation — expected when another caller
+    // already claimed. Anything else is a real failure; log and treat
+    // as "lost the claim" so we fall through to polling.
+    if (error.code !== "23505") {
+      console.warn("[artist-updates] tryClaim threw:", error);
+    }
+    return false;
+  }
+  return true;
+}
+
+async function evictStaleRow(key: string): Promise<void> {
+  if (!cacheAdminClient) return;
+  try {
+    await cacheAdminClient.from("nugget_cache").delete().eq("track_id", key);
+  } catch (e) {
+    console.warn("[artist-updates] evict threw:", e);
   }
 }
 
 async function writeToCache(key: string, updates: ArtistUpdate[]): Promise<void> {
   if (!cacheAdminClient || updates.length === 0) return;
   try {
+    // Explicitly set created_at so the TTL window resets when we
+    // regenerate a stale row. The column defaults to `now()` on INSERT
+    // only, so an upsert that hits the existing row would otherwise
+    // leave the original timestamp and the row would be stale forever
+    // after first refresh.
     await cacheAdminClient.from("nugget_cache").upsert(
-      { track_id: key, nuggets: updates, sources: {}, status: "ready" },
+      {
+        track_id: key,
+        nuggets: updates,
+        sources: {},
+        status: "ready",
+        created_at: new Date().toISOString(),
+      },
       { onConflict: "track_id" },
     );
   } catch (e) {
@@ -337,12 +603,58 @@ serve(async (req) => {
 
   const key = cacheKey(artist, tier);
 
-  // 1. Cache hit? Return the whole set.
-  const cached = await readFromCache(key);
-  if (cached) {
-    return new Response(JSON.stringify({ updates: cached, cached: true }), {
+  // 1. Cache state machine — picks one of:
+  //    - ready  → return cached
+  //    - generating (fresh) → poll for the leader's result; on timeout
+  //      / eviction, fall through to claim+generate ourselves
+  //    - generating (stale) → leader probably crashed; evict and claim
+  //    - stale  → ready row past TTL; evict and claim
+  //    - missing → claim and generate
+  //
+  //    The claim is an INSERT with track_id UNIQUE — atomic, so two
+  //    concurrent callers can't both win. The loser polls.
+  const initialState = await readCacheState(key);
+
+  if (initialState.kind === "ready") {
+    return new Response(JSON.stringify({ updates: initialState.updates, cached: true }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
+  }
+
+  if (initialState.kind === "generating" && initialState.ageMs < STALE_GENERATION_MS) {
+    console.info(`[artist-updates] ${artist} — joining in-flight generation`);
+    const polled = await waitForGeneration(key);
+    if (polled) {
+      return new Response(JSON.stringify({ updates: polled, cached: true }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    // Polling failed/timed out — fall through to evict + claim.
+  }
+
+  // Evict any stale row before attempting to claim. INSERT into
+  // existing track_id would fail with unique_violation; better to
+  // delete first so our claim succeeds.
+  if (initialState.kind === "stale" || initialState.kind === "generating") {
+    await evictStaleRow(key);
+  }
+
+  const claimed = await tryClaim(key);
+  if (!claimed) {
+    // Lost a tight race with another concurrent caller. Poll for
+    // their result rather than generating a duplicate.
+    console.info(`[artist-updates] ${artist} — lost claim race, polling for winner`);
+    const polled = await waitForGeneration(key);
+    if (polled) {
+      return new Response(JSON.stringify({ updates: polled, cached: true }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    // Worst case: poll timed out and we still need to respond. Fall
+    // through to generation. The duplicate write is benign — last
+    // writeToCache wins, both responses arrive at consistent data on
+    // any subsequent read.
+    console.warn(`[artist-updates] ${artist} — lost claim AND poll failed; generating anyway`);
   }
 
   // 2. Resolve artist on Spotify.
@@ -364,18 +676,35 @@ serve(async (req) => {
     });
   }
 
-  // 3. Run release lookup + fact generation in parallel to minimize
-  //    total latency for the user (cold-start overlap).
-  const [release, facts] = await Promise.all([
+  // 3. Sparse detection from Spotify's follower count. Below the
+  //    threshold we pull top tracks (for catalog grounding) and flip
+  //    the Gemini prompt into sparse-safe mode.
+  const followers = artistInfo.followers?.total ?? 0;
+  const isSparse = followers < SPARSE_FOLLOWER_THRESHOLD;
+
+  // 4. Fetch Spotify data in parallel (release always, top tracks
+  //    only when sparse), then feed into Gemini. Running top-tracks
+  //    alongside release keeps wall time flat even on the sparse
+  //    path — the sequencing penalty is only on facts-after-tracks.
+  const [release, topTracks] = await Promise.all([
     fetchRecentRelease(token, artistInfo.id),
-    generateArtistFacts(artistInfo.name, tier, FACTS_PER_ARTIST),
+    isSparse ? fetchArtistTopTracks(token, artistInfo.id) : Promise.resolve([] as SpotifyTopTrack[]),
   ]);
+
+  const facts = await generateArtistFacts({
+    artistName: artistInfo.name,
+    tier,
+    count: FACTS_PER_ARTIST,
+    sparse: isSparse,
+    genres: artistInfo.genres,
+    topTracks: isSparse ? topTracks : undefined,
+  });
 
   const releaseAgeDays = release ? daysSince(release.release_date) : null;
   console.log(
-    `[artist-updates] ${artistInfo.name} → release=${
+    `[artist-updates] ${artistInfo.name} (followers=${followers}${isSparse ? ", SPARSE" : ""}) → release=${
       release ? `${release.name} (${releaseAgeDays}d)` : "none"
-    }, facts=${facts.length}`,
+    }, facts=${facts.length}, topTracks=${topTracks.length}`,
   );
 
   const updates: ArtistUpdate[] = [];

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -55,6 +55,10 @@ interface ArtistUpdate {
   kind: "new-release" | "collab" | "fact";
   headline: string;
   body: string;
+  /** Track-level metadata for new-release/collab kinds — lets the client
+   *  build a /listen/ route that the Spotify SDK can actually play. */
+  relatedTrackTitle?: string;
+  relatedAlbumName?: string;
   source?: {
     type: string;
     title?: string;
@@ -88,6 +92,11 @@ interface SpotifyReleaseItem {
   artists: { id: string; name: string }[];
   external_urls?: { spotify: string };
   images?: { url: string }[];
+  // Populated by fetchRecentRelease's secondary call to /albums/:id/tracks.
+  // Present iff the call succeeded; client navigates to the artist page as
+  // a fallback when these are missing.
+  firstTrackUri?: string;
+  firstTrackName?: string;
 }
 
 // ── Module-level admin client for cache upsert ────────────────────────
@@ -150,7 +159,33 @@ async function fetchRecentRelease(
   // Spotify's default ordering is already most-recent-first but we sort
   // defensively so a market variance can't surface an older release.
   items.sort((a, b) => (a.release_date < b.release_date ? 1 : -1));
-  return items[0];
+  const release = items[0];
+
+  // Grab the first track of the release. The album-level URI
+  // (`spotify:album:…`) can't be played via Spotify's `uris` array
+  // (that endpoint only takes track URIs), so the Listen route would
+  // open with a playable-looking URI and silently fail to start
+  // playback. Track-level URI gives Listen something it can actually
+  // hand to the Web Playback SDK.
+  try {
+    const tracksRes = await fetch(
+      `https://api.spotify.com/v1/albums/${release.id}/tracks?limit=1&market=US`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (tracksRes.ok) {
+      const tracksData = await tracksRes.json();
+      const firstTrack = tracksData?.items?.[0];
+      if (firstTrack?.uri && firstTrack?.name) {
+        release.firstTrackUri = firstTrack.uri;
+        release.firstTrackName = firstTrack.name;
+      }
+    }
+  } catch (e) {
+    console.warn("[artist-updates] album-tracks fetch failed:", e);
+    // Fall through — we'll still return the release without track info.
+    // The client falls back to artist-page navigation in that case.
+  }
+  return release;
 }
 
 function daysSince(isoDate: string): number {
@@ -187,6 +222,11 @@ function buildReleaseUpdate(
     (release.images?.[0]?.url) ??
     (artist.images?.[0]?.url) ??
     "";
+  // Prefer the album's first track URI for navigation; fall back to the
+  // album URI (which won't actually play, but at least the client can
+  // detect the missing track signal and route to the artist page).
+  const navUri = release.firstTrackUri ?? release.uri;
+  const navTitle = release.firstTrackName ?? release.name;
   return {
     artistId: artist.id,
     artistName: artist.name,
@@ -200,7 +240,9 @@ function buildReleaseUpdate(
       publisher: "Spotify",
       url: release.external_urls?.spotify,
     },
-    relatedTrackUri: release.uri,
+    relatedTrackUri: navUri,
+    relatedTrackTitle: navTitle,
+    relatedAlbumName: release.name,
     nuggetId: `release-${release.id}`,
   };
 }

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -705,6 +705,9 @@ serve(async (req) => {
     token = await getSpotifyAppToken();
   } catch (e) {
     console.error("[artist-updates] Spotify token unavailable:", e);
+    // Release the sentinel — followers shouldn't poll forever on a
+    // transient Spotify-token failure.
+    await evictStaleRow(key);
     return new Response(JSON.stringify({ error: "spotify unavailable" }), {
       status: 502,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -713,6 +716,10 @@ serve(async (req) => {
 
   const artistInfo = await searchArtist(token, artist);
   if (!artistInfo) {
+    // Release the sentinel — this artist is unresolvable on Spotify, no
+    // amount of polling will produce a ready row. Followers should give
+    // up immediately on the next poll cycle.
+    await evictStaleRow(key);
     return new Response(JSON.stringify({ updates: [], reason: "artist-not-found" }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
@@ -761,7 +768,13 @@ serve(async (req) => {
   });
 
   if (updates.length === 0) {
-    // Couldn't compose anything — don't cache; let a retry try again.
+    // Couldn't compose anything (sparse artist + Gemini returned 0
+    // facts, no recent release). We claimed the sentinel earlier via
+    // tryClaim() — must release it now so concurrent followers don't
+    // sit in waitForGeneration polling for a row that's never going
+    // to flip to 'ready'. Without this they'd timeout after 95s and
+    // re-claim+re-fail in a thundering loop.
+    await evictStaleRow(key);
     return new Response(JSON.stringify({ updates: [], reason: "compose-failed" }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -3302,16 +3302,41 @@ Return ONLY valid JSON:
               const prevHeadlines = [...safePreviousNuggets];
               const generatedHeadlines: string[] = [];
 
-              // ── Step 3: Define the 3 nugget kinds ──
-              // Focus strings come directly from TIER_CONFIG. Each is an evidence-
-              // palette with a selection rule — Gemini picks the strongest angle
-              // the research supports, pivoting when data is thin. Constitution
-              // rules 3/4 remain the global fabrication guard.
-              const nuggetDefs = [
+              // ── Step 3: Define the nugget kinds ──
+              // Tier-scaled output:
+              //   casual = 3 (1 artist, 1 track, 1 discovery)
+              //   curious = 6 (2 artist, 2 track, 2 discovery)
+              //   nerd = 9 (3 artist, 3 track, 3 discovery)
+              // Each kind generates sequentially; subsequent same-kind
+              // nuggets see prior `generatedHeadlines` in the
+              // nonRepeat block, so Gemini picks a different angle.
+              // Cost: more calls = longer wall time at higher tiers,
+              // but SSE streams nuggets as they land so the user sees
+              // the first appear quickly.
+              const NUGGETS_PER_KIND: Record<Tier, number> = {
+                casual: 1,
+                curious: 2,
+                nerd: 3,
+              };
+              const perKind = NUGGETS_PER_KIND[tier];
+              const baseDefs = [
                 { kind: "artist", focus: tierConfig.artistFocus, listenFor: false, includeArtistSummary: true },
                 { kind: "track", focus: tierConfig.trackFocus, listenFor: true, includeArtistSummary: false },
                 { kind: "discovery", focus: tierConfig.discoveryFocus, listenFor: false, includeArtistSummary: false },
               ];
+              // Expand per kind, tagging variant index so the prompt can
+              // ask for a distinct angle on the second/third pass.
+              // Only the FIRST artist-kind def carries includeArtistSummary
+              // so we don't generate the bio block N times per call.
+              const nuggetDefs = baseDefs.flatMap((d, baseIdx) =>
+                Array.from({ length: perKind }, (_, variantIdx) => ({
+                  ...d,
+                  variantIdx,
+                  variantTotal: perKind,
+                  baseIdx, // stable citation-group anchor (artist=0, track=1, discovery=2)
+                  includeArtistSummary: d.includeArtistSummary && variantIdx === 0,
+                })),
+              );
 
               let streamedIndex = 0;
               const streamedNuggets: any[] = [];
@@ -3346,7 +3371,7 @@ SOURCES: Match facts to [CIT N] citations via "citIndex". Do not invent URLs.
 ${nonRepeat}
 
 TASK: Generate exactly ONE "${def.kind}" nugget.
-Focus: ${def.focus}
+${def.variantTotal > 1 ? `This is "${def.kind}" nugget #${def.variantIdx + 1} of ${def.variantTotal} for this listen — pick a DIFFERENT angle from the prior ${def.kind} nugget(s) above. No two ${def.kind} nuggets should overlap in subject, citation source, or framing. If the research only supports one strong ${def.kind} angle, return a nugget that pivots to an adjacent verifiable detail rather than padding the same story.\n` : ""}Focus: ${def.focus}
 listenFor: ${def.listenFor}
 ${def.kind === "discovery" ? `HONESTY RULE: Only claim a connection you can verify from the research. Do NOT recommend artists sharing any part of ${artist}'s name.` : ""}
 ${def.includeArtistSummary ? `\nAlso generate "artistSummary": 2-3 punchy sentences about ${artist}.` : ""}
@@ -3442,13 +3467,26 @@ Return ONLY valid JSON:
                   continue;
                 }
 
+                // Force kind to match what we asked for. Each per-kind
+                // prompt explicitly says `kind: "${def.kind}"` in the
+                // JSON template, but Gemini occasionally drifts (returns
+                // "track" when asked for "context", etc). Without this,
+                // tier-scaled outputs (curious=6, nerd=9) would have no
+                // safety net since the batch-path kind-fix block only
+                // covers slots 0/1/2.
+                if (nuggetData.kind !== def.kind) {
+                  console.log(`[SSE KindFix] ${def.kind}#${def.variantIdx + 1}: "${nuggetData.kind}" → "${def.kind}"`);
+                  nuggetData.kind = def.kind;
+                }
+
                 const headlineForHistory = nuggetData.headline || nuggetData.text;
                 if (headlineForHistory) generatedHeadlines.push(headlineForHistory);
 
                 // ── Image: Exa first (instant), Wikipedia fallback ──
-                // Use defIdx (not streamedIndex) so citation grouping stays
-                // aligned even when earlier nuggets are skipped by validation.
-                resolveExaImageForNugget(nuggetData, defIdx, exaCitationsStrict, usedImageUrls);
+                // Use baseIdx (kind anchor: artist=0, track=1, discovery=2)
+                // so citation grouping stays aligned across tier-scaled
+                // expansions where multiple nuggetDefs share a kind.
+                resolveExaImageForNugget(nuggetData, def.baseIdx, exaCitationsStrict, usedImageUrls);
                 if (!nuggetData._resolvedImageUrl && isValidImageQuery(nuggetData.imageSearchQuery)) {
                   try {
                     const wikiResult = await resolveNuggetImage(nuggetData.imageSearchQuery!);

--- a/supabase/functions/spotify-taste/index.ts
+++ b/supabase/functions/spotify-taste/index.ts
@@ -34,10 +34,15 @@ serve(async (req) => {
 
     const authHeader = { Authorization: `Bearer ${accessToken}` };
 
-    // Parallel: top artists (medium ~6mo + short ~4wk) and top tracks
+    // Parallel: top artists (medium ~6mo + short ~4wk) and top tracks.
+    // Limits are sized to what Browse actually renders:
+    //   - 3 artists are shown in "Your artists, lately" (ArtistUpdatesSection)
+    //   - The remaining ≤5 are only used as seeds for lastfm-recommendations
+    //   - Tracks drive the "Your Top Tracks" rail (first 15)
+    // Fetching 20 artists previously meant ~12 were cold ballast.
     const [artistsMediumRes, artistsShortRes, tracksMediumRes, profileRes] = await Promise.all([
-      fetch("https://api.spotify.com/v1/me/top/artists?limit=20&time_range=medium_term", { headers: authHeader }),
-      fetch("https://api.spotify.com/v1/me/top/artists?limit=10&time_range=short_term", { headers: authHeader }),
+      fetch("https://api.spotify.com/v1/me/top/artists?limit=10&time_range=medium_term", { headers: authHeader }),
+      fetch("https://api.spotify.com/v1/me/top/artists?limit=5&time_range=short_term", { headers: authHeader }),
       fetch("https://api.spotify.com/v1/me/top/tracks?limit=20&time_range=medium_term", { headers: authHeader }),
       fetch("https://api.spotify.com/v1/me", { headers: authHeader }),
     ]);
@@ -89,7 +94,10 @@ serve(async (req) => {
         .map((a: any) => a.name as string),
     ];
 
-    const topArtists = [...new Set(allArtists)].slice(0, 20);
+    // Cap at 8 artists: first 3 drive the Browse artist-row, remaining
+    // 5 seed Last.fm similar-artist recommendations. More than 8 seeds
+    // doesn't meaningfully improve recommendation quality.
+    const topArtists = [...new Set(allArtists)].slice(0, 8);
 
     // Build artist images object: { "Artist Name": "https://..." }
     const artistImages: Record<string, string> = {};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,6 +63,12 @@ export default {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      fontFamily: {
+        // Used by overlay/splash headlines (SpotifySyncingOverlay,
+        // PreparingExperience). Falls back through the system stack so
+        // missing-Nunito-Sans renders cleanly on iOS / older devices.
+        nunito: ["'Nunito Sans'", "system-ui", "-apple-system", "sans-serif"],
+      },
       keyframes: {
         "accordion-down": {
           from: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,11 +11,13 @@ export default defineConfig(({ mode }) => ({
     hmr: {
       overlay: false,
     },
-    // Allow ngrok tunnels for mobile testing. ".ngrok-free.app" and
-    // ".ngrok.app" cover the free + paid tunnel domains. Each ngrok
-    // restart picks a new subdomain, so a wildcard is the only way to
-    // avoid editing this file every session.
-    allowedHosts: [".ngrok-free.app", ".ngrok.app"],
+    // Allow ngrok tunnels for mobile testing — DEV ONLY. allowedHosts
+    // is a dev-server-only Vite option (no effect on `vite build`),
+    // but gating by mode keeps intent explicit so reading the config
+    // doesn't suggest a wider production trust surface.
+    ...(mode === "development"
+      ? { allowedHosts: [".ngrok-free.app", ".ngrok.app"] }
+      : {}),
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig(({ mode }) => ({
     hmr: {
       overlay: false,
     },
+    // Allow ngrok tunnels for mobile testing. ".ngrok-free.app" and
+    // ".ngrok.app" cover the free + paid tunnel domains. Each ngrok
+    // restart picks a new subdomain, so a wildcard is the only way to
+    // avoid editing this file every session.
+    allowedHosts: [".ngrok-free.app", ".ngrok.app"],
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {


### PR DESCRIPTION
## Summary

Background refresh cascade for taste + artist-updates, plus visible loading
states. Tier-scaled per-listen nugget output (3/6/9). Grounded artist facts
via Google Search. Concurrent-safe artist-updates cache. Release cards open
the track. TV focus glow suppressed on touch.

### Refresh cascade
- New `useBackgroundTasteRefresh` mounted at app level. 24h TTL on
  `profile.tasteRefreshedAt`; silent re-pull of Spotify taste when stale.
  Returning users no longer get a frozen library snapshot.
- `artist-updates` server-side TTL = 7d. Stale rows treated as miss and
  regenerated.
- Sentinel-based concurrency guard in `artist-updates`. Atomic INSERT on
  unique `track_id` claims the right to generate; concurrent followers poll
  for the leader's result. Eliminates the Browse-vs-ArtistProfile race that
  produced two different facts for the same artist. All early-exit paths
  (compose-failed, spotify-token-error, artist-not-found) release the
  sentinel via `evictStaleRow()` so followers don't hang for 90s.

### Nugget pipeline
- `generate-nuggets` SSE path now produces tier-scaled output:
  casual=3, curious=6, nerd=9 nuggets per listen (1/2/3 of each kind).
  Per-variant prompt asks Gemini for a different angle than prior same-kind
  nuggets in the same call.
- Per-nugget kind override after parse — guards against Gemini drifting on
  the requested kind.
- Early-cancel on Listen: when ≥4 nuggets received and ≤45s remain on the
  current track, `reader.cancel()` stops the stream and writes the partial
  set as the canonical cache row. Saves ~5-30s of Gemini per Curious/Nerd
  cold listen. `currentTimeRef` + `isPlayingRef` mirror live playback state
  so the SSE loop reads current values, not stale closures.
- Cache-key URL-encoding fix in `canonicalCacheKey()` — server writes
  decoded artist/title/uri, client previously read encoded. Tracks with
  spaces / special chars now hit cache instead of re-running the full
  ~30s pipeline on every Listen mount.

### Artist-updates
- Google Search grounding on the Gemini facts call. Sparse-data artists
  now get web-grounded facts instead of catalog-only observations. Prompt
  locks the artist reference to the canonical stage name so grounding
  can't mid-fact introduce a legal/birth name.
- Edge function resolves the album's first track URI via
  `/albums/:id/tracks` so release cards expose a Spotify-playable track URI
  (`spotify:track:…`), not the album URI which Spotify's play API rejects.
- Release cards in Browse now route to `/listen/` for the track instead of
  the artist profile. Falls back to artist deep-link when track resolution
  fails server-side.

### UX polish
- Connect gate uses `<Navigate>` short-circuit for users with a cached
  profile, avoiding the AnimatePresence transition stall that left Connect
  rendered on the next URL.
- Connect redirect param sanitized via `sanitizeRedirect` (extracted to
  `src/lib/routeUtils.ts`). Rejects /, /connect, /preparing*, and now also
  rejects protocol-relative (`//evil.com`), absolute (`https://...`), and
  `javascript:` URLs — closes the open-redirect window.
- /preparing splash redesigned to match the SpotifySyncingOverlay treatment
  (aurora + cycling status + gradient progress). Only blocks on
  artist-updates readiness; stories continue loading on Browse.
- New `GlobalRefreshIndicator` (top 2px shimmer + label) when taste or
  artist-updates is refreshing in the background. Suppressed on /preparing
  where the splash already shows progress.
- Browse TV-focus glow no longer pinned to the first tile on touch — new
  `kbNavActive` state stays false until an arrow key is pressed.

### Product decisions worth flagging
- **`DEFAULT_MAX_ARTISTS = 1`** in `useArtistUpdates.ts`. The Browse
  "Your artists, lately" rail intentionally renders one artist row, not
  three. This is the current product target — see the inline comment for
  history (5→3→1) and rationale. **Not a test knob; do not revert.**

## Test plan
- [ ] Sign out → sign in with Spotify → land on /preparing briefly → /browse
- [ ] On /browse with stale taste, top shimmer bar appears + console shows
  `[bg-taste-refresh] start` (DEV builds only)
- [ ] Tap fresh track on Listen, verify per-tier nugget count (3/6/9)
- [ ] Sit on a track until ≤45s remain; console: `[SSE] early-complete`
- [ ] `DELETE FROM nugget_cache WHERE track_id LIKE 'artist::%'`, load
  Browse + ArtistProfile in two tabs simultaneously — both show identical
  fact (sentinel guard prevents the race)
- [ ] Tap a NEW RELEASE card on Browse — should open /listen/ for the
  released track, not the artist profile
- [ ] Mobile: scroll through Top Tracks rail — no glow stuck on first tile
- [ ] `npm test && npm run build` clean