### PR TITLE
feat: saved-nugget detail view + research glow

### DIFF
--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -27,6 +27,10 @@ interface ImmersiveNuggetViewProps {
   // waiting for playback to reach each timestampSec — parity with desktop's
   // fresh-SSE bypass so the first headline lands the moment the stream emits it.
   isFresh?: boolean;
+  /** Initial generation or wave-2 still running. Drives the screen-edge
+   *  glow so "we're still digging" is legible without looking at the
+   *  logo — the whole frame breathes instead of one small element. */
+  researching?: boolean;
 }
 
 // Module-level so it persists across unmount/remount cycles (e.g. navigating
@@ -119,6 +123,7 @@ export default function ImmersiveNuggetView({
   onNext,
   spotifyAlbumArt,
   isFresh = false,
+  researching = false,
 }: ImmersiveNuggetViewProps) {
   const { isPlaying, currentTime, duration, toggle, seek } = usePlayer();
   const mountedRef = useRef(true);
@@ -710,9 +715,15 @@ export default function ImmersiveNuggetView({
         </svg>
       </button>
 
-      {/* Screen-edge glow — tier-colored border effect */}
-      <div className="fixed inset-0 z-[51] pointer-events-none"
-        style={{
+      {/* Screen-edge glow — tier-colored border effect. Breathes while
+          research is in flight so the state reads from anywhere on the
+          screen, not just the logo in the corner. Settles to the static
+          glow the moment research finishes. */}
+      <div
+        className={`fixed inset-0 z-[51] pointer-events-none ${researching ? "animate-research-glow" : ""}`}
+        data-testid="screen-glow"
+        data-researching={researching ? "true" : "false"}
+        style={researching ? undefined : {
           boxShadow: "inset 0 0 30px 4px hsl(var(--neon-glow) / 0.3), inset 0 0 80px 10px hsl(var(--neon-glow) / 0.1)",
         }}
       />

--- a/src/index.css
+++ b/src/index.css
@@ -211,3 +211,31 @@
 @media (prefers-reduced-motion: reduce) {
   .animate-cue-float { animation: none; }
 }
+
+/* Screen-edge research glow. The static frame already tints the edges;
+   this breathes it so "still digging" reads from anywhere on screen
+   rather than only from the logo in the corner. Slow and shallow on
+   purpose — it sits behind editorial copy the user is reading, and a
+   hard pulse would compete with it. */
+@keyframes research-glow {
+  0%, 100% {
+    box-shadow: inset 0 0 30px 4px hsl(var(--neon-glow) / 0.28),
+                inset 0 0 80px 10px hsl(var(--neon-glow) / 0.10);
+  }
+  50% {
+    box-shadow: inset 0 0 46px 8px hsl(var(--neon-glow) / 0.62),
+                inset 0 0 120px 22px hsl(var(--neon-glow) / 0.24);
+  }
+}
+.animate-research-glow {
+  animation: research-glow 2.6s ease-in-out infinite;
+}
+/* Motion-sensitivity fallback: hold a slightly-raised static glow, so
+   the "researching" state is still distinguishable without movement. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-research-glow {
+    animation: none;
+    box-shadow: inset 0 0 40px 6px hsl(var(--neon-glow) / 0.45),
+                inset 0 0 100px 16px hsl(var(--neon-glow) / 0.18);
+  }
+}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1770,7 +1770,8 @@ export default function Listen() {
               onPrev={handlePrev}
               onNext={handleNext}
               spotifyAlbumArt={spotifyStateTrack?.albumArtUrl}
-              isFresh={!aiFromCache}
+              researching={aiLoading || waveLoading}
+            isFresh={!aiFromCache}
             />
           </Suspense>
         )}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { ArrowLeft, Heart, Music, Share2, Trash2, Check } from "lucide-react";
+import { ArrowLeft, Heart, Music, Share2, Trash2, Check, Play, X, ExternalLink } from "lucide-react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { useBookmarks, type Bookmark } from "@/hooks/useBookmarks";
 import PageTransition from "@/components/PageTransition";
+import { AnimatePresence, motion } from "framer-motion";
+import { isSafeUrl } from "@/lib/urlSafety";
 
 // Group bookmarks into date buckets for a scannable profile page. Exact
 // edges don't matter much — the goal is to let a user visually parse
@@ -27,6 +29,20 @@ function listenUrlFor(bm: Bookmark): string {
   return `/listen/${encodeURIComponent(bm.track_id)}`;
 }
 
+// Bookmarks store no artist id, so this uses the search-by-name form the
+// app already resolves server-side (same fallback RecommendedButtons uses
+// when Gemini gives a name but no Spotify id).
+function artistUrlFor(bm: Bookmark): string {
+  return `/artist/real::${encodeURIComponent(bm.artist)}`;
+}
+
+// A saved nugget's citation, when the edge function stored one.
+function sourceUrlOf(bm: Bookmark): string | null {
+  const src = bm.source as { url?: unknown } | null;
+  const url = typeof src?.url === "string" ? src.url : null;
+  return url && isSafeUrl(url) ? url : null;
+}
+
 export default function Profile() {
   const { profile } = useUserProfile();
   const { bookmarks, loading, signedIn, toggle } = useBookmarks();
@@ -34,6 +50,14 @@ export default function Profile() {
   // Transient per-row UI state for the share button's "Copied!" confirmation.
   // Keyed by bookmark id.
   const [sharedIds, setSharedIds] = useState<Set<string>>(new Set());
+  // Tapping a saved nugget used to navigate straight to Listen, which
+  // committed the user to playback before they could re-read what they
+  // saved or decide they wanted the artist instead. Now it opens.
+  const [openId, setOpenId] = useState<string | null>(null);
+  const openBookmark = useMemo(
+    () => bookmarks.find((b) => b.id === openId) ?? null,
+    [bookmarks, openId],
+  );
 
   async function handleShare(bm: Bookmark) {
     const url = `${window.location.origin}${listenUrlFor(bm)}`;
@@ -151,7 +175,7 @@ export default function Profile() {
                         className="bg-white/5 hover:bg-white/10 transition rounded-lg overflow-hidden"
                       >
                         <button
-                          onClick={() => navigate(listenUrlFor(bm))}
+                          onClick={() => setOpenId(bm.id)}
                           className="w-full text-left active:scale-[0.99] transition-transform p-4 flex gap-3"
                         >
                           {bm.image_url ? (
@@ -214,6 +238,95 @@ export default function Profile() {
             )}
         </div>
       </div>
+
+      {/* Saved-nugget detail. Opening the card first is the point: a saved
+          nugget is something you chose to keep, so the tap should let you
+          re-read it and then decide where to go — the song, the artist, or
+          the source — rather than committing you to playback.
+
+          Action shape matches the Browse expanded card deliberately: one
+          filled play control, quiet links beside it. Same gesture, same
+          meaning, on both surfaces. */}
+      <AnimatePresence>
+        {openBookmark && (
+          <motion.div
+            className="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setOpenId(null)}
+            role="dialog"
+            aria-modal="true"
+            aria-label={openBookmark.headline}
+          >
+            <motion.div
+              className="relative w-full max-w-md bg-neutral-950 rounded-2xl overflow-hidden ring-1 ring-white/10 max-h-[85vh] flex flex-col"
+              initial={{ y: 24, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: 24, opacity: 0 }}
+              transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {openBookmark.image_url && (
+                <div className="relative h-44 shrink-0">
+                  <img src={openBookmark.image_url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neutral-950 via-neutral-950/40 to-transparent" />
+                </div>
+              )}
+
+              <button
+                onClick={() => setOpenId(null)}
+                aria-label="Close"
+                className="absolute top-3 right-3 z-10 w-9 h-9 rounded-full bg-black/50 backdrop-blur-sm ring-1 ring-white/20 flex items-center justify-center active:scale-95 transition-transform"
+              >
+                <X className="w-4 h-4 text-white/80" />
+              </button>
+
+              <div className="px-5 pb-5 pt-4 overflow-y-auto scrollbar-hide">
+                <p className="text-[10px] uppercase tracking-widest text-white/40 mb-2">
+                  {openBookmark.artist} · {openBookmark.title}
+                </p>
+                <h2 className="text-xl font-black text-white leading-tight mb-3">
+                  {openBookmark.headline}
+                </h2>
+                <p className="text-sm text-white/75 leading-relaxed mb-5">
+                  {openBookmark.body}
+                </p>
+
+                <div className="flex items-center gap-3.5">
+                  <button
+                    onClick={() => navigate(listenUrlFor(openBookmark))}
+                    aria-label={`Play ${openBookmark.title} by ${openBookmark.artist}`}
+                    className="shrink-0 flex items-center justify-center w-12 h-12 rounded-full bg-white text-black hover:bg-white/90 active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                  >
+                    <Play className="w-4 h-4 ml-[2px]" fill="currentColor" />
+                  </button>
+                  <div className="flex flex-col items-start gap-1.5 min-w-0">
+                    <button
+                      onClick={() => navigate(artistUrlFor(openBookmark))}
+                      className="inline-flex items-center gap-1.5 max-w-full text-sm font-semibold text-primary hover:underline active:scale-95 transition-transform"
+                    >
+                      <span className="truncate">{openBookmark.artist}</span>
+                      <ExternalLink className="w-3 h-3 shrink-0" />
+                    </button>
+                    {sourceUrlOf(openBookmark) && (
+                      <a
+                        href={sourceUrlOf(openBookmark)!}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors"
+                      >
+                        Source
+                        <ExternalLink className="w-3 h-3 shrink-0" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </PageTransition>
   );
 }

--- a/src/test/ImmersiveNuggetView.test.tsx
+++ b/src/test/ImmersiveNuggetView.test.tsx
@@ -74,7 +74,7 @@ const HEADLINE_LESS: Nugget = {
   sourceId: "src-1",
 };
 
-function renderView(nuggets: Nugget[] = [RICH]) {
+function renderView(nuggets: Nugget[] = [RICH], researching = false) {
   return render(
     <ImmersiveNuggetView
       nuggets={nuggets}
@@ -84,6 +84,7 @@ function renderView(nuggets: Nugget[] = [RICH]) {
       artist="Cherele"
       onClose={() => {}}
       isFresh
+      researching={researching}
     />,
   );
 }
@@ -265,5 +266,49 @@ describe("ImmersiveNuggetView — deep dive", () => {
     const deeper = screen.getByRole("button", { name: /tell me more/i });
     expect(save).not.toBe(deeper);
     expect(within(save).queryByText(/tell me more/i)).toBeNull();
+  });
+});
+
+
+// ── Research glow ─────────────────────────────────────────────────────
+// Pete: "can we make the color that shows up around the screen pulse a
+// little more so we know that research is being done?" The screen-edge
+// glow is visible from anywhere on the card, so it carries the state
+// better than the small logo in the corner.
+describe("ImmersiveNuggetView — research glow", () => {
+  it("breathes the screen edge while research is in flight", () => {
+    renderView([RICH], true);
+    const glow = screen.getByTestId("screen-glow");
+    expect(glow.getAttribute("data-researching")).toBe("true");
+    expect(glow.className).toContain("animate-research-glow");
+  });
+
+  it("settles to a static glow once research finishes", () => {
+    renderView([RICH], false);
+    const glow = screen.getByTestId("screen-glow");
+    expect(glow.getAttribute("data-researching")).toBe("false");
+    expect(glow.className).not.toContain("animate-research-glow");
+    // Static state still tints the edges — it just stops moving.
+    expect(glow.getAttribute("style") ?? "").toContain("box-shadow");
+  });
+
+  it("stops breathing when research completes mid-view", () => {
+    const { rerender } = renderView([RICH], true);
+    expect(screen.getByTestId("screen-glow").className).toContain("animate-research-glow");
+
+    rerender(
+      <ImmersiveNuggetView
+        nuggets={[RICH]}
+        sources={new Map([["src-1", SOURCE]])}
+        coverArtUrl="https://example.com/art.jpg"
+        trackTitle="KIKI"
+        artist="Cherele"
+        onClose={() => {}}
+        isFresh
+        researching={false}
+      />,
+    );
+
+    expect(screen.getByTestId("screen-glow").className).not.toContain("animate-research-glow");
   });
 });

--- a/src/test/ProfileSavedNugget.test.tsx
+++ b/src/test/ProfileSavedNugget.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { Bookmark } from "@/hooks/useBookmarks";
+
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock());
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const toggleMock = vi.fn();
+let bookmarks: Bookmark[] = [];
+vi.mock("@/hooks/useBookmarks", () => ({
+  useBookmarks: () => ({
+    bookmarks,
+    loading: false,
+    signedIn: true,
+    toggle: toggleMock,
+    isBookmarked: () => true,
+    findBookmark: () => undefined,
+    adding: false,
+    removing: false,
+  }),
+}));
+
+vi.mock("@/hooks/useMusicNerdState", () => ({
+  useUserProfile: () => ({ profile: { displayName: "Pete" } }),
+}));
+
+import Profile from "@/pages/Profile";
+
+const BOOKMARK: Bookmark = {
+  id: "bm-1",
+  service: "spotify",
+  track_id: "real::Turnover::Humming",
+  artist: "Turnover",
+  title: "Humming",
+  album: null,
+  nugget_kind: "artist",
+  headline: "Turnover tracked the record with their front-of-house engineer.",
+  body: "They brought him into the studio to capture the live sound.",
+  source: { url: "https://brooklynvegan.com/turnover" },
+  image_url: "https://example.com/art.jpg",
+  created_at: new Date().toISOString(),
+};
+
+function renderProfile() {
+  return render(<MemoryRouter><Profile /></MemoryRouter>);
+}
+
+const openDialog = () => screen.queryByRole("dialog");
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  toggleMock.mockReset();
+  bookmarks = [BOOKMARK];
+});
+
+describe("Profile — opening a saved nugget", () => {
+  // Pete: "when I click on one of my saved nuggets it just goes straight to
+  // playing the song. I want to be able to open the card and then make the
+  // decision if I want to go to the song or artist."
+  it("opens the nugget instead of jumping straight to playback", () => {
+    renderProfile();
+    expect(openDialog()).toBeNull();
+
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    expect(openDialog()).not.toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the full saved nugget once open", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const dialog = openDialog()!;
+    expect(within(dialog).getByText(BOOKMARK.body)).toBeTruthy();
+  });
+
+  it("closes without navigating anywhere", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(openDialog()).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("Profile — deciding where to go", () => {
+  it("plays the track when the play control is used", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+    fireEvent.click(screen.getByRole("button", { name: /play humming by turnover/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      `/listen/${encodeURIComponent(BOOKMARK.track_id)}`,
+    );
+  });
+
+  // The other half of the ask — the saved nugget is about an artist, so
+  // reaching them has to be a real option, not just the song.
+  it("opens the artist when the artist link is used", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const dialog = openDialog()!;
+    fireEvent.click(within(dialog).getByRole("button", { name: /^turnover$/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/artist/real::Turnover");
+  });
+
+  it("links out to the citation when one was saved", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const link = within(openDialog()!).getByRole("link", { name: /source/i });
+    expect(link.getAttribute("href")).toBe("https://brooklynvegan.com/turnover");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  // The saved body is Exa/Gemini-derived, so the stored URL is untrusted.
+  it("omits the source link when the saved URL is unsafe", () => {
+    bookmarks = [{ ...BOOKMARK, source: { url: "javascript:alert(1)" } }];
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    expect(within(openDialog()!).queryByRole("link", { name: /source/i })).toBeNull();
+  });
+
+  it("omits the source link when nothing was saved", () => {
+    bookmarks = [{ ...BOOKMARK, source: null }];
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    expect(within(openDialog()!).queryByRole("link", { name: /source/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## 1. Saved nuggets open before they play

> "When I click on one of my saved nuggets it just goes straight to playing the song. I want to be able to open the card and then make the decision if I want to go to the song or artist."

A saved nugget is something you deliberately kept — the tap should let you re-read it and choose, not commit you to playback.

Tapping now opens a detail view with the full nugget and three destinations: **play the track**, **open the artist**, or **follow the citation**.

The action shape matches the Browse expanded card on purpose — one filled play control, quiet links beside it — so the same gesture means the same thing on both surfaces.

Two details worth noting:
- Bookmarks carry no artist id, so the artist link uses the search-by-name route the app already resolves server-side (same fallback `RecommendedButtons` uses).
- The stored source URL is Exa/Gemini-derived, so it goes through `isSafeUrl`. When it fails, the link is **omitted** rather than rendered inert.

## 2. The glow breathes while researching

> "Can we make the color that shows up around the screen pulse a little more so we know that research is being done?"

The screen-edge glow now breathes while generation or wave-2 is in flight, and settles to the static tint when research finishes. It reads from anywhere on the card, unlike the logo in the corner.

Slow and shallow deliberately — it sits behind copy the user is reading, and a hard pulse would compete with it. `prefers-reduced-motion` holds a raised static glow so the state stays distinguishable without movement.

## Mutation-verified

Both changes, not just tested:
- Reverting the tap to navigate-straight-to-Listen → **all 8 Profile tests fail**
- Removing the animation class → **2 glow tests fail**

## Verification

- `npm test` — 532 passing (11 new)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline