### PR TITLE
fix(auth): switch OAuth from PKCE to implicit flow for iOS Safari

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -24,5 +24,16 @@ export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, 
     storage: localStorage,
     persistSession: true,
     autoRefreshToken: true,
-  }
+    // implicit (not the v2 default of pkce). PKCE stores a code_verifier
+    // in localStorage before redirecting to the provider and reads it
+    // back from the callback URL to exchange the code for a session.
+    // iOS Safari's ITP wipes that localStorage as "cross-site tracking"
+    // during the mntv → spotify → supabase callback → mntv chain, so
+    // the verifier is gone by the time the client tries to use it,
+    // and the session is never created. Implicit puts the tokens in
+    // the URL hash fragment on the callback — no stored state needed.
+    // Slightly less secure (tokens land in browser history) but the
+    // OAuth flow actually completes on restrictive browsers.
+    flowType: "implicit",
+  },
 });


### PR DESCRIPTION
## Problem
Boss (iPhone Safari) still hit "Your last Spotify sign-in didn't complete" on staging after the AuthContext race fix landed. That rules out the async-getSession() race as the only cause.

## Root cause
PKCE flow (Supabase's v2 default) stores a code_verifier in localStorage before the redirect chain, then reads it back after the callback to exchange the code for a session. iOS Safari's Intelligent Tracking Prevention wipes that localStorage as cross-site tracking state during the mntv → spotify → supabase → mntv redirect chain. By the time the client tries to exchange the code, the verifier is gone — exchange fails silently — session never created.

## Fix
\`flowType: "implicit"\` in the Supabase client config. Implicit flow puts the tokens directly in the callback URL's hash fragment, so no localStorage state is needed between the redirect-out and the redirect-back.

Tradeoff: tokens land in browser history (vs PKCE which only puts a single-use code there). For an SPA without a backend custodian, this is acceptable.

## Test plan
- [x] \`npm test\` 367/367 + build clean
- [ ] Boss retries on iPhone Safari — should now reach tier picker
- [ ] Pete on desktop Chrome — should still work (no regression)