### PR TITLE
chore(review): PR #83 review follow-ups

### DIFF
--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader2, X, ExternalLink } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -60,19 +60,19 @@ function ArtistUpdatesSectionInner({
 
   // cardKey is a pure function — see module-level definition below.
 
-  // Find the currently-expanded update so we can render its expanded
-  // content. Linear scan across groups since expandedKey is global.
-  // Worst case is O(artists × updates_per_artist) ≈ 3 × 3 = 9 today.
-  // Fine at this scale; if DEFAULT_MAX_ARTISTS or per-artist cap grow
-  // significantly, switch to a Map keyed by cardKey built once per
-  // render.
-  let expandedUpdate: ArtistUpdate | null = null;
-  if (expandedKey) {
+  // Look up the currently-expanded update so we can render its
+  // expanded content. Memoized on (expandedKey, groups) so the scan
+  // doesn't run on every keystroke / scroll / unrelated re-render
+  // (parent context emits readyCount changes as artist rows resolve).
+  // Worst case O(artists × updates_per_artist) ≈ 3 × 3 = 9 today.
+  const expandedUpdate = useMemo<ArtistUpdate | null>(() => {
+    if (!expandedKey) return null;
     for (const g of groups) {
       const found = g.updates?.find((u) => cardKey(u) === expandedKey);
-      if (found) { expandedUpdate = found; break; }
+      if (found) return found;
     }
-  }
+    return null;
+  }, [expandedKey, groups]);
 
   const openArtistAtNugget = useCallback((update: ArtistUpdate) => {
     // New-release / collab cards: tap should land on Listen for the

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -144,6 +144,22 @@ export function sanitizeNugget(n: Nugget): Nugget {
   return headline === n.headline ? n : { ...n, headline };
 }
 
+/**
+ * Narrow-validate a `sources` JSONB value from nugget_cache before casting
+ * to `Source`. Required keys: `id` + `type` (both strings) — these are
+ * what every downstream consumer reads. Optional fields aren't checked;
+ * if the row lacks them the UI falls back to safe defaults.
+ *
+ * Without this guard a malformed row (manual DB edit, partial migration,
+ * server bug) would silently corrupt the client cache and crash whatever
+ * tries to read `source.title` / `source.url`.
+ */
+export function isValidSourceShape(v: unknown): v is Source {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.id === "string" && typeof o.type === "string";
+}
+
 export function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {
   return {
     id: nuggetId, trackId, timestampSec, durationMs: 7000,
@@ -234,7 +250,10 @@ async function pollForReadyNuggets(
     if (data?.status === "ready" && (data.nuggets as Nugget[] | null)?.length) {
       const nuggs = (data.nuggets as Nugget[]).map(sanitizeNugget);
       const srcs = new Map<string, Source>();
-      for (const [key, val] of Object.entries(data.sources as Record<string, Source>)) {
+      const rawSourcesObj = (data.sources ?? {}) as Record<string, unknown>;
+      for (const [key, val] of Object.entries(rawSourcesObj)) {
+        if (key.startsWith("_")) continue;
+        if (!isValidSourceShape(val)) continue;
         srcs.set(key, val);
       }
       return { nuggets: nuggs, sources: srcs };
@@ -535,10 +554,12 @@ export function useAINuggets(
           const cachedSources = new Map<string, Source>();
           const rawSourcesObj = (cached.sources ?? {}) as Record<string, unknown>;
           for (const [key, val] of Object.entries(rawSourcesObj)) {
-            // Skip meta keys (anything beginning with `_`) and non-Source
-            // shapes (e.g. artistSummary string, externalLinks array).
-            if (key.startsWith("_") || typeof val !== "object" || val === null || Array.isArray(val)) continue;
-            cachedSources.set(key, val as Source);
+            // Skip meta keys (anything beginning with `_`) and any value
+            // that doesn't satisfy the Source shape contract — a
+            // malformed row would otherwise silently corrupt the cache.
+            if (key.startsWith("_")) continue;
+            if (!isValidSourceShape(val)) continue;
+            cachedSources.set(key, val);
           }
           if (cancelledRef.current) return;
           setNuggets(cachedNuggets);

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -156,6 +156,13 @@ export function sanitizeNugget(n: Nugget): Nugget {
  * Optional fields (`embedId`, `thumbnailUrl`, etc.) aren't checked
  * here — the type marks them optional, so consumers must already
  * null-guard those reads.
+ *
+ * NOTE: URL scheme (`javascript:`, `data:`) is NOT validated here —
+ * that's a render-time concern. Every call site that renders
+ * `source.url` in an `<a href>` / `window.open()` MUST enforce the
+ * `^https?://` allowlist independently. Today that gate lives in
+ * `ExpandedUpdateModal`; if you add a new render site, replicate it
+ * there too or this turns into an XSS vector.
  */
 export function isValidSourceShape(v: unknown): v is Source {
   if (!v || typeof v !== "object" || Array.isArray(v)) return false;

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -145,19 +145,26 @@ export function sanitizeNugget(n: Nugget): Nugget {
 }
 
 /**
- * Narrow-validate a `sources` JSONB value from nugget_cache before casting
- * to `Source`. Required keys: `id` + `type` (both strings) — these are
- * what every downstream consumer reads. Optional fields aren't checked;
- * if the row lacks them the UI falls back to safe defaults.
+ * Narrow-validate a `sources` JSONB value from nugget_cache before
+ * casting to `Source`. Verifies every REQUIRED field on the Source
+ * type (`id`, `type`, `title`, `publisher`, `url`) is a string —
+ * downstream consumers commonly call `source.url.startsWith(...)`
+ * and `source.title.toLowerCase()` without null-guarding, so a
+ * malformed row that's missing any of those would crash the page
+ * rather than be silently dropped.
  *
- * Without this guard a malformed row (manual DB edit, partial migration,
- * server bug) would silently corrupt the client cache and crash whatever
- * tries to read `source.title` / `source.url`.
+ * Optional fields (`embedId`, `thumbnailUrl`, etc.) aren't checked
+ * here — the type marks them optional, so consumers must already
+ * null-guard those reads.
  */
 export function isValidSourceShape(v: unknown): v is Source {
   if (!v || typeof v !== "object" || Array.isArray(v)) return false;
   const o = v as Record<string, unknown>;
-  return typeof o.id === "string" && typeof o.type === "string";
+  return typeof o.id === "string"
+    && typeof o.type === "string"
+    && typeof o.title === "string"
+    && typeof o.publisher === "string"
+    && typeof o.url === "string";
 }
 
 export function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, trackId: string, timestampSec: number): Nugget {

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -22,14 +22,24 @@ export default function Browse() {
   const navigate = useNavigate();
   const { profile, saveProfile } = useUserProfile();
   const { tierConfirmed } = useTierGate();
-  // direct-navigating to /browse (refresh, bookmark,
-  // new tab) skips PreparingExperience and lands here with
-  // tierConfirmed=false. StoriesProvider + ArtistUpdatesProvider both
-  // gate pre-gen on tierConfirmed, so Browse would render empty rails
-  // and look broken. Route through /preparing — which shows the picker
-  // when needed — and let it hand back to /browse.
+  // Direct-navigating to /browse (refresh, bookmark, new tab) skips
+  // PreparingExperience and lands here with tierConfirmed=false.
+  // StoriesProvider + ArtistUpdatesProvider both gate pre-gen on
+  // tierConfirmed, so Browse would render empty rails. Route through
+  // /preparing for the picker.
+  //
+  // One-shot guard: fire the redirect at most once per mount. Without
+  // this, if a transient context re-emit ever flipped tierConfirmed
+  // false→true→false the user could be yanked out of Browse mid-
+  // session. The legitimate "needs to confirm tier" case happens
+  // exactly at mount; later flips during an active session are
+  // either bugs or expected (sign-out clears the flag, which is its
+  // own navigation path).
+  const tierRedirectFiredRef = useRef(false);
   useEffect(() => {
+    if (tierRedirectFiredRef.current) return;
     if (profile && !tierConfirmed) {
+      tierRedirectFiredRef.current = true;
       navigate("/preparing?next=/browse", { replace: true });
     }
   }, [profile, tierConfirmed, navigate]);

--- a/src/test/isValidSourceShape.test.ts
+++ b/src/test/isValidSourceShape.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { isValidSourceShape } from "@/hooks/useAINuggets";
+
+// `isValidSourceShape` gates DB → in-memory Map conversion in
+// useAINuggets. Source type requires { id, type, title, publisher, url }
+// all to be strings. Anything missing causes downstream consumers
+// (which call `.startsWith()` / `.toLowerCase()` without null-guarding)
+// to crash. Tests below lock the contract.
+
+describe("isValidSourceShape", () => {
+  const valid = {
+    id: "src-1",
+    type: "article",
+    title: "Some Article",
+    publisher: "MusicNerd",
+    url: "https://example.com/x",
+  };
+
+  it("returns true for a fully-shaped Source", () => {
+    expect(isValidSourceShape(valid)).toBe(true);
+  });
+
+  it("returns true even when optional fields are present", () => {
+    expect(isValidSourceShape({ ...valid, embedId: "abc", quoteSnippet: "q" })).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(isValidSourceShape(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isValidSourceShape(undefined)).toBe(false);
+  });
+
+  it("rejects primitives", () => {
+    expect(isValidSourceShape("string")).toBe(false);
+    expect(isValidSourceShape(42)).toBe(false);
+    expect(isValidSourceShape(true)).toBe(false);
+  });
+
+  it("rejects arrays", () => {
+    expect(isValidSourceShape([valid])).toBe(false);
+    expect(isValidSourceShape([])).toBe(false);
+  });
+
+  it("rejects when id is missing", () => {
+    const { id, ...rest } = valid;
+    void id;
+    expect(isValidSourceShape(rest)).toBe(false);
+  });
+
+  it("rejects when type is missing", () => {
+    const { type, ...rest } = valid;
+    void type;
+    expect(isValidSourceShape(rest)).toBe(false);
+  });
+
+  it("rejects when title is missing", () => {
+    const { title, ...rest } = valid;
+    void title;
+    expect(isValidSourceShape(rest)).toBe(false);
+  });
+
+  it("rejects when publisher is missing", () => {
+    const { publisher, ...rest } = valid;
+    void publisher;
+    expect(isValidSourceShape(rest)).toBe(false);
+  });
+
+  it("rejects when url is missing — most important case, this is what crashed pages pre-guard", () => {
+    const { url, ...rest } = valid;
+    void url;
+    expect(isValidSourceShape(rest)).toBe(false);
+  });
+
+  it("rejects when any required field is not a string (number url)", () => {
+    expect(isValidSourceShape({ ...valid, url: 123 })).toBe(false);
+  });
+
+  it("rejects when any required field is null", () => {
+    expect(isValidSourceShape({ ...valid, title: null })).toBe(false);
+  });
+
+  it("doesn't enforce a value-shape for the URL — scheme validation is a downstream concern (XSS guard)", () => {
+    // The shape guard is about cache-row sanity, not URL safety.
+    // The XSS / scheme check lives at render time (e.g.
+    // ExpandedUpdateModal's `/^https?:\/\//` test).
+    expect(isValidSourceShape({ ...valid, url: "javascript:void(0)" })).toBe(true);
+  });
+});

--- a/src/test/isValidSourceShape.test.ts
+++ b/src/test/isValidSourceShape.test.ts
@@ -44,32 +44,27 @@ describe("isValidSourceShape", () => {
   });
 
   it("rejects when id is missing", () => {
-    const { id, ...rest } = valid;
-    void id;
+    const { id: _id, ...rest } = valid;
     expect(isValidSourceShape(rest)).toBe(false);
   });
 
   it("rejects when type is missing", () => {
-    const { type, ...rest } = valid;
-    void type;
+    const { type: _type, ...rest } = valid;
     expect(isValidSourceShape(rest)).toBe(false);
   });
 
   it("rejects when title is missing", () => {
-    const { title, ...rest } = valid;
-    void title;
+    const { title: _title, ...rest } = valid;
     expect(isValidSourceShape(rest)).toBe(false);
   });
 
   it("rejects when publisher is missing", () => {
-    const { publisher, ...rest } = valid;
-    void publisher;
+    const { publisher: _publisher, ...rest } = valid;
     expect(isValidSourceShape(rest)).toBe(false);
   });
 
   it("rejects when url is missing — most important case, this is what crashed pages pre-guard", () => {
-    const { url, ...rest } = valid;
-    void url;
+    const { url: _url, ...rest } = valid;
     expect(isValidSourceShape(rest)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
Addresses the priority items from the PR #83 release review:

- 🔴 **Source shape guard**: extracted `isValidSourceShape()` narrow guard in `useAINuggets`. Applied at both DB→Map conversion sites (`pollForReadyNuggets` + main cache-hit path). Previously a malformed `nugget_cache.sources` row (manual edit, partial migration) would silently corrupt the client cache via the `as Source` cast.
- 🔴 **Browse redirect ping-pong guard**: one-shot `useRef` so the tier-redirect fires at most once per Browse mount. A transient `tierConfirmed` flip during an active session can no longer yank the user out of Browse.
- 🟠 **useMemo for `expandedUpdate` lookup**: wrap the group scan so it doesn't run on every keystroke / scroll / unrelated re-render.

## Deferred (per reviewer's "follow-up not blocker" classification)
- URL domain allowlist for AI-generated source links
- TierGateContext unit tests

## Test Plan
- [x] `npm test` — 317/317 passing
- [x] `npm run build` — clean
- [ ] Verify Browse loads cleanly with tier confirmed; tier-not-confirmed path still redirects to `/preparing` once
- [ ] Verify tap → expand → close on artist update cards (the useMemo change shouldn't affect behavior)

After merge into staging, this will roll into PR #83 automatically.