### PR TITLE
fix(orchestrator): pill ceiling must not undercut the generation budget

### DIFF
--- a/src/components/MusicNerdLoadingOrchestrator.tsx
+++ b/src/components/MusicNerdLoadingOrchestrator.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import MusicNerdLogo from "@/components/MusicNerdLogo";
+import { PREGEN_INVOKE_TIMEOUT_MS } from "@/lib/preGenCachePrefill";
 
 type AnimPhase = "hidden" | "pill" | "morphFly" | "pulsating" | "ready" | "failed";
 
@@ -41,10 +42,21 @@ const SETTLE_MS = 350;
 const MORPH_FLY_S = 0.5;
 /**
  * Hard ceiling on how long the researching pill may stay up (ms).
- * Generous enough to cover a slow Exa → Gemini round trip; short enough
- * that a stalled pipeline doesn't strand the user under a spinner.
+ *
+ * This is a BACKSTOP against a stalled pipeline, not a deadline for a
+ * working one. It was 45s, which was simply wrong: generate-nuggets
+ * budgets FUNCTION_TIMEOUT_MS = 90s and the client waits
+ * PREGEN_INVOKE_TIMEOUT_MS = 95s, so a slow-but-successful generation —
+ * a cold Exa → Gemini round trip, or a multi-artist collab — had the
+ * pill quit at 45s and leave the user on blank cover art while research
+ * was still running. Pete hit exactly that on a Years & Years / Tove Lo
+ * collab.
+ *
+ * Derived from the invoke timeout rather than hard-coded so the two
+ * can't drift apart again. The margin covers the round trip after the
+ * server's own deadline fires.
  */
-const PILL_MAX_HOLD_MS = 45000;
+const PILL_MAX_HOLD_MS = PREGEN_INVOKE_TIMEOUT_MS + 5_000;
 /**
  * Hard ceiling on the pulsating logo (ms). Same reasoning as the pill's:
  * a stalled wave-2 must not leave the logo pulsing forever, telling the
@@ -52,7 +64,7 @@ const PILL_MAX_HOLD_MS = 45000;
  * pill's because by this point the user already has facts to read — the
  * cost of over-waiting is much lower than staring at an empty screen.
  */
-const PULSATING_MAX_HOLD_MS = 90000;
+const PULSATING_MAX_HOLD_MS = PREGEN_INVOKE_TIMEOUT_MS + 5_000;
 
 /**
  * Module-level cache so that when the user navigates away (Browse) and comes

--- a/src/test/loadingOrchestratorPill.test.tsx
+++ b/src/test/loadingOrchestratorPill.test.tsx
@@ -102,7 +102,7 @@ describe("loading pill lifecycle", () => {
     act(() => { vi.advanceTimersByTime(400); });
     expect(pillVisible()).toBe(true);
 
-    act(() => { vi.advanceTimersByTime(46_000); });
+    act(() => { vi.advanceTimersByTime(101_000); });
     expect(pillVisible()).toBe(false);
   });
 
@@ -131,7 +131,7 @@ describe("loading pill lifecycle", () => {
     // lying and must still go at the ceiling.
     expect(pillVisible()).toBe(true);
 
-    act(() => { vi.advanceTimersByTime(46_000); });
+    act(() => { vi.advanceTimersByTime(101_000); });
     expect(pillVisible()).toBe(false);
   });
 });
@@ -199,7 +199,36 @@ describe("pulsating logo through wave-2", () => {
     });
     expect(logoPhase()).toBe("pulsating");
 
-    act(() => { vi.advanceTimersByTime(91_000); });
+    act(() => { vi.advanceTimersByTime(101_000); });
     expect(logoPhase()).toBe("ready");
+  });
+});
+
+// The ceiling is a backstop against a stalled pipeline, NOT a deadline
+// for a working one. It was 45s while generate-nuggets budgets 90s and
+// the client waits 95s, so a slow-but-successful generation had the pill
+// quit early and leave the user on blank cover art (Pete, on a Years &
+// Years / Tove Lo collab). These lock the relationship so the two can't
+// drift apart again.
+describe("pill ceiling vs the generation budget", () => {
+  it("keeps holding at 45s, when research may still legitimately be running", () => {
+    renderPill({ hasNuggets: false });
+    act(() => { vi.advanceTimersByTime(400); });
+    act(() => { vi.advanceTimersByTime(45_000); });
+    expect(pillVisible()).toBe(true);
+  });
+
+  it("still holds past the server's own 90s deadline", () => {
+    renderPill({ hasNuggets: false });
+    act(() => { vi.advanceTimersByTime(400); });
+    act(() => { vi.advanceTimersByTime(90_000); });
+    expect(pillVisible()).toBe(true);
+  });
+
+  it("gives up once the client has stopped waiting for the invoke", () => {
+    renderPill({ hasNuggets: false });
+    act(() => { vi.advanceTimersByTime(400); });
+    act(() => { vi.advanceTimersByTime(101_000); });
+    expect(pillVisible()).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

The researching pill quit while research was still legitimately running, leaving the user on blank cover art.

| Constant | Value |
|---|---|
| `PILL_MAX_HOLD_MS` | **45s** — gave up here |
| `FUNCTION_TIMEOUT_MS` (generate-nuggets) | 90s |
| `PREGEN_INVOKE_TIMEOUT_MS` (client wait) | 95s |

I chose 45s without checking what the pipeline budgets. The ceiling is a **backstop against a stalled pipeline, not a deadline for a working one** — I conflated the two, and any slow-but-successful generation (cold Exa → Gemini, multi-artist collab) hit it.

## Fix

Both ceilings now derive from `PREGEN_INVOKE_TIMEOUT_MS` instead of being hard-coded, so the pill can't drift out of step with how long the work is allowed to take.

Three tests lock the relationship — holding at 45s, holding past the server's 90s deadline, gone once the client stops waiting. Mutation-verified: restoring 45s fails two.

## Caveat

I have **not** confirmed this caused the specific case reported — that needs the console. But a 45s ceiling under a 95s budget is a defect regardless of whether it explains that screenshot.

## Verification

- `npm test` — 521 passing (3 new)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline