### PR TITLE
chore(review): PR #85 round-2 followups — TierPicker confirm + Listen multi-trigger + URL scheme guards

### DIFF
--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -140,7 +140,7 @@ function FactCard({ update, expanded, pulsing, onToggle, registerRef }: FactCard
       {expanded && (
         <div className="px-4 pb-4 -mt-1 flex flex-col gap-2">
           <p className="text-sm leading-relaxed text-white/70">{update.body}</p>
-          {update.source?.url && (
+          {update.source?.url && /^https?:\/\//i.test(update.source.url) && (
             <a
               href={update.source.url}
               target="_blank"

--- a/src/components/companion/NuggetCategoryCard.tsx
+++ b/src/components/companion/NuggetCategoryCard.tsx
@@ -83,7 +83,7 @@ export default function NuggetCategoryCard({ label, nuggets, colorClass }: Props
             </div>
 
             {/* Source link */}
-            {nugget.source?.url && (
+            {nugget.source?.url && /^https?:\/\//i.test(nugget.source.url) && (
               <a
                 href={nugget.source.url}
                 target="_blank"

--- a/src/components/overlays/MediaOverlay.tsx
+++ b/src/components/overlays/MediaOverlay.tsx
@@ -90,7 +90,7 @@ export default function MediaOverlay({ source, onClose }: Props) {
           >
             Return to Listening
           </button>
-          {source.url && (
+          {source.url && /^https?:\/\//i.test(source.url) && (
             <a
               href={source.url}
               target="_blank"

--- a/src/components/overlays/NuggetDeepDive.tsx
+++ b/src/components/overlays/NuggetDeepDive.tsx
@@ -346,7 +346,7 @@ export default function NuggetDeepDive({ nugget, source, artist, trackTitle, onC
             {entries.length === 0 ? "Tell me more" : "Keep exploring"}
           </button>
 
-          {source?.url && (
+          {source?.url && /^https?:\/\//i.test(source.url) && (
             <a
               ref={buttonRefs[1] as React.RefObject<HTMLAnchorElement>}
               href={source.url}

--- a/src/components/overlays/ReadingOverlay.tsx
+++ b/src/components/overlays/ReadingOverlay.tsx
@@ -71,7 +71,7 @@ export default function ReadingOverlay({ source, onClose }: Props) {
           >
             Return to Listening
           </button>
-          {source.url && (
+          {source.url && /^https?:\/\//i.test(source.url) && (
             <a
               href={source.url}
               target="_blank"

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -21,7 +21,7 @@ export default function Browse() {
   const [searchOpen, setSearchOpen] = useState(false);
   const navigate = useNavigate();
   const { profile, saveProfile } = useUserProfile();
-  const { tierConfirmed } = useTierGate();
+  const { tierConfirmed, confirmTier } = useTierGate();
   // Direct-navigating to /browse (refresh, bookmark, new tab) skips
   // PreparingExperience and lands here with tierConfirmed=false.
   // StoriesProvider + ArtistUpdatesProvider both gate pre-gen on
@@ -339,6 +339,12 @@ export default function Browse() {
               onSelect={(t) => {
                 if (!profile) return;
                 if (t !== tier) saveProfile({ ...profile, calculatedTier: t });
+                // Re-confirm so StoriesProvider + ArtistUpdatesProvider
+                // detect a tier switch and re-warm at the new tier.
+                // Without this, the dropdown saved the new tier but
+                // pre-gen never re-fired this session — "change it
+                // any time" wasn't actually live.
+                confirmTier(t);
               }}
             />
           </div>

--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -349,6 +349,7 @@ export default function Companion() {
                 <h3 className="text-lg font-bold text-foreground mb-3">Explore Further</h3>
                 <div className="space-y-2">
                   {data.externalLinks.map((link, i) => {
+                    if (!link.url || !/^https?:\/\//i.test(link.url)) return null;
                     const linkLabel = link.label || link.name || "Link";
                     const Icon =
                       linkLabel.toLowerCase().includes("wiki") ? BookOpen :

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1127,17 +1127,39 @@ export default function Listen() {
     if (!isPlaying && aiFromCache) return;
     const shouldTrigger = (n: typeof trackNuggets[0]) =>
       !aiFromCache || currentTime >= n.timestampSec;
+    // Collect every newly-eligible nugget for this tick first, then
+    // commit state once. If two nuggets' timestamps were both crossed
+    // in the same tick (e.g. after a seek or cache restore), the
+    // previous per-iter setActiveNugget calls clobbered each other
+    // and only the last one rendered — intermediates landed in
+    // shownNuggetIds but never showed as the active card. Now the
+    // intermediates are explicitly pushed into dismissedNuggets so
+    // they appear in the dismissed strip / nerd reel.
+    const newlyEligible: typeof trackNuggets = [];
     for (let i = 1; i < trackNuggets.length; i++) {
       const n = trackNuggets[i];
       if (shownNuggetIds.has(n.id)) continue;
       if (!shouldTrigger(n)) continue;
-      if (activeNugget && activeNugget.id !== n.id) {
-        setDismissedNuggets((prev) => new Map(prev).set(activeNugget.id, activeNugget));
-      }
-      setActiveNugget(n);
-      setReopenedNuggetId(null);
-      setShownNuggetIds((s) => new Set(s).add(n.id));
+      newlyEligible.push(n);
     }
+    if (newlyEligible.length === 0) return;
+    const finalActive = newlyEligible[newlyEligible.length - 1];
+    const intermediates = newlyEligible.slice(0, -1);
+    setDismissedNuggets((prev) => {
+      const next = new Map(prev);
+      if (activeNugget && activeNugget.id !== finalActive.id) {
+        next.set(activeNugget.id, activeNugget);
+      }
+      for (const n of intermediates) next.set(n.id, n);
+      return next;
+    });
+    setActiveNugget(finalActive);
+    setReopenedNuggetId(null);
+    setShownNuggetIds((s) => {
+      const next = new Set(s);
+      for (const n of newlyEligible) next.add(n.id);
+      return next;
+    });
   }, [currentTime, isPlaying, nerdActive, trackNuggets, activeNugget, shownNuggetIds, reopenedNuggetId, aiFromCache]);
 
 


### PR DESCRIPTION
## Summary
Round-2 follow-ups for PR #85 review.

- **Browse TierPicker** now calls `confirmTier(t)` after `saveProfile`. The dropdown saved a new tier but pre-gen never re-fired this session — "change it any time" wasn't actually live until you bounced back through Connect.
- **Listen nugget trigger loop** collects every newly-eligible nugget for the tick first, then commits state once. Two timestamps crossed in the same tick (after a seek or cache restore) used to clobber each other — only the last `setActiveNugget` rendered; intermediates landed in `shownNuggetIds` but never appeared. Intermediates now go straight to `dismissedNuggets` so they show up in the dismissed strip / nerd reel.
- **Source URL scheme guard audit.** The `/^https?:\/\//i` guard (already on `ArtistUpdatesSection` + `ImmersiveNuggetView`) is now applied to every remaining AI-derived source URL render path: `LatestFactsSection`, `MediaOverlay`, `NuggetDeepDive`, `ReadingOverlay`, `companion/NuggetCategoryCard`, and `Companion` external links. Any malformed Exa/Gemini source URL with a non-`http(s)` scheme is now skipped at render time, closing the XSS surface.

## Test plan
- [x] `npm test` — 331/331 passing
- [x] `npm run build` — clean
- [ ] Browse: change tier in dropdown → confirm stories + artist-updates re-warm at new tier (no manual reload required)
- [ ] Listen: seek forward across two nugget timestamps within the same tick → first nugget lands in the dismissed strip, second is active (no skipped nugget)
- [ ] Source links: any nugget with a malformed `source.url` no longer renders the `<a>` (no console error, no `javascript:` href reaches the DOM)