### PR TITLE
docs(artist-updates): document SUPABASE env-var migration state

### DIFF
--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -102,6 +102,21 @@ interface SpotifyReleaseItem {
 // ── Module-level admin client for cache upsert ────────────────────────
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+// Migration note (verified 2026-04-30 via diagnostic deploy):
+//   - SUPABASE_SECRET_KEY (singular) is NOT auto-injected by Supabase.
+//     The team's pattern below treats it as the migration target —
+//     once we generate a service-role JWT signed via JWT Signing Keys
+//     and stash it under this name (`supabase secrets set
+//     SUPABASE_SECRET_KEY=<jwt>`), this lookup picks it up
+//     transparently with no code change needed.
+//   - SUPABASE_SERVICE_ROLE_KEY is what's actually resolving today.
+//     Supabase has marked it deprecated in the dashboard ("use
+//     SUPABASE_SECRET_KEYS instead"); when they remove it we MUST
+//     have set the singular SECRET_KEY first or this client goes
+//     null and the sentinel concurrency guard silently degrades.
+//   - SUPABASE_SECRET_KEYS (plural, new) is a JSON blob of JWT
+//     signing-key metadata, NOT a usable service-role token. We
+//     can't fall back to it without a JWT-signing step.
 const SUPABASE_ADMIN_KEY =
   Deno.env.get("SUPABASE_SECRET_KEY") ??
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ??


### PR DESCRIPTION
## Summary

Follow-up to PR #78 review: a reviewer flagged the \`SUPABASE_ADMIN_KEY\` fallback chain in \`artist-updates\` and asked us to verify the env var matches production secrets. **Verified — no code change needed**, but the situation warrants an inline migration note.

## Verified state (diagnostic deploy 2026-04-30)

| Env var | Status | Notes |
|---|---|---|
| \`SUPABASE_SECRET_KEYS\` (plural, new) | Present | **JSON blob** (58 chars, starts with \`{\`) of JWT signing-key metadata. NOT a usable service-role token. |
| \`SUPABASE_SECRET_KEY\` (singular, what code looks for) | **NOT set** | Migration target. \`supabase secrets set SUPABASE_SECRET_KEY=<jwt>\` will activate it without code change. |
| \`SUPABASE_SERVICE_ROLE_KEY\` (legacy) | Present | What resolves today. Dashboard-marked **DEPRECATED**. |

## Risk

When Supabase removes \`SUPABASE_SERVICE_ROLE_KEY\` (already deprecated), every edge function in this project that uses the \`SECRET_KEY ?? SERVICE_ROLE_KEY\` pattern will break unless we've set \`SUPABASE_SECRET_KEY\` (singular) first.

That includes: \`artist-updates\`, \`seed-nuggets\`, \`bookmark-nugget\`, \`generate-nuggets\`, \`spotify-artist\`, \`generate-companion\`, \`lastfm-sync\`. **Project-wide, not specific to this PR.**

## Migration plan (when needed)

1. Generate a service-role JWT signed via the JWT signing keys in \`SUPABASE_SECRET_KEYS\`.
2. Run: \`supabase secrets set SUPABASE_SECRET_KEY=<that JWT>\`.
3. Existing code picks it up automatically — no deploy needed beyond the secret update.

This PR just adds an inline comment block in \`artist-updates/index.ts\` so the next person reading this isn't lost when the deprecation lands.

## Test plan
- [ ] No behavior change — comment-only addition
- [ ] Inline note correctly references the actual env var names found via \`supabase secrets list\`