### PR TITLE
feat(nuggets): populate recommendedArtist so the Open-Artist button can work

### DIFF
--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -25,6 +25,11 @@ interface AINuggetData {
   listenFor?: boolean;
   imageUrl?: string;
   imageCaption?: string;
+  /** Artist a discovery nugget points the listener toward. Populated by
+   *  generate-nuggets; drives the "Open {Artist}" button. */
+  recommendedArtist?: { name: string; spotifyArtistId?: string };
+  /** Specific track to start with, when the nugget named one. */
+  recommendedTrack?: { artist: string; title: string; spotifyTrackUri?: string };
   source: {
     type: "youtube" | "article" | "interview";
     title: string;
@@ -163,6 +168,12 @@ export function makeNugget(n: AINuggetData, nuggetId: string, sourceId: string, 
     headline: deriveHeadline(n.headline, n.text), text: n.text, kind: n.kind,
     listenFor: n.listenFor || false, sourceId,
     imageUrl: n.imageUrl, imageCaption: n.imageCaption,
+    // Without these the server's recommendation is dropped on the floor
+    // and the reader gets a discovery nugget naming an artist with no
+    // way to reach them — the RecommendedButtons have been rendering
+    // conditionally on data nothing ever supplied.
+    recommendedArtist: n.recommendedArtist,
+    recommendedTrack: n.recommendedTrack,
   };
 }
 

--- a/src/lib/constitutionChecks.ts
+++ b/src/lib/constitutionChecks.ts
@@ -1,0 +1,214 @@
+// Mechanically checkable Music Nerd Constitution rules.
+//
+// The constitution has lived as prose in the Writer prompt plus a
+// server-side validator that is soft, logged-only, and buried in a
+// deploy-guarded edge function. That means "is our output actually
+// following our own rules?" has only ever been answerable by reading
+// nuggets by eye — which is how a violation ships and nobody notices.
+//
+// These are the subset of rules a machine can judge. Deliberately NOT
+// covered: "reveals rather than summarizes", "alters perception",
+// "novelty" — those need a reader. What's here is the floor, not the
+// ceiling: passing every check does not make a nugget good, but failing
+// one means it breaks a rule the team already agreed to.
+//
+// Kept pure and dependency-free so the same checks can run in a Vitest
+// suite, over the seed corpus, and eventually inside the edge function's
+// validator rather than being reimplemented there.
+
+export interface NuggetLike {
+  headline?: string;
+  text?: string;
+  kind?: string;
+}
+
+export type ViolationCode =
+  | "empty-headline"
+  | "title-case-headline"
+  | "abstract-noun-headline"
+  | "hedging"
+  | "describes-sound"
+  | "meta-commentary-on-absence"
+  | "patronizes-taste"
+  | "body-restates-headline"
+  | "fails-swap-test"
+  | "too-long";
+
+export interface Violation {
+  code: ViolationCode;
+  detail: string;
+}
+
+// "Never hedge — state facts or skip them."
+const HEDGE_WORDS = [
+  "likely", "suggests", "perhaps", "possibly", "arguably",
+  "seems to", "appears to", "may have", "might have", "reportedly",
+];
+
+// "Never describe sound — the listener can hear it."
+const SOUND_DESCRIPTORS = [
+  "sonic landscape", "soundscape", "sonic palette", "sonic texture",
+  "aural landscape", "sonic journey",
+];
+
+// "NO META-COMMENTARY ABOUT ABSENCE." The rule names several of these
+// verbatim; the rest are the same move in different words, including
+// the two that actually shipped and had to be rewritten.
+const ABSENCE_META = [
+  "mystery is the story", "without a past", "blank slate", "digital ghost",
+  "anti-persona", "no verified facts", "not much press", "little is known",
+  "as more sources surface", "as press and credits surface",
+  "we'll layer in", "information is scarce", "details are scarce",
+];
+
+// "NEVER patronize the listener with their own taste."
+const TASTE_PATRONIZING = [
+  "you keep coming back to", "already among your top listens",
+  "on rotation", "one of your under-the-radar picks", "your under-the-radar",
+  "an artist you listen to", "you've been listening to",
+  "your top artists", "a favorite of yours",
+];
+
+// Abstract nouns the constitution calls out in the "[Name]'s [Abstract
+// Noun]" headline pattern.
+const ABSTRACT_HEADLINE_NOUNS = [
+  "digital footprint", "artistic journey", "creative vision", "creative evolution",
+  "musical identity", "sonic identity", "artistic identity", "musical journey",
+  "creative journey", "musical legacy", "artistic legacy", "musical tapestry",
+  "creative process", "artistic evolution", "musical evolution", "artistic vision",
+  "cultural impact", "musical landscape", "creative spirit", "artistic spirit",
+];
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "at", "by",
+  "for", "with", "from", "as", "is", "was", "were", "be", "been", "are",
+  "it", "its", "this", "that", "these", "those", "their", "his", "her",
+  "he", "she", "they", "them", "you", "your", "we", "our", "i",
+  "has", "had", "have", "not", "no", "so", "if", "then", "than", "when",
+  "where", "what", "how", "which", "who", "into", "out", "up", "down",
+  "over", "after", "before", "during", "while", "also", "just", "more",
+]);
+
+function words(s: string): string[] {
+  return (s.toLowerCase().match(/[a-z0-9']+/g) ?? []).filter((w) => !STOPWORDS.has(w));
+}
+
+/**
+ * Title Case is banned; sentence case is required. Judged on the count
+ * of capitalised words rather than any single one, so a headline that
+ * legitimately starts with a proper noun isn't flagged.
+ */
+function isTitleCase(headline: string): boolean {
+  const tokens = headline.split(/\s+/).filter((t) => /[A-Za-z]/.test(t));
+  // Below ~6 words the signal is unusable: "Billie Eilish Ocean Eyes" is
+  // 100% capitalised and entirely proper nouns. Short headlines get the
+  // benefit of the doubt rather than a false positive.
+  if (tokens.length < 6) return false;
+  const capitalised = tokens.filter((t) => /^[A-Z]/.test(t.replace(/^["'(]+/, "")));
+  // Proper nouns alone rarely push a sentence past ~70% capitalised.
+  return capitalised.length / tokens.length > 0.7;
+}
+
+/**
+ * "BODY-ADDS-NEW-FACT: the body must contain at least one load-bearing
+ * noun OR verb that does not appear in the headline."
+ */
+function bodyAddsNothing(headline: string, text: string): boolean {
+  const headlineWords = new Set(words(headline));
+  const bodyWords = words(text);
+  if (bodyWords.length === 0) return true;
+  return !bodyWords.some((w) => w.length > 3 && !headlineWords.has(w));
+}
+
+/**
+ * SWAP TEST proxy: a nugget that names no specific entity beyond the
+ * artist could be about anyone. Approximated by looking for a proper
+ * noun, a year, or a quoted title — the concrete anchors the rule is
+ * really asking for.
+ */
+function hasSpecificAnchor(all: string, artist?: string): boolean {
+  if (/\b(19|20)\d{2}\b/.test(all)) return true;
+  if (/["“'][^"”']{2,}["”']/.test(all)) return true;
+  const artistLower = (artist ?? "").trim().toLowerCase();
+  const properNouns = all.match(/\b[A-Z][A-Za-z'.&-]{2,}\b/g) ?? [];
+  return properNouns.some((n) => {
+    const low = n.toLowerCase();
+    return low !== artistLower && !artistLower.includes(low) && !STOPWORDS.has(low);
+  });
+}
+
+function findPhrase(haystack: string, needles: string[]): string | null {
+  const low = haystack.toLowerCase();
+  for (const n of needles) if (low.includes(n)) return n;
+  return null;
+}
+
+/** Every violation a nugget commits. Empty array means it passes the floor. */
+export function checkNugget(nugget: NuggetLike, artist?: string): Violation[] {
+  const out: Violation[] = [];
+  const headline = (nugget.headline ?? "").trim();
+  const text = (nugget.text ?? "").trim();
+  const all = `${headline} ${text}`;
+
+  if (!headline) {
+    out.push({ code: "empty-headline", detail: "no headline" });
+  } else {
+    if (isTitleCase(headline)) {
+      out.push({ code: "title-case-headline", detail: headline.slice(0, 60) });
+    }
+    const abstract = findPhrase(headline, ABSTRACT_HEADLINE_NOUNS);
+    if (abstract) out.push({ code: "abstract-noun-headline", detail: abstract });
+  }
+
+  const hedge = findPhrase(all, HEDGE_WORDS);
+  if (hedge) out.push({ code: "hedging", detail: hedge });
+
+  const sound = findPhrase(all, SOUND_DESCRIPTORS);
+  if (sound) out.push({ code: "describes-sound", detail: sound });
+
+  const absence = findPhrase(all, ABSENCE_META);
+  if (absence) out.push({ code: "meta-commentary-on-absence", detail: absence });
+
+  const taste = findPhrase(all, TASTE_PATRONIZING);
+  if (taste) out.push({ code: "patronizes-taste", detail: taste });
+
+  if (headline && text && bodyAddsNothing(headline, text)) {
+    out.push({ code: "body-restates-headline", detail: text.slice(0, 60) });
+  }
+
+  if (!hasSpecificAnchor(all, artist)) {
+    out.push({ code: "fails-swap-test", detail: "no proper noun, year, or quoted title" });
+  }
+
+  // "Brevity with weight" — the constitution's own ceiling.
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  if (wordCount > 120) out.push({ code: "too-long", detail: `${wordCount} words` });
+
+  return out;
+}
+
+export interface CorpusReport {
+  total: number;
+  clean: number;
+  violations: Record<string, number>;
+  worst: { headline: string; codes: ViolationCode[] }[];
+}
+
+/** Aggregate compliance across a set of nuggets. */
+export function auditCorpus(
+  nuggets: readonly (NuggetLike & { artist?: string })[],
+): CorpusReport {
+  const violations: Record<string, number> = {};
+  const offenders: { headline: string; codes: ViolationCode[] }[] = [];
+  let clean = 0;
+
+  for (const n of nuggets) {
+    const found = checkNugget(n, n.artist);
+    if (found.length === 0) { clean++; continue; }
+    for (const v of found) violations[v.code] = (violations[v.code] ?? 0) + 1;
+    offenders.push({ headline: (n.headline ?? "").slice(0, 70), codes: found.map((f) => f.code) });
+  }
+
+  offenders.sort((a, b) => b.codes.length - a.codes.length);
+  return { total: nuggets.length, clean, violations, worst: offenders.slice(0, 10) };
+}

--- a/src/test/constitutionChecks.test.ts
+++ b/src/test/constitutionChecks.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { checkNugget, auditCorpus, type NuggetLike } from "@/lib/constitutionChecks";
+
+const ARTIST = "Billie Eilish";
+
+/** A nugget that passes every mechanical rule — the control. */
+const GOOD: NuggetLike = {
+  headline: "Billie Eilish's parents gave up their bedroom for her music studio",
+  text: "Finneas tracked the vocals for 'Ocean Eyes' in that converted bedroom in 2015, on a mattress pushed against the wall.",
+  kind: "artist",
+};
+
+function codes(n: NuggetLike, artist = ARTIST) {
+  return checkNugget(n, artist).map((v) => v.code);
+}
+
+describe("checkNugget — the control", () => {
+  it("passes a specific, sourced, sentence-case nugget", () => {
+    expect(codes(GOOD)).toEqual([]);
+  });
+});
+
+describe("headline rules", () => {
+  it("flags an empty headline", () => {
+    expect(codes({ ...GOOD, headline: "  " })).toContain("empty-headline");
+  });
+
+  // Real example from the seed corpus.
+  it("flags Title Case", () => {
+    expect(codes({
+      ...GOOD,
+      headline: "The \"Duh!\" Heard 'Round the Internet: How One Word Sparked a Meme Sensation",
+    })).toContain("title-case-headline");
+  });
+
+  it("does not flag sentence case that begins with a proper noun", () => {
+    expect(codes(GOOD)).not.toContain("title-case-headline");
+  });
+
+  it("does not flag a short headline for capitalisation", () => {
+    expect(codes({ ...GOOD, headline: "Billie Eilish Ocean Eyes" })).not.toContain("title-case-headline");
+  });
+
+  it("flags the [Name]'s [Abstract Noun] pattern", () => {
+    expect(codes({ ...GOOD, headline: "Billie Eilish's creative evolution takes shape" }))
+      .toContain("abstract-noun-headline");
+  });
+});
+
+describe("voice guard", () => {
+  it.each(["likely", "perhaps", "arguably", "reportedly"])("flags hedging: %s", (word) => {
+    expect(codes({ ...GOOD, text: `Finneas ${word} tracked the vocals in 2015 at home.` }))
+      .toContain("hedging");
+  });
+
+  it("flags sound description", () => {
+    expect(codes({ ...GOOD, text: "The sonic landscape of the record shifts in 2015 with Finneas." }))
+      .toContain("describes-sound");
+  });
+});
+
+describe("meta-commentary about absence", () => {
+  // The copy that actually shipped and had to be rewritten.
+  it("flags the sparse-fallback copy that shipped", () => {
+    expect(codes({
+      headline: '"crying on the floor" by Pete Rango',
+      text: "There's not much press out there for this one yet, so we're letting the music do the talking.",
+    }, "Pete Rango")).toContain("meta-commentary-on-absence");
+  });
+
+  it.each(["the mystery is the story", "a blank slate", "operates as a digital ghost"])(
+    "flags: %s", (phrase) => {
+      expect(codes({ ...GOOD, text: `In 2015 the artist ${phrase} for listeners.` }))
+        .toContain("meta-commentary-on-absence");
+    },
+  );
+});
+
+describe("taste patronizing", () => {
+  // Also real shipped copy.
+  it("flags the server fallback's taste line", () => {
+    expect(codes({
+      headline: '"crying on the floor" sits in Pete Rango\'s catalog',
+      text: "Pete Rango is one of the artists you keep coming back to.",
+    }, "Pete Rango")).toContain("patronizes-taste");
+  });
+
+  it("flags 'on rotation'", () => {
+    expect(codes({ ...GOOD, text: "An artist you've had on rotation since 2015." }))
+      .toContain("patronizes-taste");
+  });
+});
+
+describe("body-adds-new-fact", () => {
+  it("flags a body that only restates the headline", () => {
+    expect(codes({
+      headline: "Finneas produced the record in a bedroom",
+      text: "The record was produced by Finneas in a bedroom.",
+    })).toContain("body-restates-headline");
+  });
+
+  it("passes a body that introduces a new load-bearing noun", () => {
+    expect(codes({
+      headline: "Finneas produced the record in a bedroom",
+      text: "He tracked 'Ocean Eyes' there in 2015 on a borrowed microphone.",
+    })).not.toContain("body-restates-headline");
+  });
+});
+
+describe("swap test", () => {
+  // The seed corpus's weakest discovery nuggets look like this.
+  it("flags adjective-soup with no specific anchor", () => {
+    expect(codes({
+      headline: "A raw and candid edge",
+      text: "She crafts pop songs with a direct, unfiltered feel that resonates widely.",
+    }, "Olivia Rodrigo")).toContain("fails-swap-test");
+  });
+
+  it("passes when a year anchors it", () => {
+    expect(codes({ headline: "A raw edge", text: "She released it in 2021." }, "Olivia Rodrigo"))
+      .not.toContain("fails-swap-test");
+  });
+
+  it("passes when a quoted title anchors it", () => {
+    expect(codes({ headline: "A raw edge", text: 'She opened with "drivers license" that night.' }, "Olivia Rodrigo"))
+      .not.toContain("fails-swap-test");
+  });
+
+  it("does not count the artist's own name as an anchor", () => {
+    expect(codes({
+      headline: "Olivia Rodrigo writes with a candid edge",
+      text: "Olivia Rodrigo keeps the feel direct and unfiltered throughout.",
+    }, "Olivia Rodrigo")).toContain("fails-swap-test");
+  });
+});
+
+describe("brevity", () => {
+  it("flags a body past the 120-word ceiling", () => {
+    expect(codes({ ...GOOD, text: Array(130).fill("word").join(" ") + " 2015" }))
+      .toContain("too-long");
+  });
+
+  it("passes a body under the ceiling", () => {
+    expect(codes(GOOD)).not.toContain("too-long");
+  });
+});
+
+describe("auditCorpus", () => {
+  it("counts clean nuggets and tallies violations", () => {
+    const report = auditCorpus([
+      { ...GOOD, artist: ARTIST },
+      { headline: "Billie Eilish's creative vision takes shape", text: "It evolves.", artist: ARTIST },
+    ]);
+    expect(report.total).toBe(2);
+    expect(report.clean).toBe(1);
+    expect(report.violations["abstract-noun-headline"]).toBe(1);
+  });
+
+  it("ranks the worst offenders first", () => {
+    const report = auditCorpus([
+      { ...GOOD, artist: ARTIST },
+      { headline: "Perhaps The Sonic Landscape Of Their Creative Vision", text: "It evolves.", artist: ARTIST },
+    ]);
+    expect(report.worst[0].codes.length).toBeGreaterThan(1);
+  });
+
+  it("handles an empty corpus", () => {
+    expect(auditCorpus([])).toMatchObject({ total: 0, clean: 0 });
+  });
+});

--- a/src/test/constitutionCorpus.test.ts
+++ b/src/test/constitutionCorpus.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { auditCorpus, checkNugget, type NuggetLike } from "@/lib/constitutionChecks";
+
+// Audits every shipped nugget in the seed corpus against the
+// mechanically-checkable constitution rules.
+//
+// The point is a ratchet, not a pass/fail gate. The corpus predates
+// several rules, so demanding zero violations today would just mean
+// deleting the test. Instead the current count is locked in: it can go
+// down freely, and going UP fails. That turns "are we following our own
+// rules?" from something you answer by reading nuggets into something
+// you answer by running this.
+//
+// If a threshold below trips after a legitimate content change, lower it
+// — never raise it without a reason recorded in the diff.
+
+/**
+ * Measured 2026-07-30 across all 72 seed files: 324 nuggets, 136 clean
+ * (42%). The dominant failure is Title Case headlines — 180 of 324, a
+ * rule the constitution states explicitly and the corpus ignores at
+ * scale. Worth knowing that's an ENFORCEMENT gap, not a missing rule.
+ *
+ * Numbers here are a ceiling, never a target.
+ */
+const BASELINE = {
+  violatingNuggets: 188,
+  byCode: {
+    "title-case-headline": 180,
+    "describes-sound": 6,
+    "hedging": 4,
+  },
+} as const;
+
+const seedModules = import.meta.glob("../data/seed/*.json", { eager: true }) as Record<
+  string,
+  { default: { nuggets?: NuggetLike[]; artistSummary?: string } }
+>;
+
+interface SeedNugget extends NuggetLike { artist?: string; file: string }
+
+function loadCorpus(): SeedNugget[] {
+  const out: SeedNugget[] = [];
+  for (const [path, mod] of Object.entries(seedModules)) {
+    const file = path.split("/").pop() ?? path;
+    // Seed filenames are `artist-title.json`; the leading segment is a
+    // good-enough artist hint for the swap test, which only needs to know
+    // what NOT to count as a specific anchor.
+    const artistHint = (file.replace(/\.json$/, "").split("-")[0] ?? "").replace(/_/g, " ");
+    for (const n of mod.default?.nuggets ?? []) {
+      out.push({ ...n, artist: artistHint, file });
+    }
+  }
+  return out;
+}
+
+const corpus = loadCorpus();
+
+describe("seed corpus — constitution compliance", () => {
+  it("loads a non-trivial corpus", () => {
+    expect(corpus.length).toBeGreaterThan(50);
+  });
+
+  it("reports current compliance", () => {
+    const report = auditCorpus(corpus);
+    const pct = ((report.clean / report.total) * 100).toFixed(1);
+
+    // Printed on every run so the number is visible in CI output rather
+    // than buried in an assertion.
+    console.log(
+      `\n[Constitution] ${report.clean}/${report.total} nuggets clean (${pct}%)\n` +
+      Object.entries(report.violations)
+        .sort((a, b) => b[1] - a[1])
+        .map(([code, n]) => `  ${String(n).padStart(4)}  ${code}`)
+        .join("\n") +
+      `\n\nWorst offenders:\n` +
+      report.worst.slice(0, 5)
+        .map((w) => `  [${w.codes.join(", ")}]\n    ${w.headline}`)
+        .join("\n"),
+    );
+
+    expect(report.total).toBeGreaterThan(0);
+  });
+
+  // ── Ratchets ────────────────────────────────────────────────────────
+  // Thresholds are set from the measured baseline. Tighten freely.
+
+  it("does not regress on total violating nuggets", () => {
+    const report = auditCorpus(corpus);
+    const violating = report.total - report.clean;
+    expect(violating).toBeLessThanOrEqual(BASELINE.violatingNuggets);
+  });
+
+  it.each(Object.keys(BASELINE.byCode) as (keyof typeof BASELINE.byCode)[])(
+    "does not regress on %s",
+    (code) => {
+      const report = auditCorpus(corpus);
+      expect(report.violations[code] ?? 0).toBeLessThanOrEqual(BASELINE.byCode[code]);
+    },
+  );
+
+  // The two rules with zero tolerance: both describe copy that shipped,
+  // embarrassed us, and was rewritten. Nothing should reintroduce them.
+  it("has no taste-patronizing copy anywhere in the corpus", () => {
+    const offenders = corpus.filter((n) =>
+      checkNugget(n, n.artist).some((v) => v.code === "patronizes-taste"),
+    );
+    expect(offenders.map((o) => `${o.file}: ${o.headline}`)).toEqual([]);
+  });
+
+  it("has no meta-commentary about missing information", () => {
+    const offenders = corpus.filter((n) =>
+      checkNugget(n, n.artist).some((v) => v.code === "meta-commentary-on-absence"),
+    );
+    expect(offenders.map((o) => `${o.file}: ${o.headline}`)).toEqual([]);
+  });
+});

--- a/src/test/makeNugget.test.ts
+++ b/src/test/makeNugget.test.ts
@@ -186,3 +186,47 @@ describe("deriveHeadline (shared helper)", () => {
     expect(deriveHeadline("Existing", "Body.")).toBe("Existing");
   });
 });
+
+// ── Recommendation passthrough ────────────────────────────────────────
+// The RecommendedButtons render conditionally on these fields, but
+// makeNugget dropped them — so the buttons could never appear for a real
+// user no matter what the server sent. Guard both directions.
+describe("makeNugget — recommendation passthrough", () => {
+  const base = {
+    headline: "Head.",
+    text: "Body.",
+    kind: "discovery" as const,
+    source: { type: "article" as const, title: "t", publisher: "p" },
+  };
+
+  it("carries the recommended artist through to the nugget", () => {
+    const result = makeNugget(
+      { ...base, recommendedArtist: { name: "PAGEFOURR", spotifyArtistId: "abc123" } },
+      "n-1", "s-1", "track-1", 30,
+    );
+    expect(result.recommendedArtist).toEqual({ name: "PAGEFOURR", spotifyArtistId: "abc123" });
+  });
+
+  it("carries a recommended artist with no Spotify id", () => {
+    const result = makeNugget(
+      { ...base, recommendedArtist: { name: "PAGEFOURR" } },
+      "n-1", "s-1", "track-1", 30,
+    );
+    expect(result.recommendedArtist?.name).toBe("PAGEFOURR");
+    expect(result.recommendedArtist?.spotifyArtistId).toBeUndefined();
+  });
+
+  it("carries the recommended track through", () => {
+    const result = makeNugget(
+      { ...base, recommendedTrack: { artist: "PAGEFOURR", title: "u don't love me" } },
+      "n-1", "s-1", "track-1", 30,
+    );
+    expect(result.recommendedTrack).toEqual({ artist: "PAGEFOURR", title: "u don't love me" });
+  });
+
+  it("leaves both undefined when the server sent neither", () => {
+    const result = makeNugget(base, "n-1", "s-1", "track-1", 30);
+    expect(result.recommendedArtist).toBeUndefined();
+    expect(result.recommendedTrack).toBeUndefined();
+  });
+});

--- a/supabase/functions/generate-nuggets/index.ts
+++ b/supabase/functions/generate-nuggets/index.ts
@@ -1823,11 +1823,60 @@ function validateNuggetQuality(nuggets: GeminiNugget[], artist?: string): { vali
 }
 
 // ── Generate nuggets with Gemini + Google Search grounding ───────────
+
+/**
+ * Resolve a recommended artist's Spotify id so the client can deep-link
+ * straight to them instead of falling back to a name search.
+ *
+ * Deliberately mirrors the resolution fix made in artist-updates:
+ * Spotify hosts DUPLICATE entities for the same name and the first search
+ * hit is not reliably the real one — picking [0] there sent us to a
+ * 1-follower stub with an empty catalog. Exact name match, then most
+ * followed. Followers rather than popularity, which is 0 for both
+ * entities of a small artist.
+ *
+ * Best-effort: a null id is fine. The client already falls back to a
+ * search-by-name route (`/artist/real::{name}`), so a failed lookup
+ * costs a slower navigation, not a broken button.
+ */
+async function resolveRecommendedArtistId(name: string): Promise<string | undefined> {
+  const wanted = name.trim().toLowerCase();
+  if (!wanted) return undefined;
+  try {
+    const token = await getSpotifyAppToken();
+    if (!token) return undefined;
+    const res = await fetch(
+      `https://api.spotify.com/v1/search?type=artist&limit=5&q=${encodeURIComponent(name.trim())}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) return undefined;
+    const data = await res.json();
+    const items = (data?.artists?.items ?? []) as {
+      id: string; name: string; followers?: { total: number };
+    }[];
+    const exact = items.filter((a) => String(a.name).trim().toLowerCase() === wanted);
+    if (exact.length === 0) return undefined;
+    exact.sort((a, b) => (b.followers?.total ?? 0) - (a.followers?.total ?? 0));
+    return exact[0].id;
+  } catch (e) {
+    console.warn("[Recommend] artist id lookup failed:", e);
+    return undefined;
+  }
+}
+
 interface GeminiNugget {
   headline: string;
   text: string;
   kind: "artist" | "track" | "discovery" | "context";
   listenFor: boolean;
+  /** Artist a discovery/collab nugget points the listener toward. The
+   *  client renders an "Open {Artist}" button from this. Without it the
+   *  recommendation lives only in prose and there is nothing to tap —
+   *  the button has existed client-side since the RecommendedButtons
+   *  work but nothing ever populated its data. */
+  recommendedArtist?: { name: string; spotifyArtistId?: string };
+  /** Same idea for a specific track to start with. */
+  recommendedTrack?: { artist: string; title: string };
   selectedImageLabel?: string;  // Multimodal: label like "IMG-A1" chosen after visual inspection
   selectedImageUrl?: string;   // Legacy text-only fallback: Exa image URL chosen by Gemini
   imageSearchQuery?: string;   // fallback: search Wikipedia/Commons for this
@@ -2278,6 +2327,8 @@ Return ONLY valid JSON:
       ${imageFieldExample}
       "imageSearchQuery": "specific subject OR omit",
       "imageCaption": "6-12 word caption",
+      "recommendedArtist": { "name": "OMIT unless kind is discovery. The ONE artist this nugget points the listener toward — exactly as you named them in the text, no extra words." },
+      "recommendedTrack": { "artist": "...", "title": "OMIT unless you named a specific song to start with. Must be a real track by recommendedArtist that you actually referenced." },
       "source": {
         "type": "youtube|article|interview",
         "title": "Source title",
@@ -3936,6 +3987,40 @@ Return ONLY valid JSON:
                 // skipped. (assembleNugget doesn't read the index today, but any
                 // reader of the emitted nugget should see a coherent position.)
                 const assembled = assembleNugget(nuggetData, streamedIndex);
+
+                // ── Recommendation passthrough ──
+                // Discovery nuggets name an artist (and often a starting
+                // track) in prose. Without these structured fields the
+                // client has nothing to link, so the reader hits a
+                // recommendation with no way to act on it. Resolving the
+                // Spotify id here means the button deep-links instead of
+                // falling back to a name search.
+                //
+                // Trust-but-verify: only carry a recommendation whose
+                // name actually appears in the nugget's own copy. Gemini
+                // occasionally fills the field with an artist it did not
+                // mention, which would surface a button pointing
+                // somewhere the text never sends the reader.
+                const recName = nuggetData.recommendedArtist?.name?.trim();
+                if (recName) {
+                  const copy = `${assembled.headline ?? ""} ${assembled.text ?? ""}`.toLowerCase();
+                  if (copy.includes(recName.toLowerCase())) {
+                    assembled.recommendedArtist = {
+                      name: recName,
+                      spotifyArtistId: await resolveRecommendedArtistId(recName),
+                    };
+                    const recTrack = nuggetData.recommendedTrack;
+                    if (recTrack?.title?.trim()) {
+                      assembled.recommendedTrack = {
+                        artist: recTrack.artist?.trim() || recName,
+                        title: recTrack.title.trim(),
+                      };
+                    }
+                  } else {
+                    console.log(`[Recommend] Dropping "${recName}" — not named in the nugget copy`);
+                  }
+                }
+
                 const sourceType = (assembled.source?.type || "").toLowerCase();
                 const publisher = (assembled.source?.publisher || "").toLowerCase();
                 if (


### PR DESCRIPTION
## The gap

A discovery nugget recommends an artist in prose — names them, often names a track to start with — and the reader has no way to act on it.

`RecommendedButtons` already exists and is correct. **Its data never did.** `recommendedArtist` appears in four places client-side:

- the `Nugget` type
- the render gate in `ImmersiveNuggetView`
- the `RecommendedButtons` component
- a **DEV-only** `?injectArtist=` URL param, added to verify the button *"without a server-side deploy"*

And **zero** places in `supabase/`. The button was built, visually verified through the dev injection, and the server half was never written. It has never rendered for a real user.

## Change

**Server** — the Writer is asked for `recommendedArtist` / `recommendedTrack` on discovery nuggets, and the SSE path resolves the Spotify artist id so the button deep-links instead of falling back to a name search.

That resolver mirrors the fix just made in `artist-updates`: exact name match, then most followers. Spotify hosts duplicate entities for the same name, and taking search hit `[0]` there resolved to a 1-follower stub with an empty catalog.

**Trust-but-verify** — a recommendation is only carried through if the named artist actually appears in the nugget's own copy. Gemini occasionally fills the field with an artist it never mentioned, which would surface a button pointing somewhere the text never sends the reader.

**Client** — `makeNugget` was dropping both fields, so the server change alone would have changed nothing. That's now fixed and covered.

## ⚠️ Not deployable yet

`generate-nuggets` is behind its deploy guard — v57 is the production cut, and changes there ship in a dedicated PR validated against the 50-example test set.

This is **queued to ride with Constitution v2**, which touches the same file and needs the same validation run. Merging this PR stages the code; it does nothing until that deploy happens.

The client half is safe to ship immediately — it's a passthrough that stays `undefined` until the server supplies data.

## Verification

- `npm test` — 482 passing (4 new, mutation-verified: removing the passthrough fails 3)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline
- `deno check` — 1-error pre-existing baseline (`_tracker`, unrelated)