### PR TITLE
feat(listen): Open {Artist} / Listen to {Track} CTA + pill+companion+typewriter fixes

### DIFF
--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -171,16 +171,27 @@ export default function MusicNerdLoadingOrchestrator({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiLoading, trackId, phase]);
 
-  // ── Pill stays visible until nuggets arrive OR loading finishes ──
-  // No timed morph — the pill persists as long as the user has nothing to see.
+  // ── Pill stays visible until nuggets ACTUALLY arrive ──
+  // Previously OR'd on !aiLoading too, which dismissed the pill when
+  // generation "finished" even if no nugget had landed in state yet
+  // (Pete: "loading state disappeared as if research was done but no
+  // nugget popped up, eventually the nugget arrived"). Two real
+  // scenarios bit this: (1) SSE completed with empty results and the
+  // synthetic fallback hadn't fired yet, leaving a window of
+  // aiLoading=false + hasNuggets=false; (2) initial generate errored
+  // and the catch-block fallback was still async-resolving. Either
+  // way the user sees an empty screen with no indication of state.
+  // Now the pill only dismisses when we genuinely have a nugget to
+  // morph into. Failures still transition out via the aiError handler
+  // below.
   useEffect(() => {
     if (phase !== "pill") return;
-    if (hasNuggets || !aiLoading) {
+    if (hasNuggets) {
       clearTimers();
       startMorphFly();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase, hasNuggets, aiLoading]);
+  }, [phase, hasNuggets]);
 
   // ── aiLoading flips false→true mid-track: re-enter the state machine ──
   // when skipping tracks, aiLoading sometimes

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -11,6 +11,7 @@ import MiniPlayer from "./MiniPlayer";
 import { useNuggetPacer } from "./useNuggetPacer";
 import { useBookmarks } from "@/hooks/useBookmarks";
 import { isSafeUrl } from "@/lib/urlSafety";
+import { RecommendedArtistButton, RecommendedTrackButton } from "./RecommendedButtons";
 
 interface ImmersiveNuggetViewProps {
   nuggets: Nugget[];
@@ -549,6 +550,16 @@ export default function ImmersiveNuggetView({
                 trackTitle={trackTitle}
                 isBookmarked={bookmarks.isBookmarked}
                 toggle={bookmarks.toggle}
+              />
+            )}
+            {activeNugget?.recommendedArtist?.name && (
+              <RecommendedArtistButton
+                recommendedArtist={activeNugget.recommendedArtist}
+              />
+            )}
+            {activeNugget?.recommendedTrack?.title && (
+              <RecommendedTrackButton
+                recommendedTrack={activeNugget.recommendedTrack}
               />
             )}
           </div>

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -472,7 +472,7 @@ export default function ImmersiveNuggetView({
               ) : (
                 <TypewriterText
                   text={activeNugget.headline || activeNugget.text}
-                  speed={35}
+                  speed={18}
                   paused={false}
                   onComplete={handleTypewriterComplete}
                   as="h2"

--- a/src/components/immersive/RecommendedButtons.tsx
+++ b/src/components/immersive/RecommendedButtons.tsx
@@ -1,0 +1,76 @@
+import { memo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Headphones } from "lucide-react";
+import type { Nugget } from "@/mock/types";
+
+/**
+ * "Open {Artist}" CTA — appears in the nugget body when the server
+ * attaches a recommendedArtist (typical for `discovery` and `collab`
+ * kind nuggets that name a specific artist). Routes to the artist's
+ * profile when we have a Spotify ID, otherwise falls back to a
+ * search by name (`/artist/real::{name}` → server-side resolution).
+ *
+ * Extracted from ImmersiveNuggetView so the buttons stay unit-
+ * testable without rendering the full immersive view (which mounts
+ * the player, pacer, bookmarks, etc.).
+ */
+export const RecommendedArtistButton = memo(function RecommendedArtistButton({
+  recommendedArtist,
+}: {
+  recommendedArtist: NonNullable<Nugget["recommendedArtist"]>;
+}) {
+  const navigate = useNavigate();
+  const { name, spotifyArtistId } = recommendedArtist;
+  const onClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (spotifyArtistId) {
+      navigate(`/artist/spotify::${spotifyArtistId}::${encodeURIComponent(name)}`);
+    } else {
+      // Fallback: artist name route resolved server-side via search.
+      navigate(`/artist/real::${encodeURIComponent(name)}`);
+    }
+  };
+  return (
+    <button
+      onClick={onClick}
+      className="text-xs px-3 py-1.5 rounded-full bg-white/10 text-white/60 active:scale-95 transition-transform flex items-center gap-1.5"
+      aria-label={`Open ${name}`}
+    >
+      <Headphones className="w-3 h-3" />
+      Open {name}
+    </button>
+  );
+});
+
+/**
+ * "Listen to {Track}" CTA — same idea but for a specific track.
+ * Routes to /listen/real::artist::title::::uri so PlayerContext picks
+ * the right engine (Spotify URI for Spotify users; Apple Music
+ * users hit the URL with no URI and Listen's findCatalogUri effect
+ * resolves the Apple equivalent via {artist, title}).
+ */
+export const RecommendedTrackButton = memo(function RecommendedTrackButton({
+  recommendedTrack,
+}: {
+  recommendedTrack: NonNullable<Nugget["recommendedTrack"]>;
+}) {
+  const navigate = useNavigate();
+  const { artist, title, spotifyTrackUri } = recommendedTrack;
+  const onClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const uri = spotifyTrackUri ?? "";
+    navigate(
+      `/listen/real::${encodeURIComponent(artist)}::${encodeURIComponent(title)}::${encodeURIComponent("")}::${encodeURIComponent(uri)}`,
+    );
+  };
+  return (
+    <button
+      onClick={onClick}
+      className="text-xs px-3 py-1.5 rounded-full bg-white/10 text-white/60 active:scale-95 transition-transform flex items-center gap-1.5"
+      aria-label={`Listen to ${title} by ${artist}`}
+    >
+      <Headphones className="w-3 h-3" />
+      Listen to "{title}"
+    </button>
+  );
+});

--- a/src/mock/types.ts
+++ b/src/mock/types.ts
@@ -60,6 +60,23 @@ export type Nugget = {
   imageUrl?: string;
   imageCaption?: string;
   visualOnly?: boolean;
+  /** Optional artist callout — when the nugget recommends or
+   *  references a specific artist by name (most common on
+   *  `discovery` and `collab` kind nuggets), the server populates
+   *  this so the client can render an "Open {Artist}" button. The
+   *  spotifyArtistId is set when the server's catalog lookup
+   *  found a match; if unset, the client falls back to a
+   *  search-by-name navigation. */
+  recommendedArtist?: {
+    name: string;
+    spotifyArtistId?: string;
+  };
+  /** Optional track callout — same idea for a specific track. */
+  recommendedTrack?: {
+    artist: string;
+    title: string;
+    spotifyTrackUri?: string;
+  };
 };
 
 export type AnimationStyle = "A" | "B" | "C";

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -746,6 +746,24 @@ export default function Listen() {
     }));
   }, [rawTrackNuggets, realDuration]);
 
+  // DEV-ONLY: inject a recommendedArtist via URL query so the
+  // "Open {Artist}" button can be visually verified without a
+  // server-side deploy. Usage: append ?injectArtist=Lunch%20$pecial
+  // (optionally &injectArtistId=SPOTIFY_ID) to any /listen URL.
+  // Stripped from production builds — guarded on import.meta.env.DEV.
+  const trackNuggetsWithDevInjection = useMemo(() => {
+    if (!import.meta.env.DEV) return trackNuggets;
+    if (typeof window === "undefined") return trackNuggets;
+    const params = new URLSearchParams(window.location.search);
+    const injectArtist = params.get("injectArtist");
+    if (!injectArtist) return trackNuggets;
+    const injectArtistId = params.get("injectArtistId") || undefined;
+    return trackNuggets.map((n, i) => (i === 0 ? {
+      ...n,
+      recommendedArtist: { name: injectArtist, spotifyArtistId: injectArtistId },
+    } : n));
+  }, [trackNuggets]);
+
   const [animStyle, setAnimStyle] = useState<AnimationStyle>("A");
   const [activeNugget, setActiveNugget] = useState<Nugget | null>(null);
   const [nuggetQueue, setNuggetQueue] = useState<Nugget[]>([]);
@@ -1709,7 +1727,7 @@ export default function Listen() {
         {isMobile && track && (
           <Suspense fallback={null}>
             <ImmersiveNuggetView
-              nuggets={trackNuggets}
+              nuggets={trackNuggetsWithDevInjection}
               sources={aiSources}
               coverArtUrl={effectiveCoverArt}
               trackTitle={track?.title || ""}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -578,18 +578,38 @@ export default function Listen() {
     setShortId(null);
   }, [rawTrackId, regenerateKey]);
 
+  // Per-trackKey count of nuggets last uploaded to companion_cache.
+  // Used to dedupe — we re-upload only when the count grows. Lives at
+  // module-instance scope so it survives effect re-runs but not Listen
+  // remounts (which is fine — a remount means a new session and a
+  // potentially new shortId anyway).
+  const lastCompanionUploadCountRef = useRef<Map<string, number>>(new Map());
+
   useEffect(() => {
     if (aiLoading || aiNuggets.length === 0 || !track) return;
     const trackKey = `${track.artist}::${track.title}`;
 
-    // Fast path: if companion was already pre-generated this session,
-    // restore the cached shortId immediately (no edge function call).
+    // Restore cached shortId immediately if we have one — but DON'T
+    // early-return. The previous version bailed here, which meant the
+    // companion content was frozen at whatever nugget count existed
+    // on the first run (typically just the pre-gen nugget). Wave-2
+    // nuggets that landed later never made it to companion_cache, so
+    // the QR-code companion page only ever showed the original bland
+    // first nugget. Now we keep going to re-upload the latest nugget
+    // set to companion_cache (the shortId stays the same).
     const cachedSid = player.getCompanionShortId(trackKey);
     if (cachedSid) {
       setShortId(cachedSid);
       setCompanionReady(true);
-      return;
     }
+
+    // Length-based debounce: skip the regen if the nugget count hasn't
+    // grown since the last upload to companion. Initial SSE streams
+    // one nugget at a time and would otherwise fire 4-5 redundant
+    // edge-function calls per fresh generation.
+    const lastSent = lastCompanionUploadCountRef.current.get(trackKey) ?? 0;
+    if (aiNuggets.length === lastSent) return;
+    lastCompanionUploadCountRef.current.set(trackKey, aiNuggets.length);
 
     let cancelled = false;
     (async () => {

--- a/src/test/RecommendedButtons.test.tsx
+++ b/src/test/RecommendedButtons.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+import {
+  RecommendedArtistButton,
+  RecommendedTrackButton,
+} from "@/components/immersive/RecommendedButtons";
+
+beforeEach(() => {
+  navigateMock.mockReset();
+});
+
+describe("RecommendedArtistButton", () => {
+  it("renders the artist name and an Open label", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedArtistButton recommendedArtist={{ name: "Kari Faux" }} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: /open kari faux/i })).toBeTruthy();
+  });
+
+  it("navigates to the spotify-prefixed artist route when an ID is provided", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedArtistButton
+          recommendedArtist={{ name: "Kari Faux", spotifyArtistId: "ABC123" }}
+        />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open kari faux/i }));
+    expect(navigateMock).toHaveBeenCalledWith("/artist/spotify::ABC123::Kari%20Faux");
+  });
+
+  it("falls back to the real:: name route when no Spotify ID is provided", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedArtistButton recommendedArtist={{ name: "Kari Faux" }} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open kari faux/i }));
+    expect(navigateMock).toHaveBeenCalledWith("/artist/real::Kari%20Faux");
+  });
+
+  it("URL-encodes special characters in the artist name", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedArtistButton recommendedArtist={{ name: "Tyler, the Creator" }} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open tyler/i }));
+    expect(navigateMock).toHaveBeenCalledWith("/artist/real::Tyler%2C%20the%20Creator");
+  });
+
+  it("stops propagation so a click on the button doesn't bubble to a parent handler", () => {
+    const parentClick = vi.fn();
+    render(
+      <MemoryRouter>
+        <div onClick={parentClick}>
+          <RecommendedArtistButton recommendedArtist={{ name: "Kari Faux" }} />
+        </div>
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open kari faux/i }));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("RecommendedTrackButton", () => {
+  it("renders the track title in the label", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedTrackButton
+          recommendedTrack={{ artist: "Kari Faux", title: "Bobby" }}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: /listen to bobby by kari faux/i })).toBeTruthy();
+  });
+
+  it("navigates to /listen with the spotify URI in the route when present", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedTrackButton
+          recommendedTrack={{
+            artist: "Kari Faux",
+            title: "Bobby",
+            spotifyTrackUri: "spotify:track:ABC",
+          }}
+        />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /listen to bobby/i }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/listen/real::Kari%20Faux::Bobby::::spotify%3Atrack%3AABC",
+    );
+  });
+
+  it("omits the URI segment when no spotifyTrackUri is provided", () => {
+    render(
+      <MemoryRouter>
+        <RecommendedTrackButton
+          recommendedTrack={{ artist: "Kari Faux", title: "Bobby" }}
+        />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /listen to bobby/i }));
+    expect(navigateMock).toHaveBeenCalledWith("/listen/real::Kari%20Faux::Bobby::::");
+  });
+});


### PR DESCRIPTION
## Summary

Client-side UI for Option 1 (artist/track recommendation CTA on nuggets) plus a batch of related bug fixes Pete reported during local testing.

### New feature
- \`Nugget\` type gains optional \`recommendedArtist\` and \`recommendedTrack\` fields
- \`RecommendedArtistButton\` and \`RecommendedTrackButton\` (new \`src/components/immersive/RecommendedButtons.tsx\`) render in the nugget body next to View Source / Tell me more / Save
- Server-side population (Writer prompt update + Spotify artist lookup) is a follow-up — generate-nuggets stays deploy-guarded
- 8 new unit tests covering button rendering, navigation routing (Spotify-prefix vs real:: fallback), URL encoding of special characters, and click-propagation

### Visual testing helper
- DEV-only \`?injectArtist=Lunch%20%24pecial\` URL param on any \`/listen/\` URL injects a synthetic \`recommendedArtist\` on the first nugget so the button can be visually verified without deploying server-side changes. Stripped from production via \`import.meta.env.DEV\`.

### Bug fixes Pete reported during this session

- **Companion page only showed the original pre-gen nugget, not wave-2 nuggets.** Listen.tsx's companion pre-gen effect bailed at a cached-shortId early-return after the first run. Now: shortId is restored from cache but the upload continues so companion_cache reflects the latest nugget set. Length-based dedupe ref prevents SSE chunks from firing 4-5 redundant edge function calls during fresh generation.
- **Typewriter felt too slow.** Speed bumped from 35 to 18 ms/char (~2x faster first paint).
- **Researching pill dismissed before any nugget arrived** (Red Room by Hiatus Kaiyote). The pill→morphFly transition was OR'd on \`!aiLoading\`, which fired when initial SSE finished even if the synthetic fallback or catch-block recovery hadn't yet landed nuggets in state. Now: pill stays up until \`hasNuggets=true\` (or \`aiError\` for genuine failures, handled separately).

## Test plan
- [x] \`npm test\` — 375/375 passing
- [x] \`npm run build\` — clean
- [ ] Tap a story → first nugget appears, typewriter feels snappy
- [ ] Open companion via the eye/logo top-right → all wave-2 nuggets are present, not just the pre-gen one
- [ ] On a sparse-artist track (bLAck pARty, Pete Rango), pill stays up until the synthetic fallback's nugget lands instead of dismissing into a blank screen
- [ ] In DEV, append \`?injectArtist=Lunch%20%24pecial\` to a listen URL — "Open Lunch $pecial" button appears