### PR TITLE
chore(review): PR #85 review follow-ups

### DIFF
--- a/src/contexts/TierGateContext.tsx
+++ b/src/contexts/TierGateContext.tsx
@@ -22,7 +22,10 @@ import type { UserProfile } from "@/mock/types";
  * the user confirms.
  */
 
-const STORAGE_KEY = "musicnerd_tier_confirmed";
+// Exported so external clean-up paths (useSignOut, Connect's OAuth
+// reset) can clear the flag without re-declaring the literal.
+export const TIER_CONFIRMED_STORAGE_KEY = "musicnerd_tier_confirmed";
+const STORAGE_KEY = TIER_CONFIRMED_STORAGE_KEY;
 
 interface TierGateContextValue {
   tierConfirmed: boolean;

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -1045,8 +1045,15 @@ export function useAINuggets(
             console.warn(`[useAINuggets] SSE failed; falling back to cached nuggets (${fbNuggets.length}) for ${dbCacheKey}`);
             const sanitized = fbNuggets.map(sanitizeNugget);
             const fbSources = new Map<string, Source>();
-            const rawSources = (fallback!.sources ?? {}) as Record<string, Source>;
-            for (const [k, v] of Object.entries(rawSources)) fbSources.set(k, v);
+            const rawSources = (fallback!.sources ?? {}) as Record<string, unknown>;
+            for (const [k, v] of Object.entries(rawSources)) {
+              // Same shape guard as the primary cache-read path — a
+              // malformed row that slips into this catch-block fallback
+              // would otherwise crash downstream on source.url reads.
+              if (k.startsWith("_")) continue;
+              if (!isValidSourceShape(v)) continue;
+              fbSources.set(k, v);
+            }
             setNuggets(sanitized);
             setSources(fbSources);
             setNuggetCache(cacheKey, { nuggets: sanitized, sources: fbSources, listenCount: currentListenCount });

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -153,8 +153,16 @@ export function useArtistUpdates(
     if (pool.length === 0) return [] as string[];
     const start = rotationStart % pool.length;
     const out: string[] = [];
-    for (let i = 0; i < maxArtists; i++) {
-      out.push(pool[(start + i) % pool.length]);
+    const seen = new Set<string>();
+    // Cap by min(maxArtists, pool.length) so a small pool (new account
+    // with < 3 top artists) doesn't wrap and render the same artist
+    // twice in the rail.
+    const sliceSize = Math.min(maxArtists, pool.length);
+    for (let i = 0; i < sliceSize; i++) {
+      const candidate = pool[(start + i) % pool.length];
+      if (seen.has(candidate)) continue;
+      seen.add(candidate);
+      out.push(candidate);
     }
     return out;
   }, [profile?.topArtists, maxArtists, rotationStart]);

--- a/src/hooks/usePreGeneratedStories.ts
+++ b/src/hooks/usePreGeneratedStories.ts
@@ -358,13 +358,11 @@ export function usePreGeneratedStories(
     // We still want a real content change (different top-N tracks
     // after a user switch / SpotifyCallback) to re-run; trackSig
     // captures that without re-running on identity-only churn.
-    //
-    // `setNuggetCache` is also used inside but omitted — it's
-    // `useCallback(..., [])`-stable in PlayerContext, so adding it
-    // would only add noise. If that ever changes, this suppression
-    // becomes a stale-closure trap.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trackSig, tier, maxStories, maxConcurrent]);
+    // `setNuggetCache` is listed explicitly (rather than via
+    // eslint-disable) — it's useCallback-stable in PlayerContext
+    // today, so listing it costs nothing; if that ever changes
+    // we still want the lint to flag it.
+  }, [trackSig, tier, maxStories, maxConcurrent, setNuggetCache]);
 
   return { stories, loading };
 }

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -24,6 +24,8 @@ import { supabase } from "@/integrations/supabase/client";
 import { clearStoredProfile } from "./useMusicNerdState";
 import { clearSpotifyToken } from "./useSpotifyToken";
 import { clearAppleMusicToken } from "./useAppleMusicToken";
+import { SPOTIFY_OAUTH_PENDING_KEY } from "./useSpotifyAuth";
+import { TIER_CONFIRMED_STORAGE_KEY } from "@/contexts/TierGateContext";
 
 // Legacy PKCE sessionStorage keys — the Supabase-managed OAuth flow
 // doesn't create these, but a tab that was mid-signin at cutover time
@@ -94,11 +96,11 @@ export function useSignOut() {
     // below would also clear it via tab context teardown, but the
     // explicit removal keeps behavior consistent if that reload is
     // ever swapped for a soft navigate.
-    sessionStorage.removeItem("musicnerd_tier_confirmed");
+    sessionStorage.removeItem(TIER_CONFIRMED_STORAGE_KEY);
     // Same logic for the Spotify OAuth-pending flag set by
     // signInWithSpotify — must clear so the next sign-in doesn't pick
     // up a stale "we're mid-OAuth" signal on Connect mount.
-    sessionStorage.removeItem("musicnerd_spotify_oauth_pending");
+    sessionStorage.removeItem(SPOTIFY_OAUTH_PENDING_KEY);
 
     // 5. Hard navigate. See module-level comment for why a full reload
     //    instead of React Router navigate().

--- a/src/hooks/useSpotifyAuth.ts
+++ b/src/hooks/useSpotifyAuth.ts
@@ -25,6 +25,7 @@
  */
 
 import { supabase } from "@/integrations/supabase/client";
+import { TIER_CONFIRMED_STORAGE_KEY } from "@/contexts/TierGateContext";
 
 const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID as string;
 // `user-library-read` was added 2026-05-10 so spotify-taste can call
@@ -66,7 +67,7 @@ export async function signInWithSpotify(): Promise<void> {
     // TierGateProvider's useState initializer reads the cleared
     // state on the very first render of /preparing — no warming-
     // spinner flash before the tier picker, no stale rotation cursor.
-    sessionStorage.removeItem("musicnerd_tier_confirmed");
+    sessionStorage.removeItem(TIER_CONFIRMED_STORAGE_KEY);
     sessionStorage.removeItem("musicnerd_artist_rotation_resolved");
   } catch {
     // Storage disabled — the overlay will still come up via the

--- a/src/lib/storySource.ts
+++ b/src/lib/storySource.ts
@@ -71,7 +71,16 @@ export function selectStorySource(
   if (!profile) return { tracks: [], source: "empty" };
   const visitedMap = visited ?? readVisited();
 
-  const liked = profile.likedTracks ?? [];
+  // Sort explicitly by addedAt desc — spotify-taste's /me/tracks
+  // call returns this order by default, but making the contract
+  // self-contained here means the freshest-first guarantee survives
+  // any upstream change to the fetch path or downstream re-ordering
+  // (DB writes, applyTastePatch merge, etc.).
+  const liked = [...(profile.likedTracks ?? [])].sort((a, b) => {
+    const ta = a.addedAt ? Date.parse(a.addedAt) : 0;
+    const tb = b.addedAt ? Date.parse(b.addedAt) : 0;
+    return tb - ta;
+  });
   const top = profile.trackImages ?? [];
 
   // Helper: filter liked tracks to a date window + unvisited + has URI.
@@ -125,10 +134,8 @@ export function selectStorySource(
   }
 
   // No window had ≥ targetCount. Try ALL liked tracks (any age, just
-  // unvisited + has URI). Order is preserved from `liked`, which
-  // spotify-taste returns sorted `added_at desc` (newest first) per
-  // Spotify's /me/tracks default. If that contract ever changes, the
-  // freshest-first guarantee silently breaks here.
+  // unvisited + has URI). `liked` is sorted addedAt-desc at the top
+  // of this function, so the freshest unvisited tracks come first.
   const allLikedUnvisited = liked.filter(
     (l) => !!l.uri && !visitedMap.has(trackKey(l)),
   );

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -14,7 +14,7 @@ import { useAppleMusicToken } from "@/hooks/useAppleMusicToken";
 import { useSpotifyPostSigninSync } from "@/hooks/useSpotifyPostSigninSync";
 import { ensureSupabaseSession } from "@/lib/ensureSupabaseSession";
 import SpotifySyncingOverlay from "@/components/SpotifySyncingOverlay";
-import { useTierGate } from "@/contexts/TierGateContext";
+import { useTierGate, TIER_CONFIRMED_STORAGE_KEY } from "@/contexts/TierGateContext";
 
 type Tier = "casual" | "curious" | "nerd";
 
@@ -111,7 +111,7 @@ export default function Connect() {
     try { pending = sessionStorage.getItem(SPOTIFY_OAUTH_PENDING_KEY) === "1"; } catch { /* noop */ }
     if (!pending) return;
     try {
-      sessionStorage.removeItem("musicnerd_tier_confirmed");
+      sessionStorage.removeItem(TIER_CONFIRMED_STORAGE_KEY);
       sessionStorage.removeItem("musicnerd_artist_rotation_resolved");
       window.dispatchEvent(new Event("musicnerd:tier-state-changed"));
     } catch { /* noop */ }


### PR DESCRIPTION
## Summary
Addresses the blockers + yellows from the PR #85 release review.

### Blockers
- 🔴 **`isValidSourceShape` in SSE catch-block fallback** (`useAINuggets.ts`): the recovery path on SSE failure now applies the same shape guard as the primary cache-read path. A malformed row that slipped into this catch path could previously crash the Listen page on `source.url` reads after a network failure.
- 🔴 **Storage key duplication**: extracted `TIER_CONFIRMED_STORAGE_KEY` as a named export from `TierGateContext`. `useSignOut`, `useSpotifyAuth`, and `Connect` now import the constant instead of using the string literal `"musicnerd_tier_confirmed"`. `SPOTIFY_OAUTH_PENDING_KEY` similarly wired into `useSignOut`. A future rename of either key now propagates everywhere automatically.

### Yellows
- 🟡 **`storySource` self-contained sort**: explicit `liked.sort((a, b) => addedAt-desc)` at the top of `selectStorySource`. The freshest-first guarantee no longer depends on `spotify-taste` preserving Spotify's `/me/tracks` default order through the DB merge / patch cycle.
- 🟡 **`useArtistUpdates` rotation dedupe**: clamp to `min(maxArtists, pool.length)` + Set-based dedupe. A pool of 2 with `maxArtists=3` previously produced `[A, B, A]`; now produces `[A, B]` (no duplicate row in the rail).
- 🟡 **`setNuggetCache` eslint-disable removed**: `usePreGeneratedStories` now lists `setNuggetCache` in the effect deps explicitly. It's `useCallback`-stable today so the listing is a no-op, but a future change to its identity would now flag through the lint.

### Not addressed (acknowledged in PR #85 review as non-blocking)
- CI-level deploy guard for `generate-nuggets`: infrastructure work outside this branch. Top-of-file ⚠ DEPLOY GUARD comment + manual `supabase functions list` check remain the safeguards.
- `CATALOG_PLATFORMS` vs `BANNED_PHRASES` "last.fm" overlap in `generate-nuggets`: that file has a deploy guard, not shipping from this branch.
- Liked-tracks JSONB size: already capped at `slice(0, 50)` on the server.
- TierGateContext / useReleasePreGen / storyVisited unit tests: follow-up PRs.

## Test Plan
- [x] `npm test` — 331/331 passing
- [x] `npm run build` — clean
- [ ] Smoke-test sign-out flow: tier-confirmed sessionStorage key + OAuth-pending key both clear (verify via DevTools → Application → Session Storage after sign-out)
- [ ] New account with < 3 top artists: "Your artists, lately" renders ≤ 2 unique rows (no duplicate)

Once merged to staging, PR #85 (staging → main) picks this up automatically.