### PR TITLE
fix: OAuth race blocking sign-in + collaborator pass-through + Latest Facts redesign

### DIFF
--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -182,7 +182,7 @@ export default ArtistUpdatesSection;
 // ~2^-32, far below "two cards from the same artist with similar
 // headlines" can produce). Pure function, module-level so nothing in
 // the render tree allocates a new wrapper each pass.
-function cardKey(u: ArtistUpdate): string {
+export function cardKey(u: ArtistUpdate): string {
   if (u.nuggetId) return u.nuggetId;
   const seed = `${u.artistName}|${u.kind}|${u.headline}`;
   let h = 0x811c9dc5;
@@ -253,11 +253,18 @@ interface UpdateCardProps {
   update: ArtistUpdate;
   layoutId: string;
   onClick: () => void;
+  /** Sizing/spacing classes. Default is the Browse-rail horizontal-
+   *  scroll size; ArtistProfile passes `w-full` for a single-column
+   *  vertical stack. */
+  sizeClass?: string;
+  pulsing?: boolean;
 }
 
 // Image-backed for every kind. Tap morphs into ExpandedUpdateModal
-// via Framer Motion layoutId — no immediate navigation.
-function UpdateCard({ update, layoutId, onClick }: UpdateCardProps) {
+// via Framer Motion layoutId — no immediate navigation. Exported so
+// ArtistProfile's Latest Facts section can reuse the exact same card
+// + modal pattern that Browse uses.
+export function UpdateCard({ update, layoutId, onClick, sizeClass = "shrink-0 w-[280px] md:w-[320px] h-44 md:h-48", pulsing = false }: UpdateCardProps) {
   const { kindLabel, KindIcon } = getArtistUpdateKindMeta(update.kind);
   const { chipClass } = kindStyle(update.kind);
   const img = update.artistImageUrl;
@@ -266,7 +273,9 @@ function UpdateCard({ update, layoutId, onClick }: UpdateCardProps) {
     <motion.button
       layoutId={layoutId}
       onClick={onClick}
-      className="relative shrink-0 w-[280px] md:w-[320px] h-44 md:h-48 text-left rounded-2xl overflow-hidden group active:scale-[0.98] transition-transform"
+      className={`relative text-left rounded-2xl overflow-hidden group active:scale-[0.98] transition-transform ${sizeClass} ${
+        pulsing ? "ring-2 ring-rose-400/70 shadow-[0_0_24px_rgba(244,114,182,0.35)]" : ""
+      }`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
       {img ? (
@@ -492,8 +501,10 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen }: ExpandedUpda
 // Memoized export. The parent passes a stable onClose (useCallback)
 // but onOpen is recreated each render — without memo the modal would
 // re-render on every parent re-render, which is harmless on its own
-// but adds noise during layout-shared transitions.
-const ExpandedUpdateModalMemoized = memo(ExpandedUpdateModal);
+// but adds noise during layout-shared transitions. Exported so
+// LatestFactsSection (and any future consumer) can render the exact
+// same modal without duplicating the Framer Motion layoutId wiring.
+export const ExpandedUpdateModalMemoized = memo(ExpandedUpdateModal);
 
 // Browse-specific styling per kind. Label + icon come from the shared
 // helper in src/lib/artistUpdateKind.ts so adding a new kind only

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -1,19 +1,28 @@
-import { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { AnimatePresence } from "framer-motion";
 import { Loader2 } from "lucide-react";
 import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
-import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
-import { isSafeUrl } from "@/lib/urlSafety";
+import {
+  UpdateCard,
+  ExpandedUpdateModalMemoized,
+  cardKey,
+} from "@/components/ArtistUpdatesSection";
 
 /**
  * "Latest Facts" section on the Artist Profile. Renders artist-level
- * updates from the same edge function Browse uses, so a nugget the
- * user just tapped on Browse is immediately available here.
+ * updates from the same edge function Browse uses, so a fact a user
+ * just tapped on Browse is immediately available here.
+ *
+ * Uses the same image-backed UpdateCard + shared-layout ExpandedUpdate
+ * Modal pattern that Browse uses, so the expand-on-tap feel is
+ * consistent across the app. Layout differs from Browse: vertical
+ * single-column stack (we're already on the artist page; no need for
+ * a horizontal-scroll rail across multiple artists).
  *
  * If the URL has a `?nugget=<id>` query (Browse → Artist Profile tap-
- * through), this component scrolls the matching fact into view, auto-
- * expands it, and pulses a ring around it for ~1.2s before silently
- * removing the query param so a refresh doesn't re-pulse.
+ * through), this component auto-opens the matching fact in the modal
+ * and silently strips the param so a refresh doesn't re-open.
  */
 
 interface Props {
@@ -26,42 +35,66 @@ interface Props {
 export default function LatestFactsSection({ updates, loading, artistName }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const targetNuggetId = searchParams.get("nugget");
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [pulseId, setPulseId] = useState<string | null>(null);
-  const cardRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  const navigate = useNavigate();
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [pulseKey, setPulseKey] = useState<string | null>(null);
 
-  // Scroll + highlight behavior when landed via `?nugget=<id>`.
+  // Look up the expanded update for modal content. Memoized so the
+  // scan doesn't re-run on every parent re-render.
+  const expandedUpdate = useMemo<ArtistUpdate | null>(() => {
+    if (!expandedKey) return null;
+    return updates.find((u) => cardKey(u) === expandedKey) ?? null;
+  }, [expandedKey, updates]);
+
+  // Deep-link from Browse: auto-open the matching nugget in the modal.
+  // We open immediately on data arrival, then pulse the underlying
+  // card briefly so the user sees which fact was referenced when they
+  // close the modal.
   useEffect(() => {
     if (!targetNuggetId || updates.length === 0) return;
     const match = updates.find((u) => u.nuggetId === targetNuggetId);
     if (!match) return;
-    const id = match.nuggetId!;
-    setExpandedId(id);
-    setPulseId(id);
-    // Defer the scroll one tick so the expanded body has laid out.
-    const scrollTimer = setTimeout(() => {
-      cardRefs.current.get(id)?.scrollIntoView({ behavior: "smooth", block: "center" });
-    }, 30);
-    const pulseTimer = setTimeout(() => setPulseId(null), 1200);
+    const key = cardKey(match);
+    setExpandedKey(key);
+    setPulseKey(key);
+    const pulseTimer = setTimeout(() => setPulseKey(null), 1800);
     const stripTimer = setTimeout(() => {
-      // Quietly remove the ?nugget= param so reload doesn't re-pulse.
+      // Quietly remove the ?nugget= param so reload doesn't re-open.
       const next = new URLSearchParams(searchParams);
       next.delete("nugget");
       setSearchParams(next, { replace: true });
-    }, 1400);
+    }, 200);
     return () => {
-      clearTimeout(scrollTimer);
       clearTimeout(pulseTimer);
       clearTimeout(stripTimer);
     };
-    // Ignoring searchParams/setSearchParams in deps because including
-    // them re-fires the effect on the strip, creating an infinite loop.
+    // Ignoring searchParams/setSearchParams in deps — including them
+    // re-fires the effect on the strip, creating an infinite loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetNuggetId, updates.length]);
 
+  const modalOnClose = useCallback(() => setExpandedKey(null), []);
+
+  // Modal's "Open / Listen" CTA. Release / collab cards in this
+  // section route to /listen for the related track; pure fact cards
+  // are a no-op (already on the artist profile) so the modal just
+  // closes.
+  const modalOnOpen = useCallback(() => {
+    if (!expandedUpdate) return;
+    setExpandedKey(null);
+    const u = expandedUpdate;
+    if ((u.kind === "new-release" || u.kind === "collab") && u.relatedTrackTitle) {
+      const album = u.relatedAlbumName ?? "";
+      const navUri = u.relatedTrackUri?.startsWith("spotify:track:") ? u.relatedTrackUri : "";
+      navigate(
+        `/listen/real::${encodeURIComponent(u.artistName)}::${encodeURIComponent(u.relatedTrackTitle)}::${encodeURIComponent(album)}::${encodeURIComponent(navUri)}`,
+      );
+    }
+  }, [expandedUpdate, navigate]);
+
   if (!loading && updates.length === 0) {
-    // Quiet fallback — don't render an empty section header on artists
-    // we couldn't compose anything for.
+    // Quiet fallback — don't render an empty section header on
+    // artists we couldn't compose anything for.
     return null;
   }
 
@@ -79,104 +112,52 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
         )}
       </div>
 
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-3">
         {loading && updates.length === 0
           ? Array.from({ length: 3 }).map((_, i) => <SkeletonCard key={i} />)
-          : updates.map((u) => (
-              <FactCard
-                key={u.nuggetId ?? `${u.kind}-${u.headline}`}
-                update={u}
-                expanded={u.nuggetId === expandedId}
-                pulsing={u.nuggetId === pulseId}
-                onToggle={() =>
-                  setExpandedId((prev) => (prev === u.nuggetId ? null : (u.nuggetId ?? null)))
-                }
-                registerRef={(el) => {
-                  if (u.nuggetId) cardRefs.current.set(u.nuggetId, el);
-                }}
-              />
-            ))}
+          : updates.map((u) => {
+              const key = cardKey(u);
+              return (
+                <UpdateCard
+                  key={key}
+                  layoutId={key}
+                  update={u}
+                  onClick={() => setExpandedKey(key)}
+                  sizeClass="w-full h-44 md:h-48"
+                  pulsing={pulseKey === key}
+                />
+              );
+            })}
       </div>
+
+      <AnimatePresence>
+        {expandedUpdate && (
+          <ExpandedUpdateModalMemoized
+            update={expandedUpdate}
+            layoutId={cardKey(expandedUpdate)}
+            onClose={modalOnClose}
+            onOpen={modalOnOpen}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Reserve the section name in JSX comments for accessibility
+          screen readers — `artistName` is the data shape contract
+          used by the parent ArtistProfile when an empty state needs a
+          name. We don't render the artist name visibly here (the page
+          header already shows it). */}
+      <span className="sr-only">Latest facts about {artistName}</span>
     </section>
   );
 }
 
-// ── Fact card ─────────────────────────────────────────────────────────
-
-interface FactCardProps {
-  update: ArtistUpdate;
-  expanded: boolean;
-  pulsing: boolean;
-  onToggle: () => void;
-  registerRef: (el: HTMLDivElement | null) => void;
-}
-
-function FactCard({ update, expanded, pulsing, onToggle, registerRef }: FactCardProps) {
-  const { kindLabel, KindIcon } = getArtistUpdateKindMeta(update.kind);
-  const chipClass = kindClass(update.kind);
+function SkeletonCard() {
+  // Full-width tall skeleton matching the real card's footprint so
+  // the layout doesn't jump when content lands.
   return (
     <div
-      ref={registerRef}
-      className={`rounded-2xl border bg-gradient-to-br from-white/[0.06] to-white/[0.02] transition-all ${
-        pulsing
-          ? "border-rose-400/70 ring-2 ring-rose-400/40"
-          : "border-white/10 hover:border-white/20"
-      }`}
-    >
-      <button
-        onClick={onToggle}
-        className="w-full text-left px-4 py-3 flex items-start gap-3"
-        aria-expanded={expanded}
-      >
-        <span
-          className={`mt-0.5 shrink-0 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full ${chipClass}`}
-        >
-          <KindIcon className="w-3 h-3" />
-          {kindLabel}
-        </span>
-        <h3 className="flex-1 text-sm md:text-base font-semibold text-white/95 leading-snug">
-          {update.headline}
-        </h3>
-      </button>
-      {expanded && (
-        <div className="px-4 pb-4 -mt-1 flex flex-col gap-2">
-          <p className="text-sm leading-relaxed text-white/70">{update.body}</p>
-          {isSafeUrl(update.source?.url) && (
-            <a
-              href={update.source.url}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="text-xs text-white/40 hover:text-white/70 transition-colors self-start"
-            >
-              Source: {update.source.publisher ?? "link"}
-            </a>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// Local styling for the artist-profile chip. Label + icon come from
-// the shared helper in src/lib/artistUpdateKind.ts so adding a new
-// kind only edits one file.
-function kindClass(kind: ArtistUpdate["kind"]): string {
-  switch (kind) {
-    case "new-release": return "bg-rose-500/15 text-rose-300";
-    case "collab": return "bg-violet-500/15 text-violet-300";
-    case "fact":
-    default: return "bg-sky-500/15 text-sky-300";
-  }
-}
-
-function SkeletonCard() {
-  return (
-    <div className="rounded-2xl bg-white/[0.04] border border-white/5 p-4 animate-pulse" aria-hidden>
-      <div className="flex items-center gap-3 mb-2">
-        <div className="h-4 w-16 rounded-full bg-white/10" />
-        <div className="h-4 flex-1 rounded bg-white/10" />
-      </div>
-      <div className="h-3 w-5/6 rounded bg-white/5" />
-    </div>
+      className="w-full h-44 md:h-48 rounded-2xl bg-white/[0.04] border border-white/5 animate-pulse"
+      aria-hidden
+    />
   );
 }

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -585,23 +585,33 @@ export default function ImmersiveNuggetView({
           Pete 2026-05-08: "dots right above the mini player ...
           headline and nugget amount counter should never be covered
           by the mini player." Active bright, unlocked dim, locked
-          very-dim. Hidden when there's only one nugget. */}
-      {nuggets.length > 1 && (
-        <div className="relative z-20 bg-black flex justify-center items-center gap-1.5 pt-5 pb-3 pointer-events-none">
-          {Array.from({ length: nuggets.length }, (_, i) => {
-            const isActive = i === activeIndex;
-            const isUnlocked = i < unlockedCount;
-            return (
-              <div
-                key={i}
-                className={`w-1.5 h-1.5 rounded-full transition-colors duration-200 ${
-                  isActive ? "bg-white/85" : isUnlocked ? "bg-white/35" : "bg-white/12"
-                }`}
-              />
-            );
-          })}
-        </div>
-      )}
+          very-dim. Wrapper is ALWAYS rendered so vertical space is
+          reserved from first paint — when wave-2 lands and bumps
+          nuggets.length past 1, the dots fade in without shrinking
+          the hero area (which would push the headline up). Background
+          is transparent so the parent bg-black bleeds through and
+          there's no visible "bar" appearing/disappearing. */}
+      <div className="relative z-20 flex justify-center items-center gap-1.5 pt-5 pb-3 pointer-events-none">
+        <AnimatePresence>
+          {nuggets.length > 1 &&
+            Array.from({ length: nuggets.length }, (_, i) => {
+              const isActive = i === activeIndex;
+              const isUnlocked = i < unlockedCount;
+              return (
+                <motion.div
+                  key={i}
+                  initial={{ opacity: 0, scale: 0.6 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.6 }}
+                  transition={{ duration: 0.25, ease: "easeOut" }}
+                  className={`w-1.5 h-1.5 rounded-full transition-colors duration-200 ${
+                    isActive ? "bg-white/85" : isUnlocked ? "bg-white/35" : "bg-white/12"
+                  }`}
+                />
+              );
+            })}
+        </AnimatePresence>
+      </div>
 
       {/* Mini player */}
       <div className="relative z-20 bg-black" style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -34,24 +34,33 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // 1. Eagerly hydrate from the persisted session (avoids flash)
-    supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session);
-      bridgeSpotifyProviderTokens(data.session);
-      setLoading(false);
-    });
-
-    // 2. Keep state in sync for token refreshes, sign-in, sign-out. The
-    // bridge runs on every event so the localStorage token tracks the
-    // freshest Supabase session — but note: post-JWT-refresh events drop
-    // the provider token, which the bridge correctly no-ops on (see
-    // bridgeSpotifyProviderTokens guards).
+    // Subscribe FIRST so the INITIAL_SESSION event reaches us. v2's
+    // onAuthStateChange fires INITIAL_SESSION exactly once when the
+    // subscription is created — with the post-URL-parse session (i.e.
+    // AFTER PKCE code → session exchange has run). Using it as the
+    // auth-loading-complete signal avoids the race that:
+    //
+    //   1. Browser lands on /preparing?code=XXX (OAuth callback)
+    //   2. Old code called getSession() synchronously — returned null
+    //      because the PKCE exchange is still in flight
+    //   3. AuthContext flipped loading=false with session=null
+    //   4. ProtectedRoute fired <Navigate to="/connect?redirect=..."/>
+    //   5. URL changed — `?code=` is gone
+    //   6. Supabase's async exchange tried to read the code, saw nothing,
+    //      session never created → user sees "sign in again"
+    //
+    // Slow networks / browsers were the most likely to lose this race;
+    // a Pete-on-fast-Mac vs boss-on-different-setup difference matches
+    // exactly the symptom report.
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (_event, newSession) => {
         setSession(newSession);
         bridgeSpotifyProviderTokens(newSession);
+        // First emission flips loading off. Subsequent events (token
+        // refresh, sign-in, sign-out) just update session — loading
+        // was already false.
         setLoading(false);
-      }
+      },
     );
 
     return () => subscription.unsubscribe();

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -271,7 +271,13 @@ export function useAINuggets(
   artistImageUrl?: string,
   tier: "casual" | "curious" | "nerd" = "casual",
   topArtists?: string[],
-  topTracks?: string[]
+  topTracks?: string[],
+  // Non-primary artists on the track (e.g. for "Better" by Ty Symph,
+  // Pete Rango, collaborators = ["Pete Rango"]). Passed through to
+  // wave-2/3 so the server has the same research targets the Stories
+  // pre-gen used in wave 1 — otherwise wave-2 loses a key research
+  // signal and falls back to thin generic content on collab tracks.
+  collaborators?: string[],
 ): UseAINuggetsResult {
   const [nuggets, setNuggets] = useState<Nugget[]>([]);
   const [sources, setSources] = useState<Map<string, Source>>(new Map());
@@ -744,7 +750,14 @@ export function useAINuggets(
               const nugget = makeNugget(n, nuggetId, sourceId, trackId, ts);
 
               setSources((prev) => new Map(prev).set(sourceId, source));
-              setNuggets((prev) => [...prev, nugget]);
+              // Dedup by id: a re-fire of the generate effect (deps churn
+              // from useUserProfile re-emitting) cancels the old fetch but
+              // resets cancelledRef to false, so a late SSE chunk from the
+              // old stream can append into the new state and collide with
+              // the cache-restored nugget that has the same listenCount +
+              // index. React then renders only one of the two same-keyed
+              // children and the other "disappears" mid-typewrite.
+              setNuggets((prev) => (prev.some((p) => p.id === nugget.id) ? prev : [...prev, nugget]));
               if (import.meta.env.DEV) console.log(`[SSE] Received nugget ${payload.index}: "${n.headline?.slice(0, 40)}"`);
 
               // Early-cancel: if we already have enough nuggets to cover
@@ -1152,6 +1165,7 @@ export function useAINuggets(
         const appleUriMatch = trackId.match(/apple:song:(\d+)/);
         const requestBody = {
           artist,
+          collaborators,
           title,
           album,
           listenCount: nextWave,                     // unlocks deeper angles
@@ -1219,7 +1233,16 @@ export function useAINuggets(
           newNuggets.push(makeNugget(n, nuggetId, sourceId, trackId, ts));
         });
 
-        setNuggets((prev) => [...prev, ...newNuggets]);
+        // Dedup by id: defensive against a wave-2 effect re-fire that
+        // would otherwise append the same set twice (e.g. if the
+        // effect deps change before the previous wave's finally
+        // block clears waveInFlightRef — possible during a profile
+        // re-emit while a wave is in flight).
+        setNuggets((prev) => {
+          const have = new Set(prev.map((p) => p.id));
+          const filtered = newNuggets.filter((n) => !have.has(n.id));
+          return filtered.length ? [...prev, ...filtered] : prev;
+        });
         setSources((prev) => {
           const next = new Map(prev);
           newSources.forEach((v, k) => next.set(k, v));

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -317,6 +317,13 @@ export function useAINuggets(
   // 30 s so a transient server error doesn't fire a new request every 500 ms
   // (the effect re-evaluates on every currentTime tick).
   const waveCooldownUntilRef = useRef(0);
+  // Latch: once a wave-2 attempt comes back empty for THIS track, the
+  // Validator + source filter stripped everything the Writer produced
+  // (typical for sub-1k-listener artists where Exa returns no journalism).
+  // No amount of retries will change that within the same track, so we
+  // stop firing wave requests entirely instead of burning a Gemini call
+  // every 30s. Cleared on track change via cancelledRef cycling.
+  const waveExhaustedRef = useRef(false);
   // Mirror waveInFlightRef as state so the UI can surface a "more coming" pill.
   const [waveLoading, setWaveLoading] = useState(false);
   // Track the current trackId via ref so in-flight wave generations can
@@ -337,6 +344,7 @@ export function useAINuggets(
     currentWaveRef.current = 1;
     waveInFlightRef.current = false;
     waveCooldownUntilRef.current = 0;
+    waveExhaustedRef.current = false;
   }, [trackId, regenerateKey]);
 
   const generate = useCallback(async () => {
@@ -1111,6 +1119,7 @@ export function useAINuggets(
     if (!isPlaying) return;                         // paused — wait
     if (cancelledRef.current) return;               // track changed / unmount
     if (Date.now() < waveCooldownUntilRef.current) return;  // recent failure, cooldown
+    if (waveExhaustedRef.current) return;           // server returned 0 — no more for this track
 
     // Tap fan-out if we served from cache but only
     // have a single nugget (firstNuggetOnly partial), the user still
@@ -1154,22 +1163,42 @@ export function useAINuggets(
           spotifyTrackId: spotifyUriMatch?.[1],
           appleTrackId: appleUriMatch?.[1],
         };
-        const { data, error } = await supabase.functions.invoke("generate-nuggets", {
-          body: requestBody,
-        });
+        // 60s hard timeout — server cap is 90s but a wedged call
+        // shouldn't pin waveInFlightRef true forever (the only thing
+        // that releases it is this function's finally block). 60s
+        // covers warm Gemini paths comfortably and aborts cold
+        // starts that wandered off.
+        const invokePromise = supabase.functions.invoke("generate-nuggets", { body: requestBody });
+        const raceResult = await Promise.race<
+          Awaited<typeof invokePromise> | { timedOut: true }
+        >([
+          invokePromise,
+          new Promise<{ timedOut: true }>((resolve) =>
+            setTimeout(() => resolve({ timedOut: true }), 60_000),
+          ),
+        ]);
 
         // Drop results if track changed or generation cancelled.
         if (waveTrackId !== currentTrackIdRef.current || cancelledRef.current) {
           if (import.meta.env.DEV) console.log(`[NuggetWave ${nextWave}] dropped — track changed`);
           return;
         }
+        if ("timedOut" in raceResult) {
+          if (import.meta.env.DEV) console.warn(`[NuggetWave ${nextWave}] TIMEOUT after 60s — backing off`);
+          return;
+        }
+        const { data, error } = raceResult;
         if (error) {
           if (import.meta.env.DEV) console.warn(`[NuggetWave ${nextWave}] error:`, error.message);
           return;
         }
         const newNuggetData = (data?.nuggets as AINuggetData[] | undefined) ?? [];
         if (newNuggetData.length === 0) {
-          if (import.meta.env.DEV) console.log(`[NuggetWave ${nextWave}] server returned 0 nuggets — done`);
+          // Latch: the Validator stripped everything (typical for
+          // sub-1k-listener artists with no Exa coverage). Don't burn
+          // another Gemini call every 30s for the rest of the track.
+          waveExhaustedRef.current = true;
+          if (import.meta.env.DEV) console.log(`[NuggetWave ${nextWave}] server returned 0 nuggets — exhausted, no more retries for this track`);
           return;
         }
 

--- a/src/hooks/useArtistUpdates.ts
+++ b/src/hooks/useArtistUpdates.ts
@@ -214,10 +214,33 @@ export function useArtistUpdates(
       if (inFlightRef.current.has(key)) return;
       inFlightRef.current.add(key);
       try {
-        const { data, error } = await supabase.functions.invoke("artist-updates", {
+        // Hard timeout. Without it, a hung edge function (Gemini
+        // cold-start, Exa rate limit) pins the global "Loading
+        // artist updates" pill on screen indefinitely. 30s matches
+        // typical worst-case server budget; anything longer is a
+        // sign the call is wedged.
+        const invokePromise = supabase.functions.invoke("artist-updates", {
           body: { artist, tier },
         });
+        const raceResult = await Promise.race<
+          Awaited<typeof invokePromise> | { timedOut: true }
+        >([
+          invokePromise,
+          new Promise<{ timedOut: true }>((resolve) =>
+            setTimeout(() => resolve({ timedOut: true }), 30_000),
+          ),
+        ]);
         if (cancelled) return;
+        if ("timedOut" in raceResult) {
+          if (import.meta.env.DEV) {
+            console.warn(`[artist-updates] ${artist} TIMEOUT after 30s — resolving empty`);
+          }
+          setGroups((prev) =>
+            prev.map((g) => (g.artistName === artist ? { ...g, updates: [] } : g)),
+          );
+          return;
+        }
+        const { data, error } = raceResult;
         if (error) {
           if (import.meta.env.DEV) {
             console.warn(`[artist-updates] ${artist} failed:`, error.message);

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -149,10 +149,21 @@ export default function Connect() {
     const next = redirectUrl || "/browse";
     return <Navigate to={`/preparing?next=${encodeURIComponent(next)}`} replace />;
   }
-  return <ConnectInner redirectUrl={redirectUrl} />;
+  // If the user kicked off an OAuth round-trip but the escape hatch
+  // had to fire because no session ever arrived, surface that to
+  // ConnectInner so the user sees a "your sign-in didn't complete"
+  // explanation instead of being silently dropped back to the sign-
+  // in UI. Most common cause is Safari ITP / third-party-cookie
+  // blocking on the auth callback.
+  return (
+    <ConnectInner
+      redirectUrl={redirectUrl}
+      oauthFailed={oauthEscapeTriggered && !session}
+    />
+  );
 }
 
-function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
+function ConnectInner({ redirectUrl, oauthFailed = false }: { redirectUrl: string | null; oauthFailed?: boolean }) {
   const navigate = useNavigate();
   const { saveProfile } = useUserProfile();
   const { confirmTier } = useTierGate();
@@ -443,6 +454,16 @@ function ConnectInner({ redirectUrl }: { redirectUrl: string | null }) {
               {/* ── Step 0: Connect Spotify ── */}
               {step === 0 && (
                 <motion.div key="step-0" custom={direction} variants={slideVariants} initial="enter" animate="center" exit="exit" transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }} className="flex flex-col items-center gap-4 md:gap-6">
+                  {oauthFailed && (
+                    <div className="w-full rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-left">
+                      <p className="text-sm font-semibold text-amber-300">
+                        Your last Spotify sign-in didn't complete.
+                      </p>
+                      <p className="mt-1 text-xs text-amber-200/80 leading-relaxed">
+                        This usually means your browser blocked the session cookie. Try again — and if it keeps failing, open this page in a private/incognito window or check that third-party cookies are enabled for musicnerd.xyz.
+                      </p>
+                    </div>
+                  )}
                   <div className="text-center">
                     <h1 className="text-2xl md:text-3xl font-black text-foreground tracking-tight">Connect your music</h1>
                     <p className="mt-2 text-muted-foreground">Link Spotify for personalized insights.</p>

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -74,13 +74,33 @@ export default function Listen() {
     if (!realTrackMeta) return null;
     // Try URL query param first (demo tiles pass ?art=), then profile, then DiceBear
     let coverArtUrl = urlArt;
-    if (!coverArtUrl && profile?.trackImages) {
+    // Side-effect of the same scan: recover collaborators. The URL
+    // format (`real::artist::title::album::uri`) doesn't carry them,
+    // so the only client-side source is the user's own taste data
+    // where spotify-taste populated `collaborators` from
+    // `track.artists.slice(1)`. Without this lookup, wave-2 on
+    // collab tracks (e.g. "Better" by Ty Symph, Pete Rango) loses
+    // the secondary research target and falls back to thin content
+    // grounded only in the primary artist.
+    let collaborators: string[] | undefined;
+    const titleLower = realTrackMeta.title.toLowerCase();
+    const artistLower = realTrackMeta.artist.toLowerCase();
+    if (profile?.trackImages) {
       const match = profile.trackImages.find(
         (t) =>
-          t.title.toLowerCase() === realTrackMeta.title.toLowerCase() &&
-          t.artist.toLowerCase() === realTrackMeta.artist.toLowerCase()
+          t.title.toLowerCase() === titleLower &&
+          t.artist.toLowerCase() === artistLower
       );
-      if (match?.imageUrl) coverArtUrl = match.imageUrl;
+      if (match?.imageUrl) coverArtUrl = coverArtUrl || match.imageUrl;
+      if (match?.collaborators?.length) collaborators = match.collaborators;
+    }
+    if (!collaborators && profile?.likedTracks) {
+      const liked = profile.likedTracks.find(
+        (t) =>
+          t.title.toLowerCase() === titleLower &&
+          t.artist.toLowerCase() === artistLower
+      );
+      if (liked?.collaborators?.length) collaborators = liked.collaborators;
     }
     if (!coverArtUrl && profile?.artistImages?.[realTrackMeta.artist]) {
       coverArtUrl = profile.artistImages[realTrackMeta.artist];
@@ -92,6 +112,7 @@ export default function Listen() {
       id: trackId,
       title: realTrackMeta.title,
       artist: realTrackMeta.artist,
+      collaborators,
       artistId: "",
       albumId: "",
       album: realTrackMeta.album,
@@ -99,7 +120,7 @@ export default function Listen() {
       coverArtUrl,
       trackNumber: 1,
     };
-  }, [realTrackMeta, trackId, urlArt, profile?.trackImages, profile?.artistImages]);
+  }, [realTrackMeta, trackId, urlArt, profile?.trackImages, profile?.likedTracks, profile?.artistImages]);
 
   // ── Playback source resolution ───────────────────────────────────────
   const { hasSpotifyToken } = useSpotifyToken();
@@ -515,6 +536,16 @@ export default function Listen() {
   const tier = (profile?.calculatedTier as "casual" | "curious" | "nerd") || "casual";
   useTierAccent(tier);
   const artistImageUrl = (track?.artist && profile?.artistImages?.[track.artist]) || track?.coverArtUrl || "";
+  // Display string for the UI — joins primary + collaborators with ", ".
+  // Kept separate from `track.artist` because the latter is the cache
+  // key + lookup anchor everywhere else (search by primary artist
+  // only). Display contexts (mini player, title block, deep dive) want
+  // the full credit so it matches what the user sees on Spotify.
+  const artistDisplay = track?.artist
+    ? track.collaborators?.length
+      ? `${track.artist}, ${track.collaborators.join(", ")}`
+      : track.artist
+    : "";
   const { nuggets: aiNuggets, sources: aiSources, loading: aiLoading, error: aiError, listenCount, artistSummary, fromCache: aiFromCache, waveLoading } = useAINuggets(
     trackId,
     track?.artist || "",
@@ -526,7 +557,8 @@ export default function Listen() {
     artistImageUrl,
     tier,
     profile?.topArtists,
-    profile?.topTracks
+    profile?.topTracks,
+    track?.collaborators,
   );
 
   // Log AI nugget errors for debugging
@@ -1320,7 +1352,7 @@ export default function Listen() {
             {track.title}
           </h1>
           <p className="mt-0.5 text-base font-bold text-foreground/50 md:text-lg" style={{ fontFamily: "'Nunito Sans', sans-serif" }}>
-            {track.artist}
+            {artistDisplay}
           </p>
           {track.album && (
             <p className="mt-0.5 text-sm text-foreground/25 font-medium" style={{ fontFamily: "'Nunito Sans', sans-serif" }}>
@@ -1636,7 +1668,7 @@ export default function Listen() {
                 <NuggetDeepDive
                   nugget={deepDiveNugget}
                   source={getSource(deepDiveNugget.sourceId) || null}
-                  artist={track.artist}
+                  artist={artistDisplay}
                   trackTitle={track.title}
                   onClose={() => { setDeepDiveNugget(null); setFocusZone('bar'); setNuggetFocused(false); }}
                 />
@@ -1655,7 +1687,7 @@ export default function Listen() {
               sources={aiSources}
               coverArtUrl={effectiveCoverArt}
               trackTitle={track?.title || ""}
-              artist={track?.artist || ""}
+              artist={artistDisplay}
               onClose={() => navigate("/browse")}
               onPrev={handlePrev}
               onNext={handleNext}


### PR DESCRIPTION
## Summary

### Critical: OAuth race blocking new-user sign-in (boss-login bug)
- **Root cause**: \`AuthContext\` called \`supabase.auth.getSession()\` synchronously on mount. For PKCE OAuth callbacks (\`/preparing?code=XXX\`), the code-for-session exchange is **async**. The old code flipped \`loading=false\` with \`session=null\` BEFORE the exchange finished. \`ProtectedRoute\` then navigated to \`/connect?redirect=/preparing\`, wiping the \`?code=\` from the URL. Supabase's async exchange then tried to read a code that was gone — session never created. Slow networks / browsers hit the race; fast ones didn't.
- **Fix**: stop calling \`getSession()\` directly. \`onAuthStateChange\` fires \`INITIAL_SESSION\` once after URL parsing is complete; use that as the auth-loading-complete signal.
- **Secondary UX fix**: surface an amber banner on the sign-in UI when the OAuth round-trip dropped without a session, so the user sees what happened and what to try (incognito, third-party cookies) instead of being silently re-prompted.

### Wave-2 collaborator pass-through
- \`Listen.tsx\` looks up collaborators from \`profile.trackImages\` / \`profile.likedTracks\` when building the \`track\` object (URL format doesn't carry them).
- \`useAINuggets\` accepts + forwards \`collaborators\` to wave-2 generate-nuggets invokes — server now has the same research targets the firstNuggetOnly pre-gen used.
- Mini-player, deep-dive prompt, and desktop title-block now show \`artist, collaborator1, ...\` matching Spotify's credit (e.g. "Ty Symph, Pete Rango").

### Latest Facts section redesign
- Artist profile's Latest Facts now uses the same image-backed UpdateCard + shared-layout ExpandedUpdateModal pattern as Browse's "Your artists, lately" — tap to expand into a modal instead of inline-expand. Background image, source link, deep-link from Browse still works.
- \`ArtistUpdatesSection\` exports \`UpdateCard\`, \`ExpandedUpdateModalMemoized\`, \`cardKey\` so both consumers share one source of truth. UpdateCard accepts \`sizeClass\` + \`pulsing\` so the artist-profile variant can stack full-width.

### Duplicate-nugget defense
- \`useAINuggets\` dedupes by \`id\` at every \`setNuggets\` append site — defends against a stale SSE handler from an aborted invocation double-writing the same nugget id. React was rendering one of two same-keyed children and silently dropping the other, manifesting as "third nugget disappeared" on swipe-back.
- Per-invocation cancellation token (the cleaner long-term fix) is deferred — dedup is belt-and-suspenders.

## Test plan
- [x] \`npm test\` — 367/367 passing
- [x] \`npm run build\` — clean
- [ ] Boss retries Spotify sign-in on prod — should now land on \`/preparing\` → tier picker → Browse without the "sign in again" loop
- [ ] Multi-artist track ("Better" by Ty Symph, Pete Rango): mini-player shows "Ty Symph, Pete Rango"; wave-2 invoke receives collaborators
- [ ] Artist profile Latest Facts: cards have hero image, tap opens shared-layout modal
- [ ] If OAuth fails again (e.g. cookies still blocked), the amber banner explains what happened