### PR TITLE
fix(nuggets): stop late-arriving enrichment aborting generation and wiping facts

### DIFF
--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -391,8 +391,28 @@ export function useAINuggets(
     waveExhaustedRef.current = false;
   }, [trackId, regenerateKey]);
 
+  // Enrichment inputs — used INSIDE generate() but deliberately not in its
+  // dependency array. They arrive asynchronously (the artist image resolves
+  // from profile.artistImages; topArtists/topTracks get replaced by the
+  // background taste refresh), so including them meant generate() got a new
+  // identity mid-listen, the effect re-ran, and its first act — setNuggets([])
+  // — wiped every fact the user was reading. Pete: "I had a track paused for a
+  // while, I unpaused, and all the facts disappeared and the researching pill
+  // showed up again."
+  //
+  // Regeneration should be decided by WHAT we are generating for (track, tier,
+  // listen depth), never by late-arriving decoration.
+  const enrichmentRef = useRef({ coverArtUrl, artistImageUrl, topArtists, topTracks });
+  enrichmentRef.current = { coverArtUrl, artistImageUrl, topArtists, topTracks };
+
   const generate = useCallback(async () => {
     if (!artist || !title) return;
+    const {
+      coverArtUrl: coverArtUrlLive,
+      artistImageUrl: artistImageUrlLive,
+      topArtists: topArtistsLive,
+      topTracks: topTracksLive,
+    } = enrichmentRef.current;
     setFromCache(false);
 
     // Clear stale state from a previous track so SSE appends don't stack
@@ -562,11 +582,11 @@ export function useAINuggets(
             nugget.imageUrl = seedNugget.imageUrl;
             nugget.imageCaption = seedNugget.imageCaption || nugget.headline;
             contextualImageIndices.add(idx);
-          } else if (nugget.kind === "artist" && isRealImg(artistImageUrl)) {
-            nugget.imageUrl = artistImageUrl;
+          } else if (nugget.kind === "artist" && isRealImg(artistImageUrlLive)) {
+            nugget.imageUrl = artistImageUrlLive;
             nugget.imageCaption = artist;
-          } else if ((nugget.kind === "track" || nugget.kind === "discovery") && isRealImg(coverArtUrl)) {
-            nugget.imageUrl = coverArtUrl;
+          } else if ((nugget.kind === "track" || nugget.kind === "discovery") && isRealImg(coverArtUrlLive)) {
+            nugget.imageUrl = coverArtUrlLive;
             nugget.imageCaption = nugget.kind === "track"
               ? `${title}${album ? " \u2014 " + album : ""}`
               : nugget.headline || "Explore next";
@@ -765,9 +785,9 @@ export function useAINuggets(
         listenCount: currentListenCount,
         previousNuggets,
         tier,
-        userTopArtists: topArtists?.slice(0, 10),
-        userTopTracks: topTracks?.slice(0, 10),
-        spotifyArtistImageUrl: artistImageUrl,
+        userTopArtists: topArtistsLive?.slice(0, 10),
+        userTopTracks: topTracksLive?.slice(0, 10),
+        spotifyArtistImageUrl: artistImageUrlLive,
         spotifyTrackId: spotifyTrackIdValue,
         appleTrackId: appleTrackIdValue,
         durationSec,  // server uses this to compute cache-side timestamps
@@ -951,11 +971,11 @@ export function useAINuggets(
         const isRealImg = (url?: string) => url && !url.includes("dicebear.com");
         for (const n of aiNuggets) {
           if (n.imageUrl) continue; // server already resolved
-          if (n.kind === "artist" && isRealImg(artistImageUrl)) {
-            n.imageUrl = artistImageUrl;
+          if (n.kind === "artist" && isRealImg(artistImageUrlLive)) {
+            n.imageUrl = artistImageUrlLive;
             n.imageCaption = artist;
-          } else if (isRealImg(coverArtUrl)) {
-            n.imageUrl = coverArtUrl;
+          } else if (isRealImg(coverArtUrlLive)) {
+            n.imageUrl = coverArtUrlLive;
             n.imageCaption = title;
           }
         }
@@ -1046,16 +1066,16 @@ export function useAINuggets(
           contextualImageIndices.add(idx);
         }
         // "context" kind: keep backend-resolved image, only fallback to artist photo
-        else if (nugget.kind === "context" && isRealImage(artistImageUrl)) {
-          nugget.imageUrl = artistImageUrl;
+        else if (nugget.kind === "context" && isRealImage(artistImageUrlLive)) {
+          nugget.imageUrl = artistImageUrlLive;
           nugget.imageCaption = artist;
         }
         // Fall back to Spotify images (only real URLs, not DiceBear placeholders)
-        else if (nugget.kind === "artist" && isRealImage(artistImageUrl)) {
-          nugget.imageUrl = artistImageUrl;
+        else if (nugget.kind === "artist" && isRealImage(artistImageUrlLive)) {
+          nugget.imageUrl = artistImageUrlLive;
           nugget.imageCaption = artist;
-        } else if ((nugget.kind === "track" || nugget.kind === "discovery") && isRealImage(coverArtUrl)) {
-          nugget.imageUrl = coverArtUrl;
+        } else if ((nugget.kind === "track" || nugget.kind === "discovery") && isRealImage(coverArtUrlLive)) {
+          nugget.imageUrl = coverArtUrlLive;
           nugget.imageCaption = nugget.kind === "track"
             ? `${title}${album ? " \u2014 " + album : ""}`
             : nugget.headline || "Explore next";
@@ -1191,7 +1211,7 @@ export function useAINuggets(
         // nugget than leave the user staring at cover art with no
         // content to read.
         console.warn(`[useAINuggets] SSE failed and no cache row exists for ${dbCacheKey}; synthesizing catalog fallback`);
-        const synth = makeSparseFallbackNugget(artist, title, trackId, durationSec, coverArtUrl);
+        const synth = makeSparseFallbackNugget(artist, title, trackId, durationSec, coverArtUrlLive);
         const synthSources = new Map<string, Source>([[synth.source.id, synth.source]]);
         setNuggets([synth.nugget]);
         setSources(synthSources);
@@ -1218,7 +1238,7 @@ export function useAINuggets(
         setLoading(false);
       }
     }
-  }, [trackId, artist, title, album, durationSec, coverArtUrl, artistImageUrl, tier, regenerateKey, topArtists, topTracks, getNuggetCache, setNuggetCache, setTrackListenCount]);
+  }, [trackId, artist, title, album, durationSec, tier, regenerateKey, getNuggetCache, setNuggetCache, setTrackListenCount]); // enrichment deliberately excluded — see enrichmentRef above
 
   useEffect(() => {
     cancelledRef.current = false;


### PR DESCRIPTION
## Symptoms this explains

Two reports, one cause:

1. *"I had a track paused for a while, I unpaused, and all the facts disappeared and the researching pill showed up again."*
2. *"It said it was doing research and then it never showed up with any facts."* (Humming — Turnover)

## Cause

`generate()`'s dependency array included `coverArtUrl`, `artistImageUrl`, `topArtists`, `topTracks`. **All four arrive asynchronously** — the artist image resolves from `profile.artistImages`, and the background taste refresh replaces the top-artist arrays.

Any of them landing gives `generate()` a new identity, which re-runs the effect. Two consequences:

- Its first act is `setNuggets([])` — wiping every fact mid-listen, then flipping `aiLoading` true so the pill returns. **Symptom 1.**
- The effect cleanup sets `cancelledRef` and aborts the in-flight SSE. The re-run then finds the `generating` sentinel it wrote itself, polls, times out, and deletes it. Research was underway, got killed, and nothing arrives — including the synthetic fallback, which is guarded by `if (cancelledRef.current) return`. **Symptom 2.**

The clearing comment says it exists to stop nuggets stacking "across track boundaries". That intent is correct; the implementation cleared on every invocation rather than on track change.

## Fix

Those four are read from a ref inside `generate()` and excluded from its deps. Regeneration is decided by **what** we're generating for — track, tier, listen depth — never by late-arriving decoration.

## ⚠️ No dedicated regression test

This bug lives in a dependency array and nothing in the suite renders the hook's lifecycle. **That gap is the real finding, not this one-line fix.** `Listen.tsx` is 1,798 lines with 31 effects and zero tests; every bug reported this session lived in that kind of seam and the 521-test suite caught none of them.

Symptom 2 in particular needs a lifecycle test — mount, begin generation, change enrichment mid-flight, assert the stream is not aborted.

## Verification

- `npm test` — 521 passing
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline