### PR TITLE
Release: bug-bash UX fixes (Listen, Browse, stories pre-gen, artist-updates research)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { PlayerProvider } from "./contexts/PlayerContext";
 import { StoriesProvider } from "./contexts/StoriesContext";
 import { ArtistUpdatesProvider } from "./contexts/ArtistUpdatesContext";
+import { TierGateProvider } from "./contexts/TierGateContext";
 import NowPlayingBar from "./components/NowPlayingBar";
 import SpotifyReconnectBanner from "./components/SpotifyReconnectBanner";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -86,8 +87,9 @@ const App = () => (
       <BrowserRouter>
         <AuthProvider>
           <PlayerProvider>
-            <StoriesProvider>
-              <ArtistUpdatesProvider>
+            <TierGateProvider>
+              <StoriesProvider>
+                <ArtistUpdatesProvider>
                 <RefreshIndicatorProvider>
                   <ErrorBoundary fallback={
                     <div className="min-h-screen bg-background flex items-center justify-center p-6">
@@ -109,8 +111,9 @@ const App = () => (
                     <GlobalRefreshIndicator />
                   </ErrorBoundary>
                 </RefreshIndicatorProvider>
-              </ArtistUpdatesProvider>
-            </StoriesProvider>
+                </ArtistUpdatesProvider>
+              </StoriesProvider>
+            </TierGateProvider>
           </PlayerProvider>
         </AuthProvider>
       </BrowserRouter>

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -53,19 +53,28 @@ function ArtistUpdatesSectionInner({
 
   function openArtistAtNugget(update: ArtistUpdate) {
     // New-release / collab cards: tap should land on Listen for the
-    // released track, not the artist profile. Requires a track-level
-    // URI (Spotify's playback API rejects album URIs in `uris`); the
-    // edge function populates `relatedTrackTitle` only when it
-    // successfully resolved the album's first track.
+    // released track, not the artist profile. We need at minimum a
+    // track-level title from the edge function (set only when it
+    // successfully resolved the album's first track via Spotify).
+    //
+    // Service-aware URI handling:
+    //   - Spotify users: bake the spotify:track: URI into the route
+    //     so Listen plays instantly without a catalog re-lookup.
+    //   - Apple Music users: omit the URI so Listen's findCatalogUri
+    //     effect resolves the Apple equivalent via {artist, title}.
+    //     Passing the Spotify URI directly would lock Listen into a
+    //     URI Apple Music can't play.
     if (
       (update.kind === "new-release" || update.kind === "collab") &&
-      update.relatedTrackUri &&
-      update.relatedTrackTitle &&
-      update.relatedTrackUri.startsWith("spotify:track:")
+      update.relatedTrackTitle
     ) {
       const album = update.relatedAlbumName ?? "";
+      const isAppleUser = profile?.streamingService === "Apple Music";
+      const hasSpotifyTrackUri =
+        !!update.relatedTrackUri && update.relatedTrackUri.startsWith("spotify:track:");
+      const navUri = !isAppleUser && hasSpotifyTrackUri ? update.relatedTrackUri! : "";
       navigate(
-        `/listen/real::${encodeURIComponent(update.artistName)}::${encodeURIComponent(update.relatedTrackTitle)}::${encodeURIComponent(album)}::${encodeURIComponent(update.relatedTrackUri)}`,
+        `/listen/real::${encodeURIComponent(update.artistName)}::${encodeURIComponent(update.relatedTrackTitle)}::${encodeURIComponent(album)}::${encodeURIComponent(navUri)}`,
       );
       return;
     }

--- a/src/components/NuggetCard.tsx
+++ b/src/components/NuggetCard.tsx
@@ -207,11 +207,15 @@ export default function NuggetCard({ nugget, animationStyle, onSourceClick, curr
               </motion.div>
             )}
 
-            {/* Nugget headline */}
+            {/* Nugget headline. Capped at 3 lines so a long headline
+                doesn't push the card's bottom edge into the playback
+                bar's timeline (which renders marker dots that visually
+                overlap the lower lines). The expanded body view from
+                "Tell me more" already shows the full text. */}
             <motion.p
               initial={{ opacity: 0 }}
               animate={{ opacity: 1, transition: { delay: animationStyle === "B" ? 0.5 : 0.4, duration: 0.3 } }}
-              className="text-base md:text-lg leading-7 text-foreground/90"
+              className="text-base md:text-lg leading-7 text-foreground/90 line-clamp-3"
             >
               {nugget.headline || nugget.text}
             </motion.p>

--- a/src/contexts/ArtistUpdatesContext.tsx
+++ b/src/contexts/ArtistUpdatesContext.tsx
@@ -4,6 +4,7 @@ import {
   useArtistUpdates,
   type ArtistUpdateGroup,
 } from "@/hooks/useArtistUpdates";
+import { useTierGate } from "@/contexts/TierGateContext";
 
 /**
  * Hoists the "Your artists, lately" fetch above the route tree so
@@ -40,8 +41,14 @@ const ArtistUpdatesContext = createContext<ArtistUpdatesContextValue>({
 
 export function ArtistUpdatesProvider({ children }: { children: ReactNode }) {
   const { profile } = useUserProfile();
+  const { tierConfirmed } = useTierGate();
   const tier = (profile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
-  const { groups, loading, totalCount, readyCount } = useArtistUpdates(profile, { tier });
+  // Mirror StoriesProvider: hold off on the artist-updates fan-out until
+  // the user has confirmed tier this session, so the warm-up runs at the
+  // right tier and we don't burn Gemini at the previously-persisted tier
+  // when the user intends to switch on this login.
+  const profileForUpdates = tierConfirmed ? profile : null;
+  const { groups, loading, totalCount, readyCount } = useArtistUpdates(profileForUpdates, { tier });
   return (
     <ArtistUpdatesContext.Provider value={{ groups, loading, totalCount, readyCount }}>
       {children}

--- a/src/contexts/StoriesContext.tsx
+++ b/src/contexts/StoriesContext.tsx
@@ -1,11 +1,17 @@
 import { createContext, useContext, type ReactNode } from "react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { usePreGeneratedStories, type Story } from "@/hooks/usePreGeneratedStories";
+import { useTierGate } from "@/contexts/TierGateContext";
 
 // Stories state lives here instead of in Browse so pre-generation starts the
 // moment the user's profile is hydrated — not when they navigate to Browse.
 // This closes the window where onboarding finishes but stories haven't begun
 // warming, which was the source of "I got to Browse and the rings were gray."
+//
+// TierGate: Pete asked for a tier-pick step on every login, BEFORE we burn
+// Gemini calls warming stories at whatever tier was last persisted. We pass
+// `null` to usePreGeneratedStories (which no-ops gracefully) until the user
+// has confirmed tier this session — that gating happens on /preparing.
 interface StoriesContextValue {
   stories: Story[];
   loading: boolean;
@@ -15,10 +21,13 @@ const StoriesContext = createContext<StoriesContextValue>({ stories: [], loading
 
 export function StoriesProvider({ children }: { children: ReactNode }) {
   const { profile } = useUserProfile();
+  const { tierConfirmed } = useTierGate();
   const tier = (profile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
-  // usePreGeneratedStories no-ops gracefully when profile is null, so we can
-  // mount the provider unconditionally above the protected routes.
-  const { stories, loading } = usePreGeneratedStories(profile, { tier });
+  // Pass `null` profile until tier-gate clears, which suppresses pre-gen.
+  // The hook is built to no-op on null, so this also covers the
+  // pre-onboarding window before profile exists.
+  const profileForPreGen = tierConfirmed ? profile : null;
+  const { stories, loading } = usePreGeneratedStories(profileForPreGen, { tier });
   return (
     <StoriesContext.Provider value={{ stories, loading }}>
       {children}

--- a/src/contexts/TierGateContext.tsx
+++ b/src/contexts/TierGateContext.tsx
@@ -1,0 +1,101 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { useUserProfile } from "@/hooks/useMusicNerdState";
+import type { UserProfile } from "@/mock/types";
+
+/**
+ * Per-session "tier confirmed for this login" flag.
+ *
+ * Why: Pete's ask — "I should be able to pick my tier every time I log in,
+ * and stories / artist-updates should NOT start warming up until I've
+ * confirmed it." Stories pre-gen and artist-updates fan-out are both
+ * expensive Gemini calls keyed off tier; if the user wants to switch tier
+ * on login, kicking off warm-up at the OLD tier wastes the budget and
+ * delays the new-tier results.
+ *
+ * Backed by sessionStorage so the flag clears when the tab closes (a
+ * fresh login is required to set it again). localStorage would persist
+ * across sessions, which defeats the "every time I log in" requirement.
+ *
+ * The flag is *gates pre-gen*, not navigation. Returning users still land
+ * on /preparing after sign-in; /preparing renders a tier-pick UI when
+ * `tierConfirmed === false`, then transitions to the warmup spinner once
+ * the user confirms.
+ */
+
+const STORAGE_KEY = "musicnerd_tier_confirmed";
+
+interface TierGateContextValue {
+  tierConfirmed: boolean;
+  confirmTier: (tier: NonNullable<UserProfile["calculatedTier"]>) => void;
+  resetTierConfirmation: () => void;
+}
+
+const TierGateContext = createContext<TierGateContextValue>({
+  tierConfirmed: false,
+  confirmTier: () => {},
+  resetTierConfirmation: () => {},
+});
+
+function readSessionFlag(): boolean {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    // Storage disabled — degrade to "always require confirmation".
+    return false;
+  }
+}
+
+export function TierGateProvider({ children }: { children: ReactNode }) {
+  const { profile, saveProfile } = useUserProfile();
+  const [tierConfirmed, setTierConfirmed] = useState<boolean>(() => readSessionFlag());
+
+  // Sync flag across tabs / late-mounting consumers via a custom event.
+  // sessionStorage doesn't fire `storage` events for same-document writes,
+  // so we dispatch our own.
+  useEffect(() => {
+    function onConfirmEvent() {
+      setTierConfirmed(readSessionFlag());
+    }
+    window.addEventListener("musicnerd:tier-confirmed", onConfirmEvent);
+    return () => window.removeEventListener("musicnerd:tier-confirmed", onConfirmEvent);
+  }, []);
+
+  const confirmTier = useCallback(
+    (tier: NonNullable<UserProfile["calculatedTier"]>) => {
+      // Persist the tier choice into the user's profile if it changed,
+      // so a change-and-confirm flow on /preparing actually updates the
+      // tier (otherwise the next page would still see the old tier).
+      if (profile && profile.calculatedTier !== tier) {
+        saveProfile({ ...profile, calculatedTier: tier });
+      }
+      try {
+        sessionStorage.setItem(STORAGE_KEY, "1");
+      } catch {
+        // Storage disabled — fall through; in-memory state still flips.
+      }
+      setTierConfirmed(true);
+      window.dispatchEvent(new Event("musicnerd:tier-confirmed"));
+    },
+    [profile, saveProfile],
+  );
+
+  const resetTierConfirmation = useCallback(() => {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Storage disabled — fall through.
+    }
+    setTierConfirmed(false);
+    window.dispatchEvent(new Event("musicnerd:tier-confirmed"));
+  }, []);
+
+  return (
+    <TierGateContext.Provider value={{ tierConfirmed, confirmTier, resetTierConfirmation }}>
+      {children}
+    </TierGateContext.Provider>
+  );
+}
+
+export function useTierGate(): TierGateContextValue {
+  return useContext(TierGateContext);
+}

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -289,6 +289,11 @@ export function useAINuggets(
     setError(null);
     // true once we own the 'generating' sentinel; reset to false after cache write succeeds
     let sentinelClaimed = false;
+    // Hoisted so the catch block's cache-fallback can read the latest
+    // listen count when SSE fails (the deeper-tier path skips the cache
+    // check; on failure we want to recover with whatever cached row
+    // exists, regardless of which listen the user is on).
+    let currentListenCount = 1;
     // Tier-scoped key for nugget_cache DB table — different tiers get
     // different cached nuggets. We blank the album slot so that different
     // entry points to the same track (story rail with empty album, tile /
@@ -315,7 +320,10 @@ export function useAINuggets(
       })();
 
       // ── Listen history ────────────────────────────────────────────
-      let currentListenCount = 1;
+      // currentListenCount declared above (outside try) so the catch's
+      // fallback can use it. Reset to default in case a previous
+      // generate() run left a stale value in scope.
+      currentListenCount = 1;
       let previousNuggets: string[] = [];
 
       const { data: historyRow } = await supabase
@@ -884,7 +892,40 @@ export function useAINuggets(
       // AbortError is intentional (user skipped track) — don't surface it
       if (e instanceof DOMException && e.name === "AbortError") return;
       console.error("AI nugget generation failed:", e);
+
+      // FALLBACK: try the canonical cache row even though `currentListenCount`
+      // gated us out of using it earlier. The repeat-listen flow normally
+      // skips cache to force a fresh deeper-tier generation, but if the
+      // generation fails (network, edge timeout, 5xx) we'd otherwise leave
+      // the user staring at cover art with zero nuggets — when there's a
+      // perfectly good listen-1 cache row sitting in the DB. The deeper-
+      // tier content is "nice to have"; cached nuggets are the safety net.
       if (!cancelledRef.current) {
+        try {
+          const { data: fallback } = await supabase
+            .from("nugget_cache")
+            .select("nuggets, sources, status")
+            .eq("track_id", dbCacheKey)
+            .maybeSingle();
+          const fbNuggets = fallback?.status === "ready"
+            ? (fallback.nuggets as Nugget[] | null) ?? []
+            : [];
+          if (fbNuggets.length > 0) {
+            console.warn(`[useAINuggets] SSE failed; falling back to cached nuggets (${fbNuggets.length}) for ${dbCacheKey}`);
+            const sanitized = fbNuggets.map(sanitizeNugget);
+            const fbSources = new Map<string, Source>();
+            const rawSources = (fallback!.sources ?? {}) as Record<string, Source>;
+            for (const [k, v] of Object.entries(rawSources)) fbSources.set(k, v);
+            setNuggets(sanitized);
+            setSources(fbSources);
+            setNuggetCache(cacheKey, { nuggets: sanitized, sources: fbSources, listenCount: currentListenCount });
+            setError(null);
+            // Don't fall through to error / sentinel cleanup — we recovered.
+            return;
+          }
+        } catch (fbErr) {
+          console.warn("[useAINuggets] cache fallback lookup threw:", fbErr);
+        }
         setError(e instanceof Error ? e.message : "Unknown error");
       }
       // Remove the 'generating' sentinel so waiting clients don't poll indefinitely.

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -96,11 +96,26 @@ function makeSource(id: string, s: AINuggetData["source"]): Source {
 }
 
 export function makeTimestamp(index: number, totalNuggets: number, durationSec: number) {
-  const earlyStart = 20;
+  // Nugget timestamps are reveal-times during playback. Three constraints:
+  //   1. First nugget pinned at `earlyStart` so the user sees content
+  //      almost immediately when the song starts (Pete's UX: "tap a
+  //      story, song plays, I'm displayed with the first nugget I
+  //      found"). Previously the first nugget landed at `earlyStart +
+  //      spacing` ≈ 49s into a 4-min Curious-tier listen — long enough
+  //      to look like nothing was happening even when cache was hit.
+  //   2. Last nugget pinned at `durationSec - endBuffer` so the user
+  //      doesn't lose the final beat to a nugget appearing in the last
+  //      few seconds of the track.
+  //   3. Middle nuggets distributed evenly between.
+  const earlyStart = 3;
   const endBuffer = 15;
   const usable = Math.max(durationSec - earlyStart - endBuffer, 30);
-  const spacing = usable / (totalNuggets + 1);
-  return Math.min(Math.floor(earlyStart + spacing * (index + 1)), durationSec - 10);
+  // Denominator guards a 1-nugget track (would otherwise divide by 0
+  // and place the only nugget at NaN). With one nugget we want it at
+  // earlyStart exactly, so the formula collapses to `earlyStart + 0`.
+  const denom = Math.max(totalNuggets - 1, 1);
+  const spacing = usable / denom;
+  return Math.min(Math.floor(earlyStart + spacing * index), durationSec - 10);
 }
 
 /**
@@ -370,11 +385,15 @@ export function useAINuggets(
           };
           newSources.set(sourceId, source);
 
-          const earlyStart = 20;
+          // Mirror the spacing logic in makeTimestamp: first seed nugget
+          // pinned at earlyStart (3s) so it shows almost immediately,
+          // last at duration - endBuffer, middle distributed evenly.
+          const earlyStart = 3;
           const endBuffer = 15;
           const usableDuration = Math.max(durationSec - earlyStart - endBuffer, 30);
-          const spacing = usableDuration / (seedData.length + 1);
-          const timestampSec = Math.floor(earlyStart + spacing * (i + 1));
+          const seedDenom = Math.max(seedData.length - 1, 1);
+          const spacing = usableDuration / seedDenom;
+          const timestampSec = Math.floor(earlyStart + spacing * i);
 
           return {
             id: nuggetId,

--- a/src/hooks/usePreGeneratedStories.ts
+++ b/src/hooks/usePreGeneratedStories.ts
@@ -163,13 +163,19 @@ export function usePreGeneratedStories(
         if (!tierSwitched) {
           const { data: rows } = await supabase
             .from("nugget_cache")
-            .select("track_id, status")
+            .select("track_id, status, nuggets")
             .or(likePatterns.map((p) => `track_id.ilike.${p}`).join(","));
 
           if (cancelled) return;
 
           (rows || []).forEach((r) => {
-            if (r.status === "ready") {
+            // Require status='ready' AND a non-empty nuggets array. An
+            // empty 'ready' row would pin the story circle as "ready" but
+            // a tap would land on a blank Listen page — see the matching
+            // generatedAny check in the pre-gen invoke path below.
+            const nuggets = r.nuggets as unknown[] | null | undefined;
+            const hasContent = Array.isArray(nuggets) && nuggets.length > 0;
+            if (r.status === "ready" && hasContent) {
               // Extract artist::title from track_id to match story.trackKey
               const parts = String(r.track_id).split("::");
               if (parts.length >= 3) {
@@ -206,7 +212,7 @@ export function usePreGeneratedStories(
           kickedOffRef.current.add(kickKey);
           if (cancelled) return;
           try {
-            const { error } = await supabase.functions.invoke("generate-nuggets", {
+            const { data, error } = await supabase.functions.invoke("generate-nuggets", {
               body: {
                 artist: story.artist,
                 title: story.title,
@@ -230,8 +236,22 @@ export function usePreGeneratedStories(
               if (import.meta.env.DEV) console.warn(`[Stories] pre-gen failed for ${story.trackKey}:`, error.message);
               return;
             }
-            // Flip this story's ready flag and record cross-session success
-            // so a reload doesn't refetch.
+            // Bug fix: only treat the story as ready when the server actually
+            // produced nuggets. The JSON path of generate-nuggets returns a
+            // 200 with an empty `nuggets` array if every Writer attempt got
+            // stripped by the Validator (sparse / low-popularity artists do
+            // this regularly — e.g. "4 U" by Ty Symph). Marking the story
+            // ready in that case made the circle pink, but tapping it landed
+            // on a Listen page that had nothing to render. We now require a
+            // non-empty `nuggets` array before stamping the ledger.
+            const responseNuggets = (data as { nuggets?: unknown[] } | null)?.nuggets;
+            const generatedAny = Array.isArray(responseNuggets) && responseNuggets.length > 0;
+            if (!generatedAny) {
+              if (import.meta.env.DEV) {
+                console.warn(`[Stories] pre-gen returned 0 nuggets for ${story.trackKey} — leaving story in "warming" state`);
+              }
+              return;
+            }
             recordPregen(story.trackKey, tier);
             setStories((prev) =>
               prev.map((s) => (s.trackKey === story.trackKey ? { ...s, ready: true } : s)),

--- a/src/hooks/usePreGeneratedStories.ts
+++ b/src/hooks/usePreGeneratedStories.ts
@@ -92,11 +92,32 @@ export function usePreGeneratedStories(
   // re-renders (profile hydration, tier switch) don't retrigger the same
   // pre-gen request. Keyed by `artist::title::tier`.
   const kickedOffRef = useRef<Set<string>>(new Set());
+  // Detect tier switches (vs initial mount). When the user explicitly
+  // changes tier — Casual → Curious — they want to see ALL stories
+  // re-warm with the new depth, not silently inherit any stray cache row
+  // that happens to exist for the new tier from a prior visit. On a
+  // detected tier switch we bypass cache + ledger checks for this run so
+  // every story flips through the warming animation and the server
+  // regenerates with whatever the latest Constitution / prompt looks
+  // like. Initial mount keeps the efficient cache-first path.
+  const prevTierRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!profile?.trackImages?.length) {
       setStories([]);
       return;
+    }
+    const tierSwitched = prevTierRef.current !== null && prevTierRef.current !== tier;
+    prevTierRef.current = tier;
+    // On a tier switch, drop kickedOffRef entries scoped to the new tier
+    // so we'll actually re-fire pre-gen. Without this, a user who toggles
+    // curious → casual → curious would see the second curious switch
+    // bail in runThrottled (kicked-off in the first curious run) and the
+    // skipped cache lookup leaves stories stuck in warming forever.
+    if (tierSwitched) {
+      kickedOffRef.current.forEach((key) => {
+        if (key.endsWith(`::${tier}`)) kickedOffRef.current.delete(key);
+      });
     }
 
     // Seed stories from the top-tracks list, preserving order. Require a
@@ -133,40 +154,52 @@ export function usePreGeneratedStories(
       );
 
       try {
-        const { data: rows } = await supabase
-          .from("nugget_cache")
-          .select("track_id, status")
-          .or(likePatterns.map((p) => `track_id.ilike.${p}`).join(","));
-
-        if (cancelled) return;
-
+        // On a tier switch we deliberately skip the cache lookup so the
+        // user sees every story re-warm and the server regenerates with
+        // the new depth. `readyKeys` stays empty in that branch, which
+        // both leaves all five stories in the warming state and forces
+        // every story into `needsGen` below.
         const readyKeys = new Set<string>();
-        (rows || []).forEach((r) => {
-          if (r.status === "ready") {
-            // Extract artist::title from track_id to match story.trackKey
-            const parts = String(r.track_id).split("::");
-            if (parts.length >= 3) {
-              readyKeys.add(`${parts[1]}::${parts[2]}`);
-            }
-          }
-        });
+        if (!tierSwitched) {
+          const { data: rows } = await supabase
+            .from("nugget_cache")
+            .select("track_id, status")
+            .or(likePatterns.map((p) => `track_id.ilike.${p}`).join(","));
 
-        // Flip ready flags on stories that have cached nuggets OR that we've
-        // pre-gen'd within the last 24h (treat them as hot without re-querying
-        // every reload, even if cache key lookup happened to miss).
-        setStories((prev) =>
-          prev.map((s) => {
-            const fromCache = readyKeys.has(s.trackKey);
-            const fromLedger = wasPregennedRecently(s.trackKey, tier);
-            return fromCache || fromLedger ? { ...s, ready: true } : s;
-          }),
-        );
+          if (cancelled) return;
+
+          (rows || []).forEach((r) => {
+            if (r.status === "ready") {
+              // Extract artist::title from track_id to match story.trackKey
+              const parts = String(r.track_id).split("::");
+              if (parts.length >= 3) {
+                readyKeys.add(`${parts[1]}::${parts[2]}`);
+              }
+            }
+          });
+
+          // Flip ready flags on stories that have cached nuggets OR that we've
+          // pre-gen'd within the last 24h (treat them as hot without re-querying
+          // every reload, even if cache key lookup happened to miss).
+          setStories((prev) =>
+            prev.map((s) => {
+              const fromCache = readyKeys.has(s.trackKey);
+              const fromLedger = wasPregennedRecently(s.trackKey, tier);
+              return fromCache || fromLedger ? { ...s, ready: true } : s;
+            }),
+          );
+        }
 
         // 2. Kick off pre-gen for the rest, throttled. Skip tracks we've
         // already pre-gen'd recently (cross-session dedup via ledger).
-        const needsGen = seeded.filter(
-          (s) => !readyKeys.has(s.trackKey) && !wasPregennedRecently(s.trackKey, tier),
-        );
+        // On tier switch, regenerate ALL stories — bypass the ledger so a
+        // recently-pregenned (but old-tier) entry doesn't suppress the
+        // re-warm.
+        const needsGen = tierSwitched
+          ? seeded
+          : seeded.filter(
+              (s) => !readyKeys.has(s.trackKey) && !wasPregennedRecently(s.trackKey, tier),
+            );
         await runThrottled(needsGen, maxConcurrent, async (story) => {
           const kickKey = `${story.trackKey}::${tier}`;
           if (kickedOffRef.current.has(kickKey)) return;

--- a/src/hooks/usePreGeneratedStories.ts
+++ b/src/hooks/usePreGeneratedStories.ts
@@ -194,7 +194,12 @@ export function usePreGeneratedStories(
             });
             if (cancelled) return;
             if (error) {
-              if (import.meta.env.DEV) console.warn(`[Stories] pre-gen failed for ${story.trackKey}:`, error.message);
+              // Production-visible: a failed pre-gen leaves the story
+              // permanently in "warming up" state because we never set
+              // ready=true here. Surfacing in console so users hitting
+              // a real failure (Gemini quota, edge timeout) can report
+              // it instead of staring at a frozen indicator.
+              console.warn(`[Stories] pre-gen failed for ${story.trackKey}:`, error.message);
               return;
             }
             // Flip this story's ready flag and record cross-session success
@@ -204,7 +209,10 @@ export function usePreGeneratedStories(
               prev.map((s) => (s.trackKey === story.trackKey ? { ...s, ready: true } : s)),
             );
           } catch (e) {
-            if (import.meta.env.DEV) console.warn(`[Stories] pre-gen threw for ${story.trackKey}:`, e);
+            // Same reasoning as the `error` branch above — a thrown
+            // pre-gen leaves the story stuck in "warming up". Visible
+            // in production so the failure is actionable.
+            console.warn(`[Stories] pre-gen threw for ${story.trackKey}:`, e);
           }
         });
       } finally {

--- a/src/hooks/usePreGeneratedStories.ts
+++ b/src/hooks/usePreGeneratedStories.ts
@@ -194,12 +194,7 @@ export function usePreGeneratedStories(
             });
             if (cancelled) return;
             if (error) {
-              // Production-visible: a failed pre-gen leaves the story
-              // permanently in "warming up" state because we never set
-              // ready=true here. Surfacing in console so users hitting
-              // a real failure (Gemini quota, edge timeout) can report
-              // it instead of staring at a frozen indicator.
-              console.warn(`[Stories] pre-gen failed for ${story.trackKey}:`, error.message);
+              if (import.meta.env.DEV) console.warn(`[Stories] pre-gen failed for ${story.trackKey}:`, error.message);
               return;
             }
             // Flip this story's ready flag and record cross-session success
@@ -209,10 +204,7 @@ export function usePreGeneratedStories(
               prev.map((s) => (s.trackKey === story.trackKey ? { ...s, ready: true } : s)),
             );
           } catch (e) {
-            // Same reasoning as the `error` branch above — a thrown
-            // pre-gen leaves the story stuck in "warming up". Visible
-            // in production so the failure is actionable.
-            console.warn(`[Stories] pre-gen threw for ${story.trackKey}:`, e);
+            if (import.meta.env.DEV) console.warn(`[Stories] pre-gen threw for ${story.trackKey}:`, e);
           }
         });
       } finally {

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -88,6 +88,13 @@ export function useSignOut() {
     sessionStorage.removeItem("spotify_pending_taste");
     sessionStorage.removeItem(LEGACY_PKCE_STATE_KEY);
     sessionStorage.removeItem(LEGACY_PKCE_VERIFIER_KEY);
+    // Tier-confirmed flag is per-session — clear it so the next login
+    // forces the tier-pick step (Pete: "I should be able to pick my
+    // tier every time I log in"). The window.location.href reload
+    // below would also clear it via tab context teardown, but the
+    // explicit removal keeps behavior consistent if that reload is
+    // ever swapped for a soft navigate.
+    sessionStorage.removeItem("musicnerd_tier_confirmed");
 
     // 5. Hard navigate. See module-level comment for why a full reload
     //    instead of React Router navigate().

--- a/src/index.css
+++ b/src/index.css
@@ -83,7 +83,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(ellipse at center, transparent 40%, hsl(240 6% 6% / 0.8) 100%);
+  background: radial-gradient(ellipse at center, transparent 60%, hsl(240 6% 6% / 0.45) 100%);
   z-index: 1;
 }
 

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { Search, LogOut, Heart } from "lucide-react";
+import { Search, LogOut, Heart, ChevronDown } from "lucide-react";
 import { Link } from "react-router-dom";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
 import TileRow from "@/components/TileRow";
@@ -8,7 +8,7 @@ import SearchOverlay from "@/components/SearchOverlay";
 import PageTransition from "@/components/PageTransition";
 import StoriesRail from "@/components/StoriesRail";
 import ArtistUpdatesSection from "@/components/ArtistUpdatesSection";
-import { useUserProfile, tierGreeting, tierBadgeLabel, tierBadgeColor, tierGlowClass } from "@/hooks/useMusicNerdState";
+import { useUserProfile, tierGreeting, tierBadgeLabel, tierGlowClass } from "@/hooks/useMusicNerdState";
 import { usePersonalizedCatalog } from "@/hooks/usePersonalizedCatalog";
 import { useTierAccent } from "@/hooks/useTierAccent";
 import { useSignOut } from "@/hooks/useSignOut";
@@ -270,7 +270,6 @@ export default function Browse() {
 
   const focusGlow = "tv-focus-glow";
   const glowClass = tier ? tierGlowClass(tier) : "";
-  const badgeColor = tier ? tierBadgeColor(tier) : "";
 
   return (
     <PageTransition>
@@ -323,11 +322,17 @@ export default function Browse() {
             >
               {tierGreeting(tier, userName)}
             </h1>
-            {tier && (
-              <span className={`text-xs font-bold px-3 py-1 rounded-full ${badgeColor}`}>
-                ● {tierBadgeLabel(tier)}
-              </span>
-            )}
+            {/* Tier picker — surfaces tier choice on every Browse mount so
+                returning users can change tier without going back through
+                Connect. Pete: "I should be able to pick my tier every
+                time I log in." */}
+            <TierPicker
+              tier={tier}
+              onSelect={(t) => {
+                if (!profile) return;
+                if (t !== tier) saveProfile({ ...profile, calculatedTier: t });
+              }}
+            />
           </div>
           <p className="mt-1 text-muted-foreground text-lg">
             {profile?.streamingService
@@ -375,5 +380,74 @@ export default function Browse() {
         <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
       </div>
     </PageTransition>
+  );
+}
+
+// ── Tier picker ─────────────────────────────────────────────────────────
+// Pulled out of the header MusicNerdLogo (which "cycled" the tier on
+// click — a hidden interaction nobody discovered) into an explicit
+// dropdown inline with the greeting. Always visible on Browse so the
+// user can change tier on every login without going through Connect.
+
+interface TierPickerProps {
+  tier: "casual" | "curious" | "nerd" | undefined;
+  onSelect: (t: "casual" | "curious" | "nerd") => void;
+}
+
+const TIER_OPTIONS: Array<{ id: "casual" | "curious" | "nerd"; label: string; desc: string; color: string }> = [
+  { id: "casual", label: "Casual", desc: "Just here for the vibes", color: "text-green-400" },
+  { id: "curious", label: "Curious", desc: "I like the backstory", color: "text-blue-400" },
+  { id: "nerd", label: "Nerd Mode", desc: "Give me every detail", color: "text-pink-400" },
+];
+
+function TierPicker({ tier, onSelect }: TierPickerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  if (!tier) return null;
+  const current = TIER_OPTIONS.find((t) => t.id === tier);
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className={`flex items-center gap-1.5 text-xs font-bold px-3 py-1 rounded-full bg-foreground/5 hover:bg-foreground/10 transition-colors ${current?.color ?? ""}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Change tier"
+      >
+        <span>● {current?.label ?? tierBadgeLabel(tier)}</span>
+        <ChevronDown size={12} className={`transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full mt-2 z-30 w-56 rounded-xl bg-background/95 backdrop-blur-xl ring-1 ring-foreground/10 shadow-2xl py-1.5"
+        >
+          {TIER_OPTIONS.map((opt) => {
+            const selected = opt.id === tier;
+            return (
+              <button
+                key={opt.id}
+                onClick={() => { onSelect(opt.id); setOpen(false); }}
+                role="option"
+                aria-selected={selected}
+                className={`w-full flex flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-foreground/5 transition-colors ${selected ? "bg-foreground/[0.04]" : ""}`}
+              >
+                <span className={`text-sm font-bold ${opt.color}`}>● {opt.label}{selected ? " — current" : ""}</span>
+                <span className="text-xs text-muted-foreground">{opt.desc}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -14,6 +14,7 @@ import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
 import { useSpotifyPostSigninSync } from "@/hooks/useSpotifyPostSigninSync";
 import { ensureSupabaseSession } from "@/lib/ensureSupabaseSession";
 import SpotifySyncingOverlay from "@/components/SpotifySyncingOverlay";
+import { useTierGate } from "@/contexts/TierGateContext";
 
 type Tier = "casual" | "curious" | "nerd";
 
@@ -94,6 +95,7 @@ export default function Connect() {
 function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
   const navigate = useNavigate();
   const { saveProfile } = useUserProfile();
+  const { confirmTier } = useTierGate();
   const [step, setStep] = useState(0);
   const [direction, setDirection] = useState(1);
   const [spotifyConnecting, setSpotifyConnecting] = useState(false);
@@ -275,6 +277,12 @@ function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
       tasteRefreshedAt: pendingTopArtists ? new Date().toISOString() : undefined,
     };
     saveProfile(profile);
+    // Confirm tier for this session — unblocks StoriesProvider /
+    // ArtistUpdatesProvider, which were holding pre-gen until the user
+    // explicitly picked a tier this login. Without this call /preparing
+    // would render its own tier-pick step on top of the user's choice
+    // here.
+    confirmTier(t);
     sessionStorage.removeItem("musicnerd_redirect");
     // Route through /preparing so artist-updates gets a warmup window
     // before Browse renders. Splash auto-advances when 1 artist-update

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearchParams, Navigate } from "react-router-dom";
 import { useState, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
 import { motion, AnimatePresence } from "framer-motion";
 import PageTransition from "@/components/PageTransition";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
@@ -69,11 +70,16 @@ export default function Connect() {
     }
   }, [storedRedirect]);
   const redirectUrl = redirectParam || storedRedirect;
-  // Treat live profile state OR localStorage as authoritative — the live
-  // state can lag a render behind localStorage immediately after
-  // saveProfile fires, so checking both closes the gap.
+  // Need BOTH a session AND a profile to short-circuit past the
+  // sign-in UI. Profile-only (e.g. session expired but localStorage
+  // is still seeded) used to ping-pong: gate Navigates to /preparing
+  // → ProtectedRoute on /preparing fails on missing session →
+  // redirects back to /connect → loop. With both checks, an expired
+  // session falls through to ConnectInner where the user can
+  // re-authenticate.
+  const { session } = useAuth();
   const hasProfile = !!profile || !!getStoredProfile();
-  if (hasProfile) {
+  if (session && hasProfile) {
     // Route through /preparing so the artist-updates rail has a window
     // to populate before Browse renders. Without this, returning users
     // land on Browse with an empty rail and watch it fill in — the

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1227,7 +1227,7 @@ export default function Listen() {
               {topFocusIndex === 0 ? "Back" : "Open Companion"}
             </motion.p>
           )}
-          {!isMobile && <div className="flex flex-col items-center gap-1.5">
+          <div className="flex flex-col items-center gap-1.5">
             <MusicNerdLoadingOrchestrator
               aiLoading={aiLoading}
               aiError={aiError}
@@ -1244,33 +1244,15 @@ export default function Listen() {
                 }
               }}
             />
-            <button
-              onClick={() => setDevOpen((o) => !o)}
-              className="rounded-md bg-foreground/5 px-2.5 py-0.5 text-[10px] text-muted-foreground/50 hover:bg-foreground/10 hover:text-muted-foreground transition-colors"
-            >
-              DEV
-            </button>
-          </div>}
-          {/* Mobile-visible research indicator. The MusicNerdLoadingOrchestrator
-              above is desktop-tuned (anchored container, fixed top-bar
-              spacing) and gated behind !isMobile — without this fallback,
-              phone users tapping a cold-cache track see the song start
-              with zero indication that nugget research is running. Pill
-              hides once any nugget streams in or generation errors. */}
-          {isMobile && aiLoading && trackNuggets.length === 0 && (
-            <motion.div
-              initial={{ opacity: 0, y: -6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0 }}
-              className="flex items-center gap-2 rounded-full bg-foreground/10 backdrop-blur-md px-3 py-1.5 text-xs text-foreground/80"
-            >
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />
-              <span>
-                Researching <span className="font-semibold">{track.artist}</span>
-                <span className="inline-block w-4 text-left animate-pulse">…</span>
-              </span>
-            </motion.div>
-          )}
+            {!isMobile && (
+              <button
+                onClick={() => setDevOpen((o) => !o)}
+                className="rounded-md bg-foreground/5 px-2.5 py-0.5 text-[10px] text-muted-foreground/50 hover:bg-foreground/10 hover:text-muted-foreground transition-colors"
+              >
+                DEV
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Track info — fixed bottom-left, visible when playback bar is hidden */}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1251,6 +1251,26 @@ export default function Listen() {
               DEV
             </button>
           </div>}
+          {/* Mobile-visible research indicator. The MusicNerdLoadingOrchestrator
+              above is desktop-tuned (anchored container, fixed top-bar
+              spacing) and gated behind !isMobile — without this fallback,
+              phone users tapping a cold-cache track see the song start
+              with zero indication that nugget research is running. Pill
+              hides once any nugget streams in or generation errors. */}
+          {isMobile && aiLoading && trackNuggets.length === 0 && (
+            <motion.div
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              className="flex items-center gap-2 rounded-full bg-foreground/10 backdrop-blur-md px-3 py-1.5 text-xs text-foreground/80"
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />
+              <span>
+                Researching <span className="font-semibold">{track.artist}</span>
+                <span className="inline-block w-4 text-left animate-pulse">…</span>
+              </span>
+            </motion.div>
+          )}
         </div>
 
         {/* Track info — fixed bottom-left, visible when playback bar is hidden */}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1317,17 +1317,22 @@ export default function Listen() {
           </motion.div>
         )}
 
-        {/* Centered album art */}
+        {/* Centered album art — responsive sizing scales with viewport so
+            it fills the frame on phones (where there's no foreground card
+            of its own) and on TVs. Sized off the smaller viewport axis
+            (min(70vw, 70vh)) so it stays square regardless of orientation
+            and never gets cropped against the playback bar. */}
         <motion.div
-          className="hidden md:flex absolute inset-0 z-[5] items-center justify-center pointer-events-none"
-          animate={{ opacity: barVisible ? 0.85 : 1, scale: barVisible ? 0.95 : 1 }}
+          className="absolute inset-0 z-[5] flex items-center justify-center pointer-events-none"
+          animate={{ opacity: barVisible ? 0.9 : 1, scale: barVisible ? 0.96 : 1 }}
           transition={{ duration: 0.7, ease: [0.4, 0, 0.2, 1] }}
         >
           <motion.img
             key={effectiveCoverArt}
             src={effectiveCoverArt}
             alt={`${track.title} cover art`}
-            className="w-[400px] h-[400px] rounded-2xl object-cover shadow-2xl shadow-black/50"
+            className="rounded-2xl object-cover shadow-2xl shadow-black/50"
+            style={{ width: "min(70vw, 70vh)", height: "min(70vw, 70vh)" }}
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1065,48 +1065,28 @@ export default function Listen() {
     // for content and should see nuggets the moment they arrive.
     if (!isPlaying && aiFromCache) return;
 
+    // Reveal rule (Pete: "an active shouldn't auto-dismiss; it should
+    // stay up until another nugget arrives, pushing it to the side so
+    // the new nugget is displayed"):
+    //   - No 8s auto-dismiss, no queue.
+    //   - When a new nugget triggers and one is already active, push
+    //     the active one into `dismissedNuggets` (so the playback-bar
+    //     re-open chip renders for it) and replace it with the new
+    //     nugget immediately.
+    //   - The last nugget of the track stays on screen until track
+    //     end, navigation, or user re-opens an earlier nugget.
     for (const n of trackNuggets) {
       if (shownNuggetIds.has(n.id)) continue;
-      if (shouldTrigger(n)) {
-        if (activeNugget) {
-          if (reopenedNuggetId) {
-            setDismissedNuggets((prev) => new Map(prev).set(activeNugget.id, activeNugget));
-            setActiveNugget(n);
-            setReopenedNuggetId(null);
-            setShownNuggetIds((s) => new Set(s).add(n.id));
-          } else {
-            setNuggetQueue((q) => (q.find((x) => x.id === n.id) ? q : [...q, n]));
-          }
-        } else {
-          setActiveNugget(n);
-          setReopenedNuggetId(null);
-          setShownNuggetIds((s) => new Set(s).add(n.id));
-        }
+      if (!shouldTrigger(n)) continue;
+      if (activeNugget && activeNugget.id !== n.id) {
+        setDismissedNuggets((prev) => new Map(prev).set(activeNugget.id, activeNugget));
       }
+      setActiveNugget(n);
+      setReopenedNuggetId(null);
+      setShownNuggetIds((s) => new Set(s).add(n.id));
     }
   }, [currentTime, isPlaying, nerdActive, trackNuggets, activeNugget, shownNuggetIds, reopenedNuggetId, aiFromCache]);
 
-  // Auto-dismiss nugget: quick swap if queued, otherwise fade after 8s
-  useEffect(() => {
-    if (!activeNugget || deepDiveNugget || nuggetFocused) return;
-    const delay = nuggetQueue.length > 0 ? 6000 : 8000;
-    const timer = setTimeout(() => {
-      setDismissedNuggets((prev) => new Map(prev).set(activeNugget.id, activeNugget));
-      setActiveNugget(null);
-      setReopenedNuggetId(null);
-    }, delay);
-    return () => clearTimeout(timer);
-  }, [activeNugget, deepDiveNugget, nuggetFocused, nuggetQueue.length]);
-
-  useEffect(() => {
-    if (!activeNugget && nuggetQueue.length > 0) {
-      const next = nuggetQueue[0];
-      setNuggetQueue((q) => q.slice(1));
-      setActiveNugget(next);
-      setReopenedNuggetId(null);
-      setShownNuggetIds((s) => new Set(s).add(next.id));
-    }
-  }, [activeNugget, nuggetQueue]);
 
   const getSource = useCallback((sourceId: string): Source | undefined => {
     return aiSources.get(sourceId);
@@ -1635,20 +1615,12 @@ export default function Listen() {
         </div>
       )}
 
-      {/* "More coming" pill — surfaces while wave 2/3 generates silently in
-          the background so the user knows additional nuggets are on the way
-          without interrupting their current reading. */}
-      {track && waveLoading && (
-        <div
-          className="fixed left-1/2 -translate-x-1/2 bottom-24 z-[55] pointer-events-none"
-          style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
-        >
-          <div className="flex items-center gap-2 rounded-full px-3 py-1.5 bg-black/70 border border-white/10 text-xs text-white/80">
-            <span className="w-1.5 h-1.5 rounded-full bg-rose-400 animate-pulse" />
-            <span>More coming…</span>
-          </div>
-        </div>
-      )}
+      {/* "More coming…" pill removed — the timeline-marker dots in
+          the playback bar already communicate how many nuggets are
+          on deck, and the pill was overlapping the active nugget's
+          headline on mobile. `waveLoading` state stays in
+          useAINuggets for any future use that doesn't compete with
+          content for screen real estate. */}
     </PageTransition>
   );
 }

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1337,10 +1337,17 @@ export default function Listen() {
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Floating nugget card — independent of bar visibility, anchored to timeline position */}
+        {/* Floating nugget card — independent of bar visibility, anchored to timeline position.
+            Bottom offsets must keep the card's bottom edge ABOVE the
+            playback bar's top edge or the headline's lower lines render
+            in the same vertical band as the timeline-marker dots. Live
+            measurement (vh=628): bar top sits at ~y=560, so anything
+            with bottom<68 ends up overlapping. 90/240 give a clear gap
+            in both states (bar hidden → mini-bar at bottom; bar visible
+            → full controls). */}
         <div
           className="fixed left-0 right-0 z-30 pointer-events-none transition-[bottom] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
-          style={{ bottom: barVisible ? 160 : 48 }}
+          style={{ bottom: barVisible ? 240 : 90 }}
         >
           {/* Layout wrapper matching progress bar track horizontal bounds */}
           <div className="px-4 md:px-10">

--- a/src/pages/PreparingExperience.tsx
+++ b/src/pages/PreparingExperience.tsx
@@ -6,6 +6,8 @@ import PageTransition from "@/components/PageTransition";
 import { useUserProfile, getStoredProfile } from "@/hooks/useMusicNerdState";
 import { useFirstRunReadiness, MAX_WAIT_MS } from "@/hooks/useFirstRunReadiness";
 import { sanitizeRedirect } from "@/lib/routeUtils";
+import { useTierGate } from "@/contexts/TierGateContext";
+import type { UserProfile } from "@/mock/types";
 
 /**
  * Splash shown between sign-in and Browse. Waits for the artist-updates
@@ -43,10 +45,52 @@ const STATUS_STEPS = [
   { threshold: 35_000, label: "Just a moment more" },                     // 35s — final stretch before timeout
 ];
 
+type Tier = NonNullable<UserProfile["calculatedTier"]>;
+
+const TIER_PICKER_OPTIONS: Array<{
+  id: Tier;
+  label: string;
+  desc: string;
+  emoji: string;
+  ringClass: string;
+  glowClass: string;
+}> = [
+  {
+    id: "casual",
+    label: "Casual Listener",
+    desc: "Just here for the vibes",
+    emoji: "🎵",
+    ringClass: "ring-green-500/30 hover:ring-green-400",
+    glowClass: "hover:shadow-[0_0_24px_rgba(34,197,94,0.25)]",
+  },
+  {
+    id: "curious",
+    label: "Curious Fan",
+    desc: "I like knowing the backstory",
+    emoji: "🎼",
+    ringClass: "ring-blue-500/30 hover:ring-blue-400",
+    glowClass: "hover:shadow-[0_0_24px_rgba(59,130,246,0.25)]",
+  },
+  {
+    id: "nerd",
+    label: "Hardcore Nerd",
+    desc: "Give me every detail",
+    emoji: "🎛️",
+    ringClass: "ring-pink-500/30 hover:ring-pink-400",
+    glowClass: "hover:shadow-[0_0_24px_rgba(236,72,153,0.25)]",
+  },
+];
+
 export default function PreparingExperience() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { profile } = useUserProfile();
+  const { tierConfirmed, confirmTier } = useTierGate();
+  // useFirstRunReadiness reads artist-updates context state; pre-gen
+  // doesn't kick off until tier is confirmed (StoriesContext +
+  // ArtistUpdatesContext gate on it). Calling the hook before
+  // confirmation is harmless — it just returns ready=false until the
+  // post-confirmation effect runs and progress lands.
   const { ready, skipAvailable } = useFirstRunReadiness();
 
   // Deep-link support: a user signed in via /connect?redirect=/listen/xxx
@@ -64,12 +108,15 @@ export default function PreparingExperience() {
     }
   }, [profile, navigate]);
 
-  // Auto-advance once ready. replace: true so back-button doesn't
-  // bring the user back to the splash. `nextUrl` honors ?next= for
-  // users who came in via a deep link; defaults to /browse.
+  // Auto-advance once ready AND tier-confirmed. The tier-confirmed
+  // guard matters because `ready` can fire on stale artist-updates
+  // state before confirmation happens (the providers no-op pre-gen
+  // until confirmed, so they technically never enter "loading", which
+  // useFirstRunReadiness reads as "done"). Without this guard a fresh
+  // login would skip the tier picker entirely and land on Browse.
   useEffect(() => {
-    if (ready) navigate(nextUrl, { replace: true });
-  }, [ready, navigate, nextUrl]);
+    if (ready && tierConfirmed) navigate(nextUrl, { replace: true });
+  }, [ready, tierConfirmed, navigate, nextUrl]);
 
   // Status-message timer — same pattern as SpotifySyncingOverlay so the
   // copy advances even when the underlying generation is silent
@@ -103,76 +150,132 @@ export default function PreparingExperience() {
           }}
         />
 
-        <motion.div
-          className="relative z-10 flex w-full max-w-sm flex-col items-center gap-6 text-center"
-          initial={{ y: 8, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
-        >
+        {!tierConfirmed ? (
+          // Tier-pick step — required on every login. Pre-gen for stories
+          // and artist-updates is gated on `tierConfirmed` (see
+          // StoriesContext + ArtistUpdatesContext) so nothing warms up
+          // until the user picks a tier here. Returning users with a
+          // persisted tier still see this step; the persisted choice is
+          // visually marked as "current" so a quick tap keeps it.
           <motion.div
-            animate={{ scale: [1, 1.04, 1] }}
-            transition={{ duration: 2.4, ease: "easeInOut", repeat: Infinity }}
+            key="tier-pick"
+            className="relative z-10 flex w-full max-w-md flex-col items-center gap-7 text-center"
+            initial={{ y: 8, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
           >
-            <MusicNerdLogo size={72} glow />
-          </motion.div>
-
-          <div className="space-y-1.5">
-            <h1 className="text-xl md:text-2xl font-black text-white tracking-tight font-nunito">
-              Setting up your music
-            </h1>
-            <div className="relative h-5 overflow-hidden">
-              <AnimatePresence mode="wait">
-                <motion.p
-                  key={currentStep.label}
-                  initial={{ y: 10, opacity: 0 }}
-                  animate={{ y: 0, opacity: 1 }}
-                  exit={{ y: -10, opacity: 0 }}
-                  transition={{ duration: 0.3, ease: "easeOut" }}
-                  className="text-sm text-white/70"
-                >
-                  {currentStep.label}
-                  <span className="inline-block ml-0.5 animate-pulse">…</span>
-                </motion.p>
-              </AnimatePresence>
+            <MusicNerdLogo size={56} glow />
+            <div className="space-y-1.5">
+              <h1 className="text-2xl md:text-3xl font-black text-white tracking-tight font-nunito">
+                Pick your nerd level
+              </h1>
+              <p className="text-sm text-white/60">
+                We tune every fact and discovery to your tier — change it any time.
+              </p>
             </div>
-          </div>
-
-          {/* Bar pacing matches SpotifySyncingOverlay (4% → 95% over the
-              expected wait window). Duration is 45s — same as
-              useFirstRunReadiness's MAX_WAIT_MS so the bar never
-              overshoots the auto-advance. On success, exit snaps to
-              100%. */}
-          <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+            <div className="flex w-full flex-col gap-3">
+              {TIER_PICKER_OPTIONS.map((opt) => {
+                const isCurrent = profile?.calculatedTier === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    onClick={() => confirmTier(opt.id)}
+                    className={`flex items-start gap-3 md:gap-4 w-full rounded-2xl bg-white/[0.04] ring-1 px-4 md:px-5 py-3 md:py-4 text-left transition-all duration-200 ${opt.ringClass} ${opt.glowClass}`}
+                  >
+                    <span className="text-2xl md:text-3xl shrink-0">{opt.emoji}</span>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-base md:text-lg font-bold text-white">{opt.label}</p>
+                        {isCurrent && (
+                          <span className="text-[10px] uppercase tracking-widest text-white/50 px-1.5 py-0.5 rounded-full bg-white/5">
+                            current
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-xs md:text-sm text-white/55">{opt.desc}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-[11px] uppercase tracking-widest text-white/30">
+              Tier choice runs every login
+            </p>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="warming"
+            className="relative z-10 flex w-full max-w-sm flex-col items-center gap-6 text-center"
+            initial={{ y: 8, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          >
             <motion.div
-              className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-green-400 via-emerald-300 to-pink-400"
-              initial={{ width: "4%" }}
-              animate={{ width: ready ? "100%" : "95%" }}
-              transition={{ duration: ready ? 0.3 : MAX_WAIT_MS / 1000, ease: [0.2, 0.6, 0.3, 1] }}
-            />
-            <motion.div
-              className="absolute inset-y-0 w-24 rounded-full"
-              style={{
-                background:
-                  "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
-              }}
-              animate={{ x: ["-20%", "420%"] }}
-              transition={{ duration: 1.6, ease: "easeInOut", repeat: Infinity }}
-            />
-          </div>
-
-          <p className="text-[11px] uppercase tracking-widest text-white/35">
-            Stories will keep loading on Browse
-          </p>
-
-          {skipAvailable && !ready && (
-            <button
-              onClick={() => navigate(nextUrl, { replace: true })}
-              className="text-xs text-white/40 hover:text-white/70 transition-colors underline underline-offset-4"
+              animate={{ scale: [1, 1.04, 1] }}
+              transition={{ duration: 2.4, ease: "easeInOut", repeat: Infinity }}
             >
-              Jump in
-            </button>
-          )}
-        </motion.div>
+              <MusicNerdLogo size={72} glow />
+            </motion.div>
+
+            <div className="space-y-1.5">
+              <h1 className="text-xl md:text-2xl font-black text-white tracking-tight font-nunito">
+                Setting up your music
+              </h1>
+              <div className="relative h-5 overflow-hidden">
+                <AnimatePresence mode="wait">
+                  <motion.p
+                    key={currentStep.label}
+                    initial={{ y: 10, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    exit={{ y: -10, opacity: 0 }}
+                    transition={{ duration: 0.3, ease: "easeOut" }}
+                    className="text-sm text-white/70"
+                  >
+                    {currentStep.label}
+                    <span className="inline-block ml-0.5 animate-pulse">…</span>
+                  </motion.p>
+                </AnimatePresence>
+              </div>
+            </div>
+
+            {/* Bar pacing matches SpotifySyncingOverlay (4% → 95% over the
+                expected wait window). Duration is 45s — same as
+                useFirstRunReadiness's MAX_WAIT_MS so the bar never
+                overshoots the auto-advance. On success, exit snaps to
+                100%. */}
+            <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+              <motion.div
+                className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-green-400 via-emerald-300 to-pink-400"
+                initial={{ width: "4%" }}
+                animate={{ width: ready ? "100%" : "95%" }}
+                transition={{ duration: ready ? 0.3 : MAX_WAIT_MS / 1000, ease: [0.2, 0.6, 0.3, 1] }}
+              />
+              <motion.div
+                className="absolute inset-y-0 w-24 rounded-full"
+                style={{
+                  background:
+                    "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
+                }}
+                animate={{ x: ["-20%", "420%"] }}
+                transition={{ duration: 1.6, ease: "easeInOut", repeat: Infinity }}
+              />
+            </div>
+
+            <p className="text-[11px] uppercase tracking-widest text-white/35">
+              Stories will keep loading on Browse
+            </p>
+
+            {skipAvailable && !ready && (
+              <button
+                onClick={() => navigate(nextUrl, { replace: true })}
+                className="text-xs text-white/40 hover:text-white/70 transition-colors underline underline-offset-4"
+              >
+                Jump in
+              </button>
+            )}
+          </motion.div>
+        )}
       </div>
     </PageTransition>
   );

--- a/src/test/makeTimestamp.test.ts
+++ b/src/test/makeTimestamp.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from "vitest";
 import { makeTimestamp } from "@/hooks/useAINuggets";
 
 describe("makeTimestamp", () => {
-  it("spaces 3 nuggets evenly across a 300s track", () => {
-    // earlyStart=20, endBuffer=15, usable=265, spacing=265/4=66.25
+  it("pins first nugget at earlyStart and spaces the rest evenly across a 300s track", () => {
+    // earlyStart=3, endBuffer=15, usable=282, spacing=282/2=141
     const t0 = makeTimestamp(0, 3, 300);
     const t1 = makeTimestamp(1, 3, 300);
     const t2 = makeTimestamp(2, 3, 300);
-    expect(t0).toBe(86);  // floor(20 + 66.25*1)
-    expect(t1).toBe(152); // floor(20 + 66.25*2)
-    expect(t2).toBe(218); // floor(20 + 66.25*3)
+    expect(t0).toBe(3);   // earlyStart
+    expect(t1).toBe(144); // floor(3 + 141*1)
+    expect(t2).toBe(285); // floor(3 + 141*2), clamped under durationSec-10=290
   });
 
   it("spaces 9 nuggets (nerd tier) without piling up at the end", () => {
@@ -18,26 +18,28 @@ describe("makeTimestamp", () => {
     for (let i = 1; i < timestamps.length; i++) {
       expect(timestamps[i]).toBeGreaterThan(timestamps[i - 1]);
     }
+    // First nugget pinned at earlyStart so the user sees content quickly
+    expect(timestamps[0]).toBe(3);
     // Last nugget should be before track end - 10
     expect(timestamps[8]).toBeLessThanOrEqual(290);
   });
 
   it("clamps to durationSec - 10 for short tracks", () => {
-    // 40s track: earlyStart=20, endBuffer=15, usable=max(5,30)=30
+    // 40s track: earlyStart=3, endBuffer=15, usable=max(22,30)=30
     const t = makeTimestamp(0, 1, 40);
     expect(t).toBeLessThanOrEqual(30); // 40 - 10
   });
 
-  it("handles single nugget", () => {
+  it("handles single nugget by pinning at earlyStart", () => {
     const t = makeTimestamp(0, 1, 300);
-    // earlyStart=20, usable=265, spacing=265/2=132.5 → floor(20+132.5)=152
-    expect(t).toBe(152);
+    // Single nugget collapses to earlyStart so the user sees it right away
+    expect(t).toBe(3);
   });
 
   it("handles very short track (durationSec < 45)", () => {
-    // usable = max(durationSec - 20 - 15, 30) = max(-5, 30) = 30
+    // usable = max(durationSec - 3 - 15, 30) = max(12, 30) = 30
     const t = makeTimestamp(0, 1, 30);
-    // floor(20 + 30/2 * 1) = floor(35) = 35, clamped to min(35, 20) = 20
-    expect(t).toBeLessThanOrEqual(20); // 30 - 10
+    // floor(3 + 0) = 3, clamped under min(durationSec-10) = 20
+    expect(t).toBeLessThanOrEqual(20);
   });
 });

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -262,6 +262,85 @@ function buildReleaseUpdate(
   };
 }
 
+// ── Exa research (lightweight wrapper) ─────────────────────────────────
+//
+// One Exa /search call per non-sparse artist gives Gemini real journalism
+// to anchor a fact in. Without this, the row was effectively asking
+// gemini-2.5-flash to recall trivia from training data — Pete's
+// complaint: "really poor, feels like its not diving in doing research
+// like we do our regular nuggets." generate-nuggets uses 3 Exa calls
+// (artist / track / discovery) and a Curator+Writer+Validator pipeline;
+// here we settle for a single artist-scoped search to keep wall-time
+// under the existing GEMINI_TIMEOUT_MS budget.
+//
+// Skipped on the sparse path — the SPARSE_FOLLOWER_THRESHOLD already
+// signals "no press exists", and the catalog-grounded prompt is what
+// prevents hallucination there.
+const EXA_TIMEOUT_MS = 8_000;
+
+async function researchArtistOnExa(
+  artistName: string,
+  apiKey: string,
+): Promise<{ snippets: string; citations: { title: string; url: string }[] }> {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), EXA_TIMEOUT_MS);
+  try {
+    const res = await fetch("https://api.exa.ai/search", {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `${artistName} interview production credits collaborators backstory`,
+        type: "auto",
+        numResults: 4,
+        livecrawl: "fallback",
+        contents: {
+          text: { maxCharacters: 3500 },
+          highlights: { numSentences: 3, highlightsPerUrl: 2 },
+        },
+        includeText: [artistName],
+        excludeDomains: ["facebook.com", "instagram.com", "tiktok.com"],
+      }),
+      signal: ctl.signal,
+    });
+    if (!res.ok) {
+      console.warn(`[artist-updates] Exa ${res.status} for ${artistName}:`, await res.text().catch(() => ""));
+      return { snippets: "", citations: [] };
+    }
+    const data = await res.json();
+    const results = (data?.results ?? []) as Array<{
+      title?: string;
+      url?: string;
+      text?: string;
+      highlights?: string[];
+    }>;
+    const citations = results
+      .filter((r) => r.url)
+      .map((r) => ({ title: r.title || "", url: r.url! }));
+    const snippets = results
+      .map((r, i) => {
+        const highlightBlock = r.highlights?.length
+          ? `\n[Key excerpts]:\n${r.highlights.map((h) => `• ${h}`).join("\n")}`
+          : "";
+        const body = (r.text || "").slice(0, 2500);
+        return `[Source ${i + 1}: "${r.title || "(no title)"}" — ${r.url}]${highlightBlock}\n${body}`;
+      })
+      .join("\n\n---\n\n");
+    return { snippets, citations };
+  } catch (e) {
+    if ((e as Error)?.name === "AbortError") {
+      console.warn(`[artist-updates] Exa timed out after ${EXA_TIMEOUT_MS}ms for ${artistName}`);
+    } else {
+      console.warn(`[artist-updates] Exa threw for ${artistName}:`, e);
+    }
+    return { snippets: "", citations: [] };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // ── Gemini fact generation (batched: N facts in one call) ─────────────
 
 interface FactGenerationContext {
@@ -278,12 +357,16 @@ interface FactGenerationContext {
   /** Top tracks with album + release year — catalog grounding for
    *  sparse prompts. Ignored in non-sparse mode. */
   topTracks?: SpotifyTopTrack[];
+  /** Exa research snippets — multi-page text + highlights from journalism
+   *  about the artist. Empty string if Exa is unavailable or returned
+   *  nothing. Sparse mode skips Exa and ignores this field. */
+  researchSnippets?: string;
 }
 
 async function generateArtistFacts(
   ctx: FactGenerationContext,
 ): Promise<{ headline: string; body: string }[]> {
-  const { artistName, tier, count, sparse, genres, topTracks } = ctx;
+  const { artistName, tier, count, sparse, genres, topTracks, researchSnippets } = ctx;
   const apiKey = Deno.env.get("GOOGLE_AI_API_KEY");
   if (!apiKey) {
     console.warn("[artist-updates] GOOGLE_AI_API_KEY not set — skipping facts");
@@ -367,17 +450,30 @@ real track name from above. NEVER invent collaborators, labels, or
 quotes. NEVER claim anything that can't be verified from the list.`
     : "";
 
+  const exaResearchBlock = !sparse && researchSnippets
+    ? `\n\nEXA RESEARCH (multi-page journalism about ${artistName} — treat this as the PRIMARY ground truth, ahead of training data and ahead of Google Search):
+${researchSnippets}
+
+REQUIREMENTS WHEN USING EXA RESEARCH:
+- Pull the most specific, surprising, or non-obvious detail from the snippets above. Vague summaries fail the SWAP TEST — anchor every fact in something concrete that came out of the research.
+- Every fact MUST contain at least TWO of: a real person's name, a year/date, a place/venue, a song or album title, a label, a producer, an engineer, a co-writer, or a verifiable number. Vibe statements ("X has a unique sound") fail.
+- Quote sparingly. If you quote, attribute to a named source from the research and keep it under 12 words.
+- If the research contradicts what you "know" from training data, trust the research.
+- If the research is thin and you can't pull two concrete anchors, return zero nuggets — empty array is better than a generic fact.
+`
+    : "";
+
   const prompt = `${CONSTITUTION_PREAMBLE}
 
 ${writerRules}
 
-${tierGuidance}${sparseGroundingBlock}
+${tierGuidance}${sparseGroundingBlock}${exaResearchBlock}
 
-You have Google Search available as a tool. USE IT FIRST to find
-verified, recent information about ${artistName} — interviews,
-production credits, label history, scene context, recent press. Pull
-the strongest grounded fact from what you find. Only fall back to the
-catalog data above if Google Search returns nothing usable.
+You also have Google Search available as a tool. USE IT to verify or
+extend the Exa research above — interviews, production credits, label
+history, scene context, recent press. Cross-check any specific name /
+year / venue / song title before committing to it. Only fall back to
+the catalog data above if both Exa and Google Search are empty.
 
 ARTIST NAME LOCK: refer to the artist as "${artistName}" throughout —
 that's their public/stage name and how the audience knows them.
@@ -487,7 +583,14 @@ function buildFactUpdate(
   headline: string,
   body: string,
   index: number,
+  citation?: { title: string; url: string },
 ): ArtistUpdate {
+  // Prefer an Exa citation if we have one — gives the fact a real
+  // article to click through to. Falls back to the generic MusicNerd
+  // source attribution when Exa was unavailable / sparse mode.
+  const source = citation && citation.url
+    ? { type: "web", title: citation.title, url: citation.url }
+    : { type: "generated", publisher: "MusicNerd" };
   return {
     artistId: artist.id,
     artistName: artist.name,
@@ -495,7 +598,7 @@ function buildFactUpdate(
     kind: "fact",
     headline,
     body,
-    source: { type: "generated", publisher: "MusicNerd" },
+    source,
     // Stable-ish id so the client can dedupe inside a cache row if we
     // ever regenerate. Uses the index within the fact set.
     nuggetId: `fact-${artist.id}-${index}`,
@@ -800,13 +903,19 @@ serve(async (req) => {
   // throw mid-flow. catch + re-throw so the platform still sees a
   // 500 — we just want to make sure the sentinel doesn't outlive us.
   try {
-    // 4. Fetch Spotify data in parallel (release always, top tracks
-    //    only when sparse), then feed into Gemini. Running top-tracks
-    //    alongside release keeps wall time flat even on the sparse
-    //    path — the sequencing penalty is only on facts-after-tracks.
-    const [release, topTracks] = await Promise.all([
+    // 4. Fetch Spotify data + (non-sparse only) Exa research in parallel,
+    //    then feed everything into Gemini. Exa adds 3-6s but anchors the
+    //    fact in real journalism instead of training-data trivia, which
+    //    was the source of "shallow" complaints. Sparse artists skip
+    //    Exa — by definition there's no journalism, and the catalog-
+    //    grounded prompt is what keeps them from hallucinating.
+    const exaApiKey = Deno.env.get("EXA_API_KEY");
+    const [release, topTracks, exaResult] = await Promise.all([
       fetchRecentRelease(token, artistInfo.id),
       isSparse ? fetchArtistTopTracks(token, artistInfo.id) : Promise.resolve([] as SpotifyTopTrack[]),
+      !isSparse && exaApiKey
+        ? researchArtistOnExa(artistInfo.name, exaApiKey)
+        : Promise.resolve({ snippets: "", citations: [] as { title: string; url: string }[] }),
     ]);
 
     const facts = await generateArtistFacts({
@@ -816,6 +925,7 @@ serve(async (req) => {
       sparse: isSparse,
       genres: artistInfo.genres,
       topTracks: isSparse ? topTracks : undefined,
+      researchSnippets: exaResult.snippets,
     });
 
     const releaseAgeDays = release ? daysSince(release.release_date) : null;
@@ -833,7 +943,11 @@ serve(async (req) => {
     }
 
     facts.forEach((f, i) => {
-      updates.push(buildFactUpdate(artistInfo, f.headline, f.body, i));
+      // Round-robin through Exa citations so multiple facts on the same
+      // artist don't all link to the same article (we ask for 1 fact per
+      // artist today but this keeps it correct if FACTS_PER_ARTIST grows).
+      const citation = exaResult.citations[i % Math.max(exaResult.citations.length, 1)];
+      updates.push(buildFactUpdate(artistInfo, f.headline, f.body, i, citation));
     });
 
     if (updates.length === 0) {


### PR DESCRIPTION
## Summary

Pete's staging walkthrough surfaced 8 issues; this PR ships fixes for all of them.

- **Listen UI** — headline cut-off + timeline-dot overlap (commit `2b93703`); cover art "PFP circle" look replaced with viewport-responsive sizing + softer vignette (commit `c818d98`).
- **Connect/preparing redirect loop** when JWT expires mid-onboarding (commit `2b93703`).
- **SSE→cache fallback** so deeper-tier listens that hit a network failure recover from the canonical cache row instead of stranding the user on a blank Listen page (commit `09e0d9c`).
- **Browse new-release card** now navigates Apple Music users to /listen/ correctly — empty URI in route lets `findCatalogUri` resolve the apple equivalent (commit `c818d98`).
- **Stories tier switch** — detect tier transitions in `usePreGeneratedStories` and re-warm all stories (instead of inheriting any stray same-tier cache rows from a prior visit). Drops kickedOff entries scoped to the new tier so curious→casual→curious doesn't stick (commit `c818d98`).
- **artist-updates fact quality** — add Exa research before Gemini for non-sparse artists, inject snippets as primary ground truth, require two concrete anchors per fact, surface Exa citation as the fact `source` (commit `c818d98`).
- **Tier picker on every login** — explicit `TierPicker` dropdown next to the Browse greeting replaces the hidden "click the logo to cycle" interaction (commit `c818d98`).

## Test plan

- [ ] Listen on iPhone-sized viewport: headline never overlaps timeline marker dots, cover art fills the frame without circle-vignette look
- [ ] Apple Music user: tap a NEW RELEASE card on Browse → song plays via Apple Music
- [ ] Switch tier casual→curious on Browse: all 5 stories show "warming up", regenerate, then flip ready
- [ ] Tap a top-artist FACT card on Browse: headline contains a real name + year/place; tap source → real article opens
- [ ] Force an SSE failure (e.g., toggle network mid-stream on a listen-3 track) → cached listen-1 nuggets render; no blank page
- [ ] On every Browse mount, `Tier:` dropdown is visible next to greeting and clicking changes tier
- [ ] `npm test && npm run build` clean