### PR TITLE
release: nugget lifecycle tests, saved-nugget detail view, research glow

### DIFF
--- a/src/components/ArtistImage.tsx
+++ b/src/components/ArtistImage.tsx
@@ -1,4 +1,5 @@
 import { useArtistImage } from "@/hooks/useArtistImage";
+import RemoteImage from "@/components/RemoteImage";
 
 interface Props {
   artistName: string;
@@ -15,7 +16,7 @@ export default function ArtistImage({ artistName, fallbackUrl, alt, className }:
   const imageUrl = useArtistImage(artistName, fallbackUrl);
 
   return (
-    <img
+    <RemoteImage
       src={imageUrl}
       alt={alt || artistName}
       className={className}

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -424,6 +424,8 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen, playTarget = n
             {img ? (
               <motion.img
                 layoutId={`${layoutId}::img`}
+                loading="eager"
+                decoding="async"
                 src={img}
                 alt=""
                 className="absolute inset-0 w-full h-full object-cover"

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -8,6 +8,7 @@ import { buildListenRoute } from "@/lib/listenRoute";
 import { serviceParamFromProfile, withAppleStorefront } from "@/lib/appleStorefront";
 import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
 import { isSafeUrl } from "@/lib/urlSafety";
+import RemoteImage from "@/components/RemoteImage";
 import { useDialogFocusTrap } from "@/hooks/useDialogFocusTrap";
 import type { UserProfile } from "@/mock/types";
 
@@ -240,15 +241,14 @@ function ArtistRow({ group, onExpand, onPlay }: ArtistRowProps) {
   return (
     <div>
       <div className="px-4 md:px-10 mb-3 flex items-center gap-3">
-        {heroImg ? (
-          <img
-            src={heroImg}
-            alt={`${group.artistName} avatar`}
-            className="w-14 h-14 rounded-full object-cover ring-2 ring-white/10 shadow-lg"
-          />
-        ) : (
-          <div className="w-14 h-14 rounded-full bg-gradient-to-br from-rose-400/40 to-pink-500/40 ring-2 ring-white/10" />
-        )}
+        <RemoteImage
+          src={heroImg}
+          alt={`${group.artistName} avatar`}
+          className="w-14 h-14 rounded-full object-cover ring-2 ring-white/10 shadow-lg"
+          fallback={
+            <div className="w-14 h-14 rounded-full bg-gradient-to-br from-rose-400/40 to-pink-500/40 ring-2 ring-white/10" />
+          }
+        />
         <span className="text-lg md:text-xl font-black text-white tracking-tight">
           {group.artistName}
         </span>
@@ -323,22 +323,14 @@ export function UpdateCard({ update, layoutId, onClick, sizeClass = "shrink-0 w-
       }`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
-      {img ? (
-        <motion.img
-          layoutId={`${layoutId}::img`}
-          src={img}
-          alt=""
-          className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
-          onError={(e) => {
-            (e.currentTarget as HTMLImageElement).style.display = "none";
-          }}
-        />
-      ) : (
-        <motion.div
-          layoutId={`${layoutId}::img`}
-          className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15"
-        />
-      )}
+      <RemoteImage
+        src={img}
+        alt=""
+        className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
+        fallback={
+          <div className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15" />
+        }
+      />
       <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/45 to-black/10" />
       <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-2xl pointer-events-none" />
       <span className={`absolute top-3 left-3 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full backdrop-blur-sm ${chipClass}`}>

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -323,12 +323,19 @@ export function UpdateCard({ update, layoutId, onClick, sizeClass = "shrink-0 w-
       }`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
+      {/* Source end of the shared-element morph — the same layoutId as
+          ExpandedUpdateModal's hero, on the loaded image AND the empty
+          state, so the photo scales into the modal instead of cutting. */}
       <RemoteImage
         src={img}
         alt=""
+        layoutId={`${layoutId}::img`}
         className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
         fallback={
-          <div className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15" />
+          <motion.div
+            layoutId={`${layoutId}::img`}
+            className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15"
+          />
         }
       />
       <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/45 to-black/10" />

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader2, X, ExternalLink, Play } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -8,6 +8,7 @@ import { buildListenRoute } from "@/lib/listenRoute";
 import { serviceParamFromProfile, withAppleStorefront } from "@/lib/appleStorefront";
 import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
 import { isSafeUrl } from "@/lib/urlSafety";
+import { useDialogFocusTrap } from "@/hooks/useDialogFocusTrap";
 import type { UserProfile } from "@/mock/types";
 
 /**
@@ -388,8 +389,6 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen, playTarget = n
   const { kindLabel, KindIcon } = getArtistUpdateKindMeta(update.kind);
   const { chipClass } = kindStyle(update.kind);
   const img = update.artistImageUrl;
-  const closeBtnRef = useRef<HTMLButtonElement>(null);
-  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   // Lock document scroll while the modal is open. Without this, the
   // Browse page scrolls behind the open modal on mobile/trackpad —
@@ -404,47 +403,8 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen, playTarget = n
 
   const titleId = `expanded-${layoutId.replace(/[^a-zA-Z0-9_-]/g, "_")}-title`;
 
-  // WCAG focus management: Esc dismisses, focus moves to close button
-  // on open and restores on close, Tab/Shift+Tab cycles within the
-  // dialog only.
-  useEffect(() => {
-    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
-    closeBtnRef.current?.focus();
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      // role="dialog" lives on the inner pointer-events-auto card; the
-      // outer flex wrapper is just a centering layer.
-      const root = closeBtnRef.current?.closest('[role="dialog"]');
-      // (closest('[role="dialog"]') still finds the inner card after
-      // the ARIA move because the close button is a descendant.)
-      if (!root) return;
-      const focusable = Array.from(
-        root.querySelectorAll<HTMLElement>(
-          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    }
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("keydown", onKey);
-      previouslyFocusedRef.current?.focus?.();
-    };
-  }, [onClose]);
+  // Shared with Profile's saved-nugget dialog — see useDialogFocusTrap.
+  const closeBtnRef = useDialogFocusTrap(onClose);
 
   return (
     <>

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -153,13 +153,13 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
               const key = layoutIdFor(u);
               return (
                 <div key={key} ref={(el) => { cardRefs.current[key] = el; }}>
-                <UpdateCard
-                  layoutId={key}
-                  update={u}
-                  onClick={() => setExpandedKey(key)}
-                  sizeClass="w-full h-44 md:h-48"
-                  pulsing={pulseKey === key}
-                />
+                  <UpdateCard
+                    layoutId={key}
+                    update={u}
+                    onClick={() => setExpandedKey(key)}
+                    sizeClass="w-full h-44 md:h-48"
+                    pulsing={pulseKey === key}
+                  />
                 </div>
               );
             })}

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { AnimatePresence } from "framer-motion";
 import { Loader2 } from "lucide-react";
@@ -21,8 +21,12 @@ import {
  * a horizontal-scroll rail across multiple artists).
  *
  * If the URL has a `?nugget=<id>` query (Browse → Artist Profile tap-
- * through), this component auto-opens the matching fact in the modal
- * and silently strips the param so a refresh doesn't re-open.
+ * through), this component scrolls the matching fact into view and
+ * pulses it, then silently strips the param so a refresh doesn't repeat
+ * it. It deliberately does NOT open the modal — the user pressed "Open
+ * {Artist}" to see the artist, and re-opening the card they just came
+ * from puts a full-screen overlay between them and the page they asked
+ * for.
  */
 
 interface Props {
@@ -32,12 +36,21 @@ interface Props {
   artistName: string;
 }
 
+/** Respect motion sensitivity for the deep-link scroll. */
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined"
+    && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}
+
 export default function LatestFactsSection({ updates, loading, artistName }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const targetNuggetId = searchParams.get("nugget");
   const navigate = useNavigate();
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const [pulseKey, setPulseKey] = useState<string | null>(null);
+  // Card nodes by layoutId, so the deep-link can scroll to the referenced
+  // fact rather than opening it.
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   // layoutId namespace prefix. Both this section and Browse's
   // "Your artists, lately" rail render UpdateCard with the same
@@ -55,17 +68,28 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
     return updates.find((u) => layoutIdFor(u) === expandedKey) ?? null;
   }, [expandedKey, updates]);
 
-  // Deep-link from Browse: auto-open the matching nugget in the modal.
-  // We open immediately on data arrival, then pulse the underlying
-  // card briefly so the user sees which fact was referenced when they
-  // close the modal.
+  // Deep-link from Browse: point AT the referenced fact without covering
+  // the page with it. Pete: "it takes me to the profile but the fact card
+  // stays open or re-opens on top of the artist profile instead of
+  // letting me see the artist profile." That was this effect calling
+  // setExpandedKey — the card was never lingering, it was being opened
+  // again on arrival.
+  //
+  // Scroll it into view and pulse it instead, which is what the artist
+  // page already documented this param as doing.
   useEffect(() => {
     if (!targetNuggetId || updates.length === 0) return;
     const match = updates.find((u) => u.nuggetId === targetNuggetId);
     if (!match) return;
     const key = layoutIdFor(match);
-    setExpandedKey(key);
     setPulseKey(key);
+    // Next frame, so the card exists before we scroll to it.
+    const scrollFrame = requestAnimationFrame(() => {
+      cardRefs.current[key]?.scrollIntoView({
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+        block: "center",
+      });
+    });
     const pulseTimer = setTimeout(() => setPulseKey(null), 1800);
     const stripTimer = setTimeout(() => {
       // Quietly remove the ?nugget= param so reload doesn't re-open.
@@ -74,6 +98,7 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
       setSearchParams(next, { replace: true });
     }, 200);
     return () => {
+      cancelAnimationFrame(scrollFrame);
       clearTimeout(pulseTimer);
       clearTimeout(stripTimer);
     };
@@ -127,14 +152,15 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
           : updates.map((u) => {
               const key = layoutIdFor(u);
               return (
+                <div key={key} ref={(el) => { cardRefs.current[key] = el; }}>
                 <UpdateCard
-                  key={key}
                   layoutId={key}
                   update={u}
                   onClick={() => setExpandedKey(key)}
                   sizeClass="w-full h-44 md:h-48"
                   pulsing={pulseKey === key}
                 />
+                </div>
               );
             })}
       </div>

--- a/src/components/NowPlayingBar.tsx
+++ b/src/components/NowPlayingBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Play, Pause, SkipBack, SkipForward, Smartphone } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -133,11 +134,12 @@ export default function NowPlayingBar() {
                   className="flex flex-1 items-center gap-3 min-w-0 text-left"
                 >
                   {externalPlayback.albumArtUrl ? (
-                    <img
+                    <RemoteImage
                       src={externalPlayback.albumArtUrl}
                       alt=""
+                      eager
                       className="h-10 w-10 rounded-lg object-cover shrink-0"
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                      fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10 shrink-0" />}
                     />
                   ) : (
                     <div className="h-10 w-10 rounded-lg bg-foreground/10 shrink-0 flex items-center justify-center">
@@ -163,11 +165,12 @@ export default function NowPlayingBar() {
                   onClick={() => navigate(listenUrl!)}
                   className={`flex flex-1 items-center gap-3 min-w-0 text-left rounded-lg transition-all ${npbFocusClass(0)}`}
                 >
-                  <img
+                  <RemoteImage
                     src={currentTrack.coverArtUrl}
                     alt=""
+                    eager
                     className="h-10 w-10 rounded-lg object-cover shrink-0"
-                    onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                    fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10 shrink-0" />}
                   />
                   <div className="min-w-0">
                     <p className="text-sm font-bold text-foreground truncate">{currentTrack.title}</p>

--- a/src/components/NuggetCard.tsx
+++ b/src/components/NuggetCard.tsx
@@ -152,6 +152,8 @@ export default function NuggetCard({ nugget, animationStyle, onSourceClick, curr
               <img
                 src={nugget.imageUrl}
                 alt={nugget.imageCaption || nugget.headline || ""}
+                loading="lazy"
+                decoding="async"
                 className="w-full rounded-xl object-contain"
                 style={{ maxHeight: "380px", minHeight: "160px", display: imgLoaded ? "block" : "none" }}
                 onLoad={() => setImgLoaded(true)}

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -6,7 +6,18 @@ export default function PageTransition({ children }: { children: ReactNode }) {
     <motion.div
       initial={{ opacity: 0, scale: 0.98, y: 10 }}
       animate={{ opacity: 1, scale: 1, y: 0 }}
-      exit={{ opacity: 0, scale: 0.98, y: -10 }}
+      // Per-variant transition — a top-level `transition` prop would be
+      // overridden by nothing and an `exitTransition` prop does not exist
+      // in framer-motion, so the override has to live inside the variant.
+      exit={{ opacity: 0, scale: 0.98, y: -10, transition: { duration: 0.18, ease: "easeIn" } }}
+      // App.tsx wraps routes in <AnimatePresence mode="wait">, so the
+      // incoming page cannot mount until this exit finishes. At 0.5s the
+      // user watched the OLD page for half a second after the URL had
+      // already changed — most visible when leaving a full-screen modal,
+      // where the card appeared to stay open on the new page (Pete: "it
+      // takes me to the artist page but the card stays open so I don't
+      // see that I'm in the artist page"). Exits are dead time; only the
+      // entrance needs to feel considered.
       transition={{ duration: 0.5, ease: "easeOut" }}
       className="min-h-screen w-full"
     >

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
 
 /**
  * An <img> for third-party artwork (Spotify's i.scdn.co, mostly).
@@ -38,6 +39,13 @@ interface RemoteImageProps {
    *  mini-player, an open overlay's hero. Deferring those only delays
    *  something the user is already looking at. */
   eager?: boolean;
+  /** Renders as a `motion.img` carrying this layoutId, so Framer Motion
+   *  can morph it into a matching element elsewhere — the artist card
+   *  thumbnail growing into the expanded modal's hero. Both ends of a
+   *  morph need the same id; supplying it on only one side hard-cuts.
+   *  Omit it and this renders a plain <img>, which is what nearly every
+   *  call site wants. */
+  layoutId?: string;
   onLoad?: () => void;
 }
 
@@ -52,6 +60,7 @@ export default function RemoteImage({
   className,
   fallback = null,
   eager = false,
+  layoutId,
   onLoad,
 }: RemoteImageProps) {
   const [failed, setFailed] = useState(false);
@@ -98,15 +107,20 @@ export default function RemoteImage({
 
   if (!src || failed) return <>{fallback}</>;
 
-  return (
-    <img
-      src={attemptSrc}
-      alt={alt}
-      className={className}
-      loading={eager ? "eager" : "lazy"}
-      decoding="async"
-      onError={handleError}
-      onLoad={onLoad}
-    />
-  );
+  const imgProps = {
+    src: attemptSrc,
+    alt,
+    className,
+    loading: eager ? ("eager" as const) : ("lazy" as const),
+    decoding: "async" as const,
+    onError: handleError,
+    onLoad,
+  };
+
+  // Deferral survives the morph — a card that animates into a modal is
+  // still offscreen artwork until it is scrolled to, and it was the
+  // bulk of the original burst.
+  if (layoutId) return <motion.img layoutId={layoutId} {...imgProps} />;
+
+  return <img {...imgProps} />;
 }

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * An <img> for third-party artwork (Spotify's i.scdn.co, mostly).
+ *
+ * Exists because Browse was firing ~53 simultaneous requests at
+ * i.scdn.co on load — every artist avatar, update card, and catalog
+ * tile across ~3.4 screens of content, none of them deferred. Spotify
+ * throttles a burst that size and answers most of it with 503, so the
+ * page rendered as a wall of black cards. The identical URLs load in
+ * ~120ms when requested individually, which is what made it look like
+ * an outage rather than something we were doing.
+ *
+ * That failure is a threshold effect, not a regression: it appeared
+ * once the image count grew past what the CDN would serve at once, with
+ * no deploy involved. It will recur — and worsen — as the catalog grows,
+ * which is why this is a shared component rather than a fix at one site.
+ *
+ * Three behaviours, in order of importance:
+ *
+ *  1. `loading="lazy"` so offscreen artwork is not requested until it is
+ *     near the viewport. This is the actual fix — it cuts the initial
+ *     burst by roughly an order of magnitude.
+ *  2. One retry with backoff. A 503 is transient by definition, and a
+ *     single retry recovers the ones that still slip through.
+ *  3. A designed fallback. If it ultimately fails, render the same
+ *     placeholder used when there is no artwork at all, rather than
+ *     leaving a hole where the image should be.
+ */
+interface RemoteImageProps {
+  src?: string | null;
+  alt?: string;
+  className?: string;
+  /** Rendered instead of the image when src is missing or every attempt
+   *  fails. Without this a failure leaves a blank element. */
+  fallback?: React.ReactNode;
+  /** Skip lazy loading for artwork that is always above the fold — the
+   *  mini-player, an open overlay's hero. Deferring those only delays
+   *  something the user is already looking at. */
+  eager?: boolean;
+  onLoad?: () => void;
+}
+
+const RETRY_DELAY_MS = 700;
+
+export default function RemoteImage({
+  src,
+  alt = "",
+  className,
+  fallback = null,
+  eager = false,
+  onLoad,
+}: RemoteImageProps) {
+  const [failed, setFailed] = useState(false);
+  // Cache-busted retry URL. Kept in state so the retry is a real second
+  // request rather than the browser replaying its cached failure.
+  const [attemptSrc, setAttemptSrc] = useState(src ?? undefined);
+  const retriedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // A new src is a new image — reset, or a previously failed URL would
+  // keep the fallback showing for a perfectly good replacement.
+  useEffect(() => {
+    setFailed(false);
+    setAttemptSrc(src ?? undefined);
+    retriedRef.current = false;
+  }, [src]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const handleError = useCallback(() => {
+    if (!src) { setFailed(true); return; }
+    if (retriedRef.current) { setFailed(true); return; }
+    retriedRef.current = true;
+    // Backoff before retrying: an immediate retry rejoins the same burst
+    // that caused the throttle in the first place.
+    timerRef.current = setTimeout(() => {
+      setAttemptSrc(`${src}${src.includes("?") ? "&" : "?"}r=1`);
+    }, RETRY_DELAY_MS);
+  }, [src]);
+
+  if (!src || failed) return <>{fallback}</>;
+
+  return (
+    <img
+      src={attemptSrc}
+      alt={alt}
+      className={className}
+      loading={eager ? "eager" : "lazy"}
+      decoding="async"
+      onError={handleError}
+      onLoad={onLoad}
+    />
+  );
+}

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -42,6 +42,9 @@ interface RemoteImageProps {
 }
 
 const RETRY_DELAY_MS = 700;
+/** Underscore-prefixed so it cannot collide with a real query param if
+ *  this component is ever pointed at something other than Spotify. */
+const RETRY_PARAM = "_retry=1";
 
 export default function RemoteImage({
   src,
@@ -60,7 +63,19 @@ export default function RemoteImage({
 
   // A new src is a new image — reset, or a previously failed URL would
   // keep the fallback showing for a perfectly good replacement.
+  //
+  // Cancelling a pending retry here is load-bearing, not tidiness. A
+  // scheduled retry holds the PREVIOUS src in its closure; if the prop
+  // moves on before it fires, it writes the old URL over the new one
+  // ~700ms later and can drop a perfectly good image into the fallback.
+  // That collision is likeliest during exactly the burst this component
+  // exists for: several images sit mid-backoff while ArtistRow's heroImg
+  // recomputes as facts stream in.
   useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     setFailed(false);
     setAttemptSrc(src ?? undefined);
     retriedRef.current = false;
@@ -77,7 +92,7 @@ export default function RemoteImage({
     // Backoff before retrying: an immediate retry rejoins the same burst
     // that caused the throttle in the first place.
     timerRef.current = setTimeout(() => {
-      setAttemptSrc(`${src}${src.includes("?") ? "&" : "?"}r=1`);
+      setAttemptSrc(`${src}${src.includes("?") ? "&" : "?"}${RETRY_PARAM}`);
     }, RETRY_DELAY_MS);
   }, [src]);
 

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { useNavigate } from "react-router-dom";
 import { Search, X, Loader2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -159,7 +160,8 @@ export default function SearchOverlay({ open, onClose }: Props) {
                               className="flex items-center gap-3 rounded-xl bg-foreground/5 p-3 pr-6 transition-colors hover:bg-foreground/10"
                             >
                               {a.imageUrl ? (
-                                <img src={a.imageUrl} alt={a.name} className="h-12 w-12 rounded-full object-cover" />
+                                <RemoteImage src={a.imageUrl} alt={a.name} className="h-12 w-12 rounded-full object-cover"
+                                  fallback={<div className="h-12 w-12 rounded-full bg-foreground/10" />} />
                               ) : (
                                 <div className="h-12 w-12 rounded-full bg-foreground/10 flex items-center justify-center text-muted-foreground text-lg font-bold">
                                   {a.name[0]}
@@ -183,7 +185,8 @@ export default function SearchOverlay({ open, onClose }: Props) {
                               className="flex w-full items-center gap-4 rounded-xl p-3 transition-colors hover:bg-foreground/5 text-left"
                             >
                               {t.imageUrl ? (
-                                <img src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover" />
+                                <RemoteImage src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover"
+                                  fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10" />} />
                               ) : (
                                 <div className="h-10 w-10 rounded-lg bg-foreground/10" />
                               )}

--- a/src/components/SpotifyReconnectBanner.tsx
+++ b/src/components/SpotifyReconnectBanner.tsx
@@ -1,21 +1,28 @@
 import { useEffect, useState } from "react";
 import { signInWithSpotify } from "@/hooks/useSpotifyAuth";
+import { RECONNECT_REQUIRED_EVENT } from "@/lib/spotifyTokenStore";
 
 /**
- * Surfaces a reconnect banner when useSpotifyToken's refresh chain fails
- * (both the server-side edge function and the legacy client-side path
- * returned null). Before this banner existed, the user was silently
- * logged out of Spotify on the next ProtectedRoute check with no
- * indication why. Dispatched via `spotify-reconnect-required` from
- * useSpotifyToken.getValidToken.
+ * Surfaces a reconnect banner when playback credentials are gone and
+ * cannot be recovered without a new OAuth round trip. Before this banner
+ * existed, the user was silently logged out of Spotify on the next
+ * ProtectedRoute check with no indication why.
+ *
+ * Two paths raise RECONNECT_REQUIRED_EVENT:
+ *   - useSpotifyToken.getValidToken, when the refresh chain fails (both
+ *     the server-side edge function and the legacy client-side path
+ *     returned null).
+ *   - bridgeSpotifyProviderTokens, when a Spotify session arrives with
+ *     no provider tokens and localStorage has none either — nothing to
+ *     refresh, so the failure never reaches getValidToken at all.
  */
 export default function SpotifyReconnectBanner() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     const onReconnect = () => setVisible(true);
-    window.addEventListener("spotify-reconnect-required", onReconnect);
-    return () => window.removeEventListener("spotify-reconnect-required", onReconnect);
+    window.addEventListener(RECONNECT_REQUIRED_EVENT, onReconnect);
+    return () => window.removeEventListener(RECONNECT_REQUIRED_EVENT, onReconnect);
   }, []);
 
   if (!visible) return null;

--- a/src/components/StoriesRail.tsx
+++ b/src/components/StoriesRail.tsx
@@ -168,6 +168,8 @@ export default function StoriesRail({ stories }: StoriesRailProps) {
                 <div className="w-full h-full rounded-full bg-background overflow-hidden p-[2px]">
                   {s.imageUrl ? (
                     <img
+                      loading="lazy"
+                      decoding="async"
                       src={s.imageUrl}
                       alt=""
                       className="w-full h-full rounded-full object-cover"

--- a/src/components/TileRow.tsx
+++ b/src/components/TileRow.tsx
@@ -110,22 +110,19 @@ export default function TileRow({ label, items, tileSize = "md", focusedIndex = 
                 onMouseLeave={(e) => handleTileLeave(e.currentTarget, isFocused)}
               >
                 <div className="absolute inset-0 rounded-xl overflow-hidden">
-                  {item.imageUrl ? (
-                    <RemoteImage
-                      src={item.imageUrl}
-                      alt={item.title}
-                      className="h-full w-full object-cover"
-                      fallback={
-                        <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
-                          <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
-                        </div>
-                      }
-                    />
-                  ) : (
-                    <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
-                      <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
-                    </div>
-                  )}
+                  {/* No outer ternary — RemoteImage renders `fallback`
+                      whenever src is missing OR every attempt fails, so
+                      guarding here would only duplicate the placeholder. */}
+                  <RemoteImage
+                    src={item.imageUrl}
+                    alt={item.title}
+                    className="h-full w-full object-cover"
+                    fallback={
+                      <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
+                        <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
+                      </div>
+                    }
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
                 </div>
                 <div className="absolute bottom-0 left-0 right-0 p-2 md:p-3 z-10">

--- a/src/components/TileRow.tsx
+++ b/src/components/TileRow.tsx
@@ -1,3 +1,4 @@
+import RemoteImage from "@/components/RemoteImage";
 import { useRef, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -110,11 +111,15 @@ export default function TileRow({ label, items, tileSize = "md", focusedIndex = 
               >
                 <div className="absolute inset-0 rounded-xl overflow-hidden">
                   {item.imageUrl ? (
-                    <img
+                    <RemoteImage
                       src={item.imageUrl}
                       alt={item.title}
                       className="h-full w-full object-cover"
-                      onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+                      fallback={
+                        <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
+                          <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
+                        </div>
+                      }
                     />
                   ) : (
                     <div className="h-full w-full bg-foreground/10 flex items-center justify-center">

--- a/src/components/companion/CompanionNuggetCard.tsx
+++ b/src/components/companion/CompanionNuggetCard.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink, ChevronRight } from "lucide-react";
+import RemoteImage from "@/components/RemoteImage";
 import type { CompanionNugget } from "@/mock/types";
 
 interface Props {
@@ -12,11 +13,10 @@ export default function CompanionNuggetCard({ nugget, onDeepDive }: Props) {
       {/* Image */}
       {nugget.imageUrl && (
         <div className="w-full">
-          <img
+          <RemoteImage
             src={nugget.imageUrl}
             alt={nugget.imageCaption || nugget.headline || ""}
             className="w-full object-contain max-h-56"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
           />
           {nugget.imageCaption && (
             <p className="px-4 py-1.5 text-xs text-muted-foreground italic">{nugget.imageCaption}</p>

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -512,6 +512,8 @@ export default function ImmersiveNuggetView({
             <img
               src={imgUrl}
               alt=""
+              loading="eager"
+              decoding="async"
               className="absolute inset-0 w-full h-full object-cover"
               onError={() => {
                 if (isNuggetImage && activeNugget?.imageUrl) {
@@ -697,7 +699,7 @@ export default function ImmersiveNuggetView({
       {/* Background */}
       <div className="absolute inset-0 pointer-events-none">
         {artUrl && (
-          <img src={artUrl} alt="" className="absolute inset-0 w-full h-full object-cover"
+          <img src={artUrl} alt="" loading="eager" decoding="async" className="absolute inset-0 w-full h-full object-cover"
             style={{ filter: "blur(48px) brightness(0.25) saturate(1.4)", transform: "scale(1.3)" }} />
         )}
         <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-transparent to-black/60" />
@@ -777,6 +779,8 @@ export default function ImmersiveNuggetView({
               <img
                 src={artUrl}
                 alt=""
+                loading="eager"
+                decoding="async"
                 className={`w-56 h-56 rounded-2xl shadow-2xl object-cover opacity-80 ${
                   isPlaying ? "animate-cover-pulse" : ""
                 }`}

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -27,6 +27,10 @@ interface ImmersiveNuggetViewProps {
   // waiting for playback to reach each timestampSec — parity with desktop's
   // fresh-SSE bypass so the first headline lands the moment the stream emits it.
   isFresh?: boolean;
+  /** Initial generation or wave-2 still running. Drives the screen-edge
+   *  glow so "we're still digging" is legible without looking at the
+   *  logo — the whole frame breathes instead of one small element. */
+  researching?: boolean;
 }
 
 // Module-level so it persists across unmount/remount cycles (e.g. navigating
@@ -119,6 +123,7 @@ export default function ImmersiveNuggetView({
   onNext,
   spotifyAlbumArt,
   isFresh = false,
+  researching = false,
 }: ImmersiveNuggetViewProps) {
   const { isPlaying, currentTime, duration, toggle, seek } = usePlayer();
   const mountedRef = useRef(true);
@@ -710,9 +715,15 @@ export default function ImmersiveNuggetView({
         </svg>
       </button>
 
-      {/* Screen-edge glow — tier-colored border effect */}
-      <div className="fixed inset-0 z-[51] pointer-events-none"
-        style={{
+      {/* Screen-edge glow — tier-colored border effect. Breathes while
+          research is in flight so the state reads from anywhere on the
+          screen, not just the logo in the corner. Settles to the static
+          glow the moment research finishes. */}
+      <div
+        className={`fixed inset-0 z-[51] pointer-events-none ${researching ? "animate-research-glow" : ""}`}
+        data-testid="screen-glow"
+        data-researching={researching ? "true" : "false"}
+        style={researching ? undefined : {
           boxShadow: "inset 0 0 30px 4px hsl(var(--neon-glow) / 0.3), inset 0 0 80px 10px hsl(var(--neon-glow) / 0.1)",
         }}
       />

--- a/src/components/immersive/MiniPlayer.tsx
+++ b/src/components/immersive/MiniPlayer.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { Play, Pause, SkipBack, SkipForward } from "lucide-react";
 
 interface MiniPlayerProps {
@@ -100,7 +101,8 @@ export default function MiniPlayer({
       {/* Player content */}
       <div className="flex items-center gap-2 px-3 py-2">
         {artUrl && (
-          <img src={artUrl} alt="" className="w-10 h-10 rounded-lg object-cover flex-shrink-0" />
+          <RemoteImage src={artUrl} alt="" eager className="w-10 h-10 rounded-lg object-cover flex-shrink-0"
+            fallback={<div className="w-10 h-10 rounded-lg bg-foreground/10 flex-shrink-0" />} />
         )}
         <div className="flex-1 min-w-0 overflow-hidden">
           {/* ~25 chars fits the mini player at 375px width with controls.

--- a/src/components/overlays/NuggetDeepDive.tsx
+++ b/src/components/overlays/NuggetDeepDive.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronRight, ExternalLink, ArrowLeft, Loader2 } from "lucide-react";
 import type { Nugget, Source } from "@/mock/types";
@@ -237,11 +238,11 @@ export default function NuggetDeepDive({ nugget, source, artist, trackTitle, onC
                 animate={{ opacity: 1, transition: { delay: 0.2, duration: 0.3 } }}
                 className="flex-shrink-0 md:w-[45%] flex flex-col"
               >
-                <img
+                <RemoteImage
                   src={nugget.imageUrl}
                   alt={nugget.imageCaption || nugget.headline || ""}
+                  eager
                   className="w-full max-h-[35vh] md:max-h-[45vh] object-contain rounded-lg"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                 />
                 {nugget.imageCaption && (
                   <p className="text-xs text-muted-foreground mt-1.5 italic text-center">{nugget.imageCaption}</p>

--- a/src/components/overlays/ReadingOverlay.tsx
+++ b/src/components/overlays/ReadingOverlay.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import RemoteImage from "@/components/RemoteImage";
 import { X, ExternalLink, FileText, Mic } from "lucide-react";
 import type { Source } from "@/mock/types";
 import { isSafeUrl } from "@/lib/urlSafety";
@@ -59,7 +60,7 @@ export default function ReadingOverlay({ source, onClose }: Props) {
         )}
 
         {source.thumbnailUrl && (
-          <img src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" />
+          <RemoteImage src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" fallback={null} />
         )}
 
         {/* Spacer to push actions to bottom */}

--- a/src/components/overlays/ReadingOverlay.tsx
+++ b/src/components/overlays/ReadingOverlay.tsx
@@ -60,7 +60,7 @@ export default function ReadingOverlay({ source, onClose }: Props) {
         )}
 
         {source.thumbnailUrl && (
-          <RemoteImage src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" fallback={null} />
+          <RemoteImage src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" />
         )}
 
         {/* Spacer to push actions to bottom */}

--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -1223,17 +1223,33 @@ export function useAINuggets(
         // client), so leaving the in-mem cache empty means a future
         // mount will go through the full pipeline again.
         setError(null);
-        // Sentinel cleanup so a future tap retries the real pipeline.
-        if (sentinelClaimed) {
-          try { await supabase.from("nugget_cache").delete().eq("track_id", dbCacheKey); } catch { /* noop */ }
-        }
         return;
       }
-      // Remove the 'generating' sentinel so waiting clients don't poll indefinitely.
-      if (sentinelClaimed) {
-        try { await supabase.from("nugget_cache").delete().eq("track_id", dbCacheKey); } catch { /* noop */ }
-      }
     } finally {
+      // Release the generation claim on EVERY exit, not just the two
+      // paths that used to reach the end of the try block.
+      //
+      // A 'generating' row is a lock: other clients poll it instead of
+      // starting their own generation. Releasing it only on the way out
+      // of the happy path meant any of the thirteen earlier exits
+      // stranded it forever — most often `if (cancelledRef.current)
+      // return` and the AbortError catch, which is precisely what the
+      // unmount cleanup below triggers when a user skips a track a few
+      // seconds in. Nothing ever cleared those rows, so the affected
+      // track showed "researching" and no facts to every later listener,
+      // permanently. Twelve had accumulated since May, including
+      // Turnover's "Humming", claimed 2026-07-30.
+      //
+      // The success paths set sentinelClaimed = false once the row holds
+      // real content, so this is a no-op there. And a delete that races
+      // a server write cannot destroy anything: RLS only permits
+      // deleting a row that is still 'generating', so once the server
+      // has written 'ready' the statement matches nothing.
+      if (sentinelClaimed) {
+        try {
+          await supabase.from("nugget_cache").delete().eq("track_id", dbCacheKey);
+        } catch { /* best-effort — a stale claim is recoverable, a throw here is not */ }
+      }
       if (!cancelledRef.current) {
         setLoading(false);
       }

--- a/src/hooks/useArtistLatestFacts.ts
+++ b/src/hooks/useArtistLatestFacts.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+import { isReadableUpdate } from "@/lib/artistUpdateKind";
 
 /**
  * Fetches the `ArtistUpdate[]` for a single artist. Hits the same
@@ -15,6 +16,11 @@ import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
  * via a Browse nugget tap); a cold artist (e.g. navigated from "Fans
  * Also Like") triggers a fresh edge-function call with the usual
  * generation latency.
+ *
+ * Returns only updates with something to read. The same response also
+ * carries Browse's `kind: "track"` play targets, which have no body —
+ * see isReadableUpdate. Filtering here rather than in the component
+ * means the hook's name matches what it returns.
  */
 export function useArtistLatestFacts(
   artistName: string | null,
@@ -45,7 +51,10 @@ export function useArtistLatestFacts(
           return;
         }
         const next = (data?.updates as ArtistUpdate[] | undefined) ?? [];
-        setUpdates(next);
+        // The edge function returns Browse's play targets in the same
+        // array. Those have no body, so "Latest Facts" would render
+        // them as titles with nothing underneath.
+        setUpdates(next.filter(isReadableUpdate));
       } catch (e) {
         if (import.meta.env.DEV) {
           console.warn(`[artist-latest-facts] ${artistName} threw:`, e);

--- a/src/hooks/useDialogFocusTrap.ts
+++ b/src/hooks/useDialogFocusTrap.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * WCAG focus management for a modal dialog: Escape dismisses, focus moves
+ * to the close button on open and returns to the triggering element on
+ * close, and Tab/Shift+Tab cycle within the dialog only.
+ *
+ * Extracted from ArtistUpdatesSection's ExpandedUpdateModal, which had
+ * the only correct implementation in the app. A second dialog (the saved
+ * nugget on Profile) was written to "match" it visually and shipped
+ * without any of this — a keyboard user could Tab straight through the
+ * backdrop into the page behind, with no way to dismiss. Copying the
+ * behaviour a second time would have set that trap again for the third
+ * dialog, so it lives here now.
+ *
+ * Returns a ref to attach to the dialog's close button. The dialog root
+ * is found from that button via `closest('[role="dialog"]')`, so the
+ * element carrying the role can be an ancestor at any depth.
+ *
+ * `active` exists because callers mount differently. ArtistUpdatesSection
+ * puts its dialog in a child component that mounts when it opens, so the
+ * effect naturally fires at the right moment. Profile renders its dialog
+ * inline from the page, where the hook would otherwise run once at page
+ * load — with no close button to focus — and never again. Pass whether
+ * the dialog is currently open and the effect tracks it.
+ */
+export function useDialogFocusTrap(onClose: () => void, active = true) {
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    closeBtnRef.current?.focus();
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const root = closeBtnRef.current?.closest('[role="dialog"]');
+      if (!root) return;
+      const focusable = Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      // Send focus back where the user left it, not to document.body.
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [onClose, active]);
+
+  return closeBtnRef;
+}

--- a/src/hooks/useSpotifyToken.ts
+++ b/src/hooks/useSpotifyToken.ts
@@ -3,6 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import {
   SPOTIFY_STORAGE_KEY,
   TOKEN_CHANGED_EVENT,
+  RECONNECT_REQUIRED_EVENT,
   type StoredSpotifyToken,
 } from "@/lib/spotifyTokenStore";
 import { refreshSpotifyToken } from "./useSpotifyAuth";
@@ -133,7 +134,7 @@ export function useSpotifyToken() {
       // the next ProtectedRoute check — no signal that anything failed.
       localStorage.removeItem(STORAGE_KEY);
       if (typeof window !== "undefined") {
-        window.dispatchEvent(new Event("spotify-reconnect-required"));
+        window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
       }
       return null;
     }

--- a/src/hooks/useSpotifyToken.ts
+++ b/src/hooks/useSpotifyToken.ts
@@ -4,6 +4,7 @@ import {
   SPOTIFY_STORAGE_KEY,
   TOKEN_CHANGED_EVENT,
   RECONNECT_REQUIRED_EVENT,
+  readStoredSpotifyToken,
   type StoredSpotifyToken,
 } from "@/lib/spotifyTokenStore";
 import { refreshSpotifyToken } from "./useSpotifyAuth";
@@ -40,15 +41,11 @@ async function refreshViaEdgeFunction(refreshToken: string): Promise<{
   }
 }
 
-function readToken(): StoredToken | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw) as StoredToken;
-  } catch {
-    return null;
-  }
-}
+// Delegates to the store so "is there a usable token?" has exactly one
+// answer. The bridge asks the same question when deciding whether the
+// user is stranded; two implementations could disagree on a corrupted
+// value and leave that dead end unsignalled.
+const readToken = (): StoredToken | null => readStoredSpotifyToken();
 
 // writeToken persists to localStorage AND dispatches TOKEN_CHANGED_EVENT so
 // every mounted useSpotifyToken hook instance re-reads and re-sets state. All

--- a/src/index.css
+++ b/src/index.css
@@ -211,3 +211,31 @@
 @media (prefers-reduced-motion: reduce) {
   .animate-cue-float { animation: none; }
 }
+
+/* Screen-edge research glow. The static frame already tints the edges;
+   this breathes it so "still digging" reads from anywhere on screen
+   rather than only from the logo in the corner. Slow and shallow on
+   purpose — it sits behind editorial copy the user is reading, and a
+   hard pulse would compete with it. */
+@keyframes research-glow {
+  0%, 100% {
+    box-shadow: inset 0 0 30px 4px hsl(var(--neon-glow) / 0.28),
+                inset 0 0 80px 10px hsl(var(--neon-glow) / 0.10);
+  }
+  50% {
+    box-shadow: inset 0 0 46px 8px hsl(var(--neon-glow) / 0.62),
+                inset 0 0 120px 22px hsl(var(--neon-glow) / 0.24);
+  }
+}
+.animate-research-glow {
+  animation: research-glow 2.6s ease-in-out infinite;
+}
+/* Motion-sensitivity fallback: hold a slightly-raised static glow, so
+   the "researching" state is still distinguishable without movement. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-research-glow {
+    animation: none;
+    box-shadow: inset 0 0 40px 6px hsl(var(--neon-glow) / 0.45),
+                inset 0 0 100px 16px hsl(var(--neon-glow) / 0.18);
+  }
+}

--- a/src/lib/artistFactToNugget.ts
+++ b/src/lib/artistFactToNugget.ts
@@ -22,7 +22,7 @@ export const ARTIST_FACT_ID_PREFIX = "artistfact";
  * function — if the two drift, this silently reads nothing and the
  * feature degrades to "no seed" with no error anywhere.
  */
-export const ARTIST_UPDATES_CACHE_VERSION = "v2";
+export const ARTIST_UPDATES_CACHE_VERSION = "v3";
 
 export function buildArtistUpdatesCacheKey(artistName: string, tier: string): string {
   return `artist::${artistName.trim().toLowerCase()}::${tier}::${ARTIST_UPDATES_CACHE_VERSION}`;

--- a/src/lib/artistUpdateKind.ts
+++ b/src/lib/artistUpdateKind.ts
@@ -18,6 +18,30 @@ export interface ArtistUpdateKindMeta {
   KindIcon: typeof Sparkles;
 }
 
+/**
+ * Whether an update has something to read.
+ *
+ * `kind: "track"` entries are play targets, not content: the edge
+ * function builds them with the track name as the headline and
+ * `body: ""` (artist-updates/index.ts:381 — the only empty body it
+ * produces). They exist for the Browse "Get into" lane, which renders
+ * them as artwork tiles.
+ *
+ * The artist profile's "Latest Facts" reads the same array and rendered
+ * them as readable cards, so the section promised facts and delivered
+ * bare catalog artwork — duplicating the "Popular" list directly below
+ * it. Pete: "I don't understand what the track cards are doing here in
+ * latest facts, when there is no facts in each of those cards."
+ *
+ * Also drops any other empty-bodied update, which would render the same
+ * broken way. Filtering here rather than in the component keeps the
+ * rule in one place for the next surface that reads these.
+ */
+export function isReadableUpdate(u: ArtistUpdate): boolean {
+  if (u.kind === "track") return false;
+  return u.body.trim().length > 0;
+}
+
 export function getArtistUpdateKindMeta(kind: ArtistUpdate["kind"]): ArtistUpdateKindMeta {
   switch (kind) {
     case "new-release":

--- a/src/lib/spotifyTokenStore.ts
+++ b/src/lib/spotifyTokenStore.ts
@@ -22,6 +22,12 @@ import type { Session } from "@supabase/supabase-js";
 
 export const SPOTIFY_STORAGE_KEY = "spotify_playback_token";
 export const TOKEN_CHANGED_EVENT = "spotify-token-changed";
+/** Playback credentials are gone and cannot be recovered without a new
+ *  OAuth round trip. SpotifyReconnectBanner listens for this and offers
+ *  the user a way back. Two things raise it: a refresh chain that failed
+ *  (useSpotifyToken), and a session that never had credentials to begin
+ *  with (the bridge below). */
+export const RECONNECT_REQUIRED_EVENT = "spotify-reconnect-required";
 
 export interface StoredSpotifyToken {
   accessToken: string;
@@ -44,13 +50,32 @@ export interface StoredSpotifyToken {
  * Exported for unit testing.
  */
 export function bridgeSpotifyProviderTokens(session: Session | null): void {
-  if (!session?.provider_token) return;
+  if (!session) return;
   if (session.user?.app_metadata?.provider !== "spotify") return;
-  // Skip the write if the session has no refresh token. Spotify requires
-  // a refresh token to issue new access tokens, so persisting without one
-  // would leave the Web Playback SDK stuck once the first access token
-  // expires (~1h) with no path forward.
-  if (!session.provider_refresh_token) return;
+
+  // A Spotify session carrying no usable provider tokens cannot establish
+  // playback credentials on its own. Routine in itself — Supabase issues
+  // provider_token only on a fresh OAuth and drops it on every JWT
+  // refresh — and harmless while localStorage still holds what was
+  // written at sign-in. Skipping the write is deliberate: an access token
+  // without a refresh token strands the SDK at the first expiry (~1h),
+  // and overwriting a good stored token with an empty one is worse than
+  // doing nothing.
+  //
+  // But when localStorage is empty too, nothing is left to fall back on:
+  // no access token, no refresh token, and no way to obtain either
+  // without sending the user back through OAuth. That state used to be
+  // entirely silent — getValidToken returns null for a missing token
+  // without raising anything — so the Web Playback SDK simply had no
+  // credentials and the play button did nothing at all. Pete hit exactly
+  // this on staging: valid session, correct track, dead transport, no
+  // error anywhere in the console.
+  if (!session.provider_token || !session.provider_refresh_token) {
+    if (typeof window !== "undefined" && !localStorage.getItem(SPOTIFY_STORAGE_KEY)) {
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
+    }
+    return;
+  }
 
   // `session.expires_in` is strictly the Supabase JWT's TTL, not the
   // Spotify access token's TTL — the two refresh on independent

--- a/src/lib/spotifyTokenStore.ts
+++ b/src/lib/spotifyTokenStore.ts
@@ -36,13 +36,42 @@ export interface StoredSpotifyToken {
 }
 
 /**
+ * The stored token, or null if there isn't a usable one.
+ *
+ * "Usable" deliberately means parseable with an access token present —
+ * NOT merely "the key exists". A corrupted value would satisfy a raw
+ * `getItem` truthiness check while every real consumer, which parses,
+ * would find nothing. Anything deciding "do we still have credentials?"
+ * must agree with the reader, or it will conclude there is a fallback
+ * that isn't there — which is the exact silent dead end this module's
+ * reconnect signalling exists to prevent.
+ *
+ * An expired token still counts as usable here: it carries the refresh
+ * token, and useSpotifyToken.getValidToken can trade it for a live one.
+ */
+export function readStoredSpotifyToken(): StoredSpotifyToken | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(SPOTIFY_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredSpotifyToken;
+    return parsed?.accessToken ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Copy Spotify provider tokens from a Supabase session into localStorage.
  * Idempotent + defensive:
  *   - no-op if the session is null or not from the Spotify provider
  *   - no-op if the session lacks a provider_token (post-JWT-refresh
  *     sessions DROP the provider token; Supabase doesn't persist it,
  *     so we must not overwrite what's already in localStorage with an
- *     empty string)
+ *     empty string) — but NOT a silent one: if nothing usable is stored
+ *     either, there is no path back to credentials without a new OAuth
+ *     round trip, so this dispatches RECONNECT_REQUIRED_EVENT rather
+ *     than leaving playback dead with no signal
  *   - skips the write if an existing token has a longer expiry, so a
  *     freshly-refreshed client-side token isn't clobbered by a stale
  *     session-bound one on re-hydration
@@ -71,7 +100,7 @@ export function bridgeSpotifyProviderTokens(session: Session | null): void {
   // this on staging: valid session, correct track, dead transport, no
   // error anywhere in the console.
   if (!session.provider_token || !session.provider_refresh_token) {
-    if (typeof window !== "undefined" && !localStorage.getItem(SPOTIFY_STORAGE_KEY)) {
+    if (typeof window !== "undefined" && !readStoredSpotifyToken()) {
       window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     }
     return;

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -320,6 +320,7 @@ function CatalogAlbumInner({
           <RemoteImage
             src={album.imageUrl}
             alt=""
+            eager
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
           />
         </div>
@@ -498,6 +499,7 @@ function MockAlbumInner({
           <RemoteImage
             src={album.coverArtUrl}
             alt=""
+            eager
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
           />
         </div>

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import RemoteImage from "@/components/RemoteImage";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getAlbumById, getTracksForAlbum, getArtistById } from "@/mock/tracks";
@@ -316,7 +317,7 @@ function CatalogAlbumInner({
       {/* Hero */}
       <div className="relative overflow-hidden">
         <div className="absolute inset-0">
-          <img
+          <RemoteImage
             src={album.imageUrl}
             alt=""
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
@@ -334,10 +335,12 @@ function CatalogAlbumInner({
         </button>
 
         <div className="relative z-10 flex flex-col md:flex-row items-center md:items-end gap-4 md:gap-8 px-4 md:px-10 pb-6 md:pb-10">
-          <img
+          <RemoteImage
             src={album.imageUrl}
             alt={album.name}
+            eager
             className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl object-cover"
+            fallback={<div className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl bg-foreground/10" />}
           />
           <div className="pb-2 text-center md:text-left">
             <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-1">
@@ -492,7 +495,7 @@ function MockAlbumInner({
     <div className="min-h-screen bg-background">
       <div className="relative overflow-hidden">
         <div className="absolute inset-0">
-          <img
+          <RemoteImage
             src={album.coverArtUrl}
             alt=""
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
@@ -510,10 +513,12 @@ function MockAlbumInner({
         </button>
 
         <div className="relative z-10 flex flex-col md:flex-row items-center md:items-end gap-4 md:gap-8 px-4 md:px-10 pb-6 md:pb-10">
-          <img
+          <RemoteImage
             src={album.coverArtUrl}
             alt={album.title}
+            eager
             className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl object-cover"
+            fallback={<div className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl bg-foreground/10" />}
           />
           <div className="pb-2 text-center md:text-left">
             <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-1">

--- a/src/pages/ArtistProfile.tsx
+++ b/src/pages/ArtistProfile.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import RemoteImage from "@/components/RemoteImage";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getArtistById, getAlbumsForArtist, getTracksForArtist, artists } from "@/mock/tracks";
@@ -438,9 +439,10 @@ function RealArtistProfileInner({ artist, trackTiles, albumTiles, relatedTiles }
     <div className="min-h-screen bg-background">
       {/* Hero */}
       <div className="relative h-60 md:h-80 overflow-hidden">
-        <img
+        <RemoteImage
           src={heroImage}
           alt={artist.name}
+          eager
           className="h-full w-full object-cover blur-[8px] scale-110 brightness-[0.4]"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/40 to-transparent" />
@@ -509,7 +511,8 @@ function RealArtistProfileInner({ artist, trackTiles, albumTiles, relatedTiles }
               >
                 <span className="w-6 text-center text-sm text-muted-foreground tabular-nums">{i + 1}</span>
                 {t.imageUrl ? (
-                  <img src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover" />
+                  <RemoteImage src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover"
+                    fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10" />} />
                 ) : (
                   <div className="h-10 w-10 rounded-lg bg-foreground/10" />
                 )}
@@ -647,9 +650,10 @@ function MockArtistProfileInner({ artist, tracksData, albumTiles, relatedTiles }
     <div className="min-h-screen bg-background">
       {/* Hero */}
       <div className="relative h-60 md:h-80 overflow-hidden">
-        <img
+        <RemoteImage
           src={heroImage}
           alt={artist.name}
+          eager
           className="h-full w-full object-cover blur-[8px] scale-110 brightness-[0.4]"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/40 to-transparent" />
@@ -697,7 +701,8 @@ function MockArtistProfileInner({ artist, tracksData, albumTiles, relatedTiles }
               }`}
             >
               <span className="w-6 text-center text-sm text-muted-foreground tabular-nums">{i + 1}</span>
-              <img src={t.coverArtUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover" />
+              <RemoteImage src={t.coverArtUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover"
+                fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10" />} />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-bold text-foreground truncate">{t.title}</p>
                 <p className="text-xs text-muted-foreground truncate">{t.album}</p>

--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import RemoteImage from "@/components/RemoteImage";
 import { useState, useEffect, useMemo } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useArtistImage } from "@/hooks/useArtistImage";
@@ -206,11 +207,11 @@ export default function Companion() {
       {/* Artist Hero */}
       <div className="relative w-full aspect-[3/1] max-h-[200px] overflow-hidden">
         {artistImage ? (
-          <img
+          <RemoteImage
             src={artistImage}
             alt={artistName}
+            eager
             className="w-full h-full object-cover"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
           />
         ) : (
           <div className="w-full h-full bg-foreground/5" />
@@ -237,7 +238,8 @@ export default function Companion() {
 
         {/* Track Details */}
         <section className="apple-glass rounded-2xl p-4 flex items-center gap-4">
-          <img src={trackInfo.coverArtUrl} alt={trackInfo.title} className="w-16 h-16 rounded-lg object-cover shrink-0" />
+          <RemoteImage src={trackInfo.coverArtUrl} alt={trackInfo.title} className="w-16 h-16 rounded-lg object-cover shrink-0"
+            fallback={<div className="w-16 h-16 rounded-lg bg-foreground/10 shrink-0" />} />
           <div className="min-w-0">
             <h2 className="text-lg font-bold text-foreground truncate">{trackInfo.title}</h2>
             {trackInfo.album && <p className="text-sm text-muted-foreground truncate">{trackInfo.album}</p>}
@@ -304,11 +306,10 @@ export default function Companion() {
                           <ErrorBoundary>
                             {nugget.imageUrl && (
                               <div className="-mx-4 -mt-4 mb-3">
-                                <img
+                                <RemoteImage
                                   src={nugget.imageUrl}
                                   alt={nugget.imageCaption || nugget.headline || ""}
                                   className="w-full object-contain max-h-44"
-                                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                                 />
                                 {nugget.imageCaption && (
                                   <p className="px-4 py-1.5 text-xs text-muted-foreground italic">{nugget.imageCaption}</p>

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1770,7 +1770,8 @@ export default function Listen() {
               onPrev={handlePrev}
               onNext={handleNext}
               spotifyAlbumArt={spotifyStateTrack?.albumArtUrl}
-              isFresh={!aiFromCache}
+              researching={aiLoading || waveLoading}
+            isFresh={!aiFromCache}
             />
           </Suspense>
         )}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1771,7 +1771,7 @@ export default function Listen() {
               onNext={handleNext}
               spotifyAlbumArt={spotifyStateTrack?.albumArtUrl}
               researching={aiLoading || waveLoading}
-            isFresh={!aiFromCache}
+              isFresh={!aiFromCache}
             />
           </Suspense>
         )}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1358,6 +1358,8 @@ export default function Listen() {
           <img
             src={effectiveCoverArt}
             alt=""
+            loading="eager"
+            decoding="async"
             className="h-full w-full object-cover scale-[1.3] transition-all duration-1000 ease-out"
             style={{
               filter: barVisible
@@ -1498,6 +1500,8 @@ export default function Listen() {
             key={effectiveCoverArt}
             src={effectiveCoverArt}
             alt={`${track.title} cover art`}
+            loading="eager"
+            decoding="async"
             className="rounded-2xl object-cover shadow-2xl shadow-black/50"
             style={{ width: "min(70vw, 70vh)", height: "min(70vw, 70vh)" }}
             initial={{ opacity: 0, scale: 0.9 }}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeft, Heart, Music, Share2, Trash2, Check, Play, X, ExternalLink } from "lucide-react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
@@ -187,17 +188,16 @@ export default function Profile() {
                           onClick={() => setOpenId(bm.id)}
                           className="w-full text-left active:scale-[0.99] transition-transform p-4 flex gap-3"
                         >
-                          {bm.image_url ? (
-                            <img
-                              src={bm.image_url}
-                              alt=""
-                              className="w-14 h-14 rounded object-cover flex-shrink-0"
-                            />
-                          ) : (
-                            <div className="w-14 h-14 rounded bg-white/10 flex items-center justify-center flex-shrink-0">
-                              <Music className="w-5 h-5 text-white/30" />
-                            </div>
-                          )}
+                          <RemoteImage
+                            src={bm.image_url}
+                            alt=""
+                            className="w-14 h-14 rounded object-cover flex-shrink-0"
+                            fallback={
+                              <div className="w-14 h-14 rounded bg-white/10 flex items-center justify-center flex-shrink-0">
+                                <Music className="w-5 h-5 text-white/30" />
+                              </div>
+                            }
+                          />
                           <div className="flex-1 min-w-0">
                             <p className="text-[10px] uppercase tracking-wider text-white/40 mb-0.5">
                               {bm.artist} · {bm.title}
@@ -278,7 +278,7 @@ export default function Profile() {
             >
               {openBookmark.image_url && (
                 <div className="relative h-44 shrink-0">
-                  <img src={openBookmark.image_url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+                  <RemoteImage src={openBookmark.image_url} alt="" eager className="absolute inset-0 w-full h-full object-cover" />
                   <div className="absolute inset-0 bg-gradient-to-t from-neutral-950 via-neutral-950/40 to-transparent" />
                 </div>
               )}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { ArrowLeft, Heart, Music, Share2, Trash2, Check } from "lucide-react";
+import { ArrowLeft, Heart, Music, Share2, Trash2, Check, Play, X, ExternalLink } from "lucide-react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { useBookmarks, type Bookmark } from "@/hooks/useBookmarks";
 import PageTransition from "@/components/PageTransition";
+import { AnimatePresence, motion } from "framer-motion";
+import { isSafeUrl } from "@/lib/urlSafety";
 
 // Group bookmarks into date buckets for a scannable profile page. Exact
 // edges don't matter much — the goal is to let a user visually parse
@@ -27,6 +29,20 @@ function listenUrlFor(bm: Bookmark): string {
   return `/listen/${encodeURIComponent(bm.track_id)}`;
 }
 
+// Bookmarks store no artist id, so this uses the search-by-name form the
+// app already resolves server-side (same fallback RecommendedButtons uses
+// when Gemini gives a name but no Spotify id).
+function artistUrlFor(bm: Bookmark): string {
+  return `/artist/real::${encodeURIComponent(bm.artist)}`;
+}
+
+// A saved nugget's citation, when the edge function stored one.
+function sourceUrlOf(bm: Bookmark): string | null {
+  const src = bm.source as { url?: unknown } | null;
+  const url = typeof src?.url === "string" ? src.url : null;
+  return url && isSafeUrl(url) ? url : null;
+}
+
 export default function Profile() {
   const { profile } = useUserProfile();
   const { bookmarks, loading, signedIn, toggle } = useBookmarks();
@@ -34,6 +50,14 @@ export default function Profile() {
   // Transient per-row UI state for the share button's "Copied!" confirmation.
   // Keyed by bookmark id.
   const [sharedIds, setSharedIds] = useState<Set<string>>(new Set());
+  // Tapping a saved nugget used to navigate straight to Listen, which
+  // committed the user to playback before they could re-read what they
+  // saved or decide they wanted the artist instead. Now it opens.
+  const [openId, setOpenId] = useState<string | null>(null);
+  const openBookmark = useMemo(
+    () => bookmarks.find((b) => b.id === openId) ?? null,
+    [bookmarks, openId],
+  );
 
   async function handleShare(bm: Bookmark) {
     const url = `${window.location.origin}${listenUrlFor(bm)}`;
@@ -151,7 +175,7 @@ export default function Profile() {
                         className="bg-white/5 hover:bg-white/10 transition rounded-lg overflow-hidden"
                       >
                         <button
-                          onClick={() => navigate(listenUrlFor(bm))}
+                          onClick={() => setOpenId(bm.id)}
                           className="w-full text-left active:scale-[0.99] transition-transform p-4 flex gap-3"
                         >
                           {bm.image_url ? (
@@ -214,6 +238,95 @@ export default function Profile() {
             )}
         </div>
       </div>
+
+      {/* Saved-nugget detail. Opening the card first is the point: a saved
+          nugget is something you chose to keep, so the tap should let you
+          re-read it and then decide where to go — the song, the artist, or
+          the source — rather than committing you to playback.
+
+          Action shape matches the Browse expanded card deliberately: one
+          filled play control, quiet links beside it. Same gesture, same
+          meaning, on both surfaces. */}
+      <AnimatePresence>
+        {openBookmark && (
+          <motion.div
+            className="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setOpenId(null)}
+            role="dialog"
+            aria-modal="true"
+            aria-label={openBookmark.headline}
+          >
+            <motion.div
+              className="relative w-full max-w-md bg-neutral-950 rounded-2xl overflow-hidden ring-1 ring-white/10 max-h-[85vh] flex flex-col"
+              initial={{ y: 24, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: 24, opacity: 0 }}
+              transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {openBookmark.image_url && (
+                <div className="relative h-44 shrink-0">
+                  <img src={openBookmark.image_url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neutral-950 via-neutral-950/40 to-transparent" />
+                </div>
+              )}
+
+              <button
+                onClick={() => setOpenId(null)}
+                aria-label="Close"
+                className="absolute top-3 right-3 z-10 w-9 h-9 rounded-full bg-black/50 backdrop-blur-sm ring-1 ring-white/20 flex items-center justify-center active:scale-95 transition-transform"
+              >
+                <X className="w-4 h-4 text-white/80" />
+              </button>
+
+              <div className="px-5 pb-5 pt-4 overflow-y-auto scrollbar-hide">
+                <p className="text-[10px] uppercase tracking-widest text-white/40 mb-2">
+                  {openBookmark.artist} · {openBookmark.title}
+                </p>
+                <h2 className="text-xl font-black text-white leading-tight mb-3">
+                  {openBookmark.headline}
+                </h2>
+                <p className="text-sm text-white/75 leading-relaxed mb-5">
+                  {openBookmark.body}
+                </p>
+
+                <div className="flex items-center gap-3.5">
+                  <button
+                    onClick={() => navigate(listenUrlFor(openBookmark))}
+                    aria-label={`Play ${openBookmark.title} by ${openBookmark.artist}`}
+                    className="shrink-0 flex items-center justify-center w-12 h-12 rounded-full bg-white text-black hover:bg-white/90 active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                  >
+                    <Play className="w-4 h-4 ml-[2px]" fill="currentColor" />
+                  </button>
+                  <div className="flex flex-col items-start gap-1.5 min-w-0">
+                    <button
+                      onClick={() => navigate(artistUrlFor(openBookmark))}
+                      className="inline-flex items-center gap-1.5 max-w-full text-sm font-semibold text-primary hover:underline active:scale-95 transition-transform"
+                    >
+                      <span className="truncate">{openBookmark.artist}</span>
+                      <ExternalLink className="w-3 h-3 shrink-0" />
+                    </button>
+                    {sourceUrlOf(openBookmark) && (
+                      <a
+                        href={sourceUrlOf(openBookmark)!}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors"
+                      >
+                        Source
+                        <ExternalLink className="w-3 h-3 shrink-0" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </PageTransition>
   );
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeft, Heart, Music, Share2, Trash2, Check, Play, X, ExternalLink } from "lucide-react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { useBookmarks, type Bookmark } from "@/hooks/useBookmarks";
 import PageTransition from "@/components/PageTransition";
 import { AnimatePresence, motion } from "framer-motion";
+import { useDialogFocusTrap } from "@/hooks/useDialogFocusTrap";
 import { isSafeUrl } from "@/lib/urlSafety";
 
 // Group bookmarks into date buckets for a scannable profile page. Exact
@@ -58,6 +59,14 @@ export default function Profile() {
     () => bookmarks.find((b) => b.id === openId) ?? null,
     [bookmarks, openId],
   );
+  // Validated once rather than on each render branch that needs it.
+  const sourceUrl = openBookmark ? sourceUrlOf(openBookmark) : null;
+  const closeDetail = useCallback(() => setOpenId(null), []);
+  // Same Escape / focus-trap / focus-restore behaviour as the Browse
+  // expanded card. This dialog was written to match that one visually
+  // and shipped without any of it, so a keyboard user could Tab straight
+  // through the backdrop with no way to dismiss.
+  const closeBtnRef = useDialogFocusTrap(closeDetail, !!openBookmark);
 
   async function handleShare(bm: Bookmark) {
     const url = `${window.location.origin}${listenUrlFor(bm)}`;
@@ -254,13 +263,13 @@ export default function Profile() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={() => setOpenId(null)}
-            role="dialog"
-            aria-modal="true"
-            aria-label={openBookmark.headline}
+            onClick={closeDetail}
           >
             <motion.div
               className="relative w-full max-w-md bg-neutral-950 rounded-2xl overflow-hidden ring-1 ring-white/10 max-h-[85vh] flex flex-col"
+              role="dialog"
+              aria-modal="true"
+              aria-label={openBookmark.headline}
               initial={{ y: 24, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: 24, opacity: 0 }}
@@ -275,7 +284,8 @@ export default function Profile() {
               )}
 
               <button
-                onClick={() => setOpenId(null)}
+                ref={closeBtnRef}
+                onClick={closeDetail}
                 aria-label="Close"
                 className="absolute top-3 right-3 z-10 w-9 h-9 rounded-full bg-black/50 backdrop-blur-sm ring-1 ring-white/20 flex items-center justify-center active:scale-95 transition-transform"
               >
@@ -309,9 +319,9 @@ export default function Profile() {
                       <span className="truncate">{openBookmark.artist}</span>
                       <ExternalLink className="w-3 h-3 shrink-0" />
                     </button>
-                    {sourceUrlOf(openBookmark) && (
+                    {sourceUrl && (
                       <a
-                        href={sourceUrlOf(openBookmark)!}
+                        href={sourceUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors"

--- a/src/test/ArtistCardMorph.test.tsx
+++ b/src/test/ArtistCardMorph.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+// layoutId is surfaced as data-layout-id here — see the helper. Without
+// that, both ends of the morph render identically whether or not they
+// agree, which is exactly how the regression below reached review.
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock({ exposeLayoutId: true }));
+
+import { UpdateCard, ExpandedUpdateModalMemoized } from "@/components/ArtistUpdatesSection";
+
+const LAYOUT_ID = "artist::turnover::fact-42";
+
+const FACT: ArtistUpdate = {
+  artistId: "a1",
+  artistName: "Turnover",
+  artistImageUrl: "https://i.scdn.co/image/abc123",
+  kind: "fact",
+  headline: "Turnover tracked the record with their live engineer.",
+  body: "They brought him into the studio to capture the room.",
+  nuggetId: "fact-42",
+};
+
+const noop = () => {};
+
+function renderCard(update: ArtistUpdate) {
+  const { container } = render(
+    <MemoryRouter>
+      <UpdateCard update={update} layoutId={LAYOUT_ID} onClick={noop} />
+    </MemoryRouter>,
+  );
+  return container;
+}
+
+function renderModal(update: ArtistUpdate) {
+  const { container } = render(
+    <MemoryRouter>
+      <ExpandedUpdateModalMemoized
+        update={update}
+        layoutId={LAYOUT_ID}
+        onClose={noop}
+        onOpen={noop}
+      />
+    </MemoryRouter>,
+  );
+  return container;
+}
+
+/** Every morph id declared in a rendered tree. Both the container and
+ *  the artwork carry one, so comparing the whole set is what catches a
+ *  half-wired pair — checking a single element would just re-find the
+ *  container on both ends and pass regardless. */
+const morphIds = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll("[data-layout-id]"))
+    .map((el) => el.getAttribute("data-layout-id"))
+    .sort();
+
+// ── The regression ────────────────────────────────────────────────────
+// Routing the card thumbnail through RemoteImage dropped its layoutId,
+// because RemoteImage rendered a plain <img>. The modal hero kept
+// its own, so the pair no longer matched and the photo hard-cut into
+// the modal instead of scaling. Both ends have to agree; asserting only
+// one end is what let this through the first time.
+describe("artist card → modal shared-element morph", () => {
+  it("gives the card thumbnail a morph id", () => {
+    expect(morphIds(renderCard(FACT))).toContain(`${LAYOUT_ID}::img`);
+  });
+
+  it("gives the modal hero the same morph id", () => {
+    expect(morphIds(renderModal(FACT))).toContain(`${LAYOUT_ID}::img`);
+  });
+
+  // Every id on one end needs a partner on the other — an unpaired id
+  // is precisely a hard cut.
+  it("declares the same morph ids on both ends", () => {
+    expect(morphIds(renderCard(FACT))).toEqual(morphIds(renderModal(FACT)));
+  });
+
+  // The original wired the empty state up too, so an artist with no
+  // photo still morphs its placeholder rather than popping.
+  it("morphs the placeholder when the artist has no photo", () => {
+    const noPhoto = { ...FACT, artistImageUrl: undefined };
+
+    expect(morphIds(renderCard(noPhoto))).toContain(`${LAYOUT_ID}::img`);
+    expect(morphIds(renderCard(noPhoto))).toEqual(morphIds(renderModal(noPhoto)));
+  });
+});
+
+// Regaining the morph must not cost the deferral — the card thumbnails
+// were the bulk of the ~53-request burst that made Browse render as a
+// wall of black cards.
+describe("morphing card thumbnails still defer loading", () => {
+  it("keeps the card thumbnail lazy", () => {
+    const img = renderCard(FACT).querySelector("img");
+    expect(img?.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("keeps decoding off the main thread", () => {
+    const img = renderCard(FACT).querySelector("img");
+    expect(img?.getAttribute("decoding")).toBe("async");
+  });
+});

--- a/src/test/ArtistUpdatesModal.test.tsx
+++ b/src/test/ArtistUpdatesModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ArtistUpdateGroup } from "@/hooks/useArtistUpdates";
+
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock());
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import ArtistUpdatesSection from "@/components/ArtistUpdatesSection";
+
+const GROUP: ArtistUpdateGroup = {
+  artistName: "Turnover",
+  updates: [
+    {
+      artistId: "art-1",
+      artistName: "Turnover",
+      artistImageUrl: "https://example.com/turnover.jpg",
+      kind: "fact",
+      headline: "Turnover tracked the record with their live engineer.",
+      body: "They brought him into the studio to capture the room.",
+      nuggetId: "n-1",
+      source: { type: "article", title: "t", publisher: "BrooklynVegan", url: "https://bv.com/x" },
+    },
+    {
+      artistId: "art-1",
+      artistName: "Turnover",
+      artistImageUrl: "https://example.com/cover.jpg",
+      kind: "track",
+      headline: "Humming",
+      body: "",
+      relatedTrackTitle: "Humming",
+      relatedAlbumName: "Peripheral Vision",
+      relatedTrackUri: "spotify:track:abc123",
+    },
+  ],
+};
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <ArtistUpdatesSection
+        groups={[GROUP]}
+        profile={{ streamingService: "Spotify" } as never}
+        artistIds={{ Turnover: "art-1" }}
+        totalCount={1}
+        readyCount={1}
+      />
+    </MemoryRouter>,
+  );
+}
+
+const dialog = () => screen.queryByRole("dialog");
+
+beforeEach(() => navigateMock.mockReset());
+
+describe("Browse expanded card — leaving it", () => {
+  it("opens when a card is tapped", () => {
+    renderSection();
+    expect(dialog()).toBeNull();
+
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    expect(dialog()).not.toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  // Pete: "when I click to go to an artist page from a card in the browse
+  // page, it takes me to the artist page but the card stays open so I
+  // don't see that I'm in the artist page."
+  //
+  // The dominant cause was the 500ms page exit under AnimatePresence
+  // mode="wait", which held Browse on screen after the URL changed. But
+  // the modal must also actually close — if it only navigated, the card
+  // would sit over the new page for as long as the transition ran.
+  it("closes the card when navigating to the artist", () => {
+    renderSection();
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    fireEvent.click(within(dialog()!).getByRole("button", { name: /^turnover$/i }));
+
+    expect(dialog()).toBeNull();
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0][0]).toContain("/artist/");
+  });
+
+  it("closes the card when starting playback", () => {
+    renderSection();
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    fireEvent.click(within(dialog()!).getByRole("button", { name: /play humming by turnover/i }));
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0][0]).toContain("/listen/");
+  });
+
+  it("closes without navigating when dismissed", () => {
+    renderSection();
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(dialog()).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/ImmersiveNuggetView.test.tsx
+++ b/src/test/ImmersiveNuggetView.test.tsx
@@ -74,7 +74,7 @@ const HEADLINE_LESS: Nugget = {
   sourceId: "src-1",
 };
 
-function renderView(nuggets: Nugget[] = [RICH]) {
+function renderView(nuggets: Nugget[] = [RICH], researching = false) {
   return render(
     <ImmersiveNuggetView
       nuggets={nuggets}
@@ -84,6 +84,7 @@ function renderView(nuggets: Nugget[] = [RICH]) {
       artist="Cherele"
       onClose={() => {}}
       isFresh
+      researching={researching}
     />,
   );
 }
@@ -265,5 +266,49 @@ describe("ImmersiveNuggetView — deep dive", () => {
     const deeper = screen.getByRole("button", { name: /tell me more/i });
     expect(save).not.toBe(deeper);
     expect(within(save).queryByText(/tell me more/i)).toBeNull();
+  });
+});
+
+
+// ── Research glow ─────────────────────────────────────────────────────
+// Pete: "can we make the color that shows up around the screen pulse a
+// little more so we know that research is being done?" The screen-edge
+// glow is visible from anywhere on the card, so it carries the state
+// better than the small logo in the corner.
+describe("ImmersiveNuggetView — research glow", () => {
+  it("breathes the screen edge while research is in flight", () => {
+    renderView([RICH], true);
+    const glow = screen.getByTestId("screen-glow");
+    expect(glow.getAttribute("data-researching")).toBe("true");
+    expect(glow.className).toContain("animate-research-glow");
+  });
+
+  it("settles to a static glow once research finishes", () => {
+    renderView([RICH], false);
+    const glow = screen.getByTestId("screen-glow");
+    expect(glow.getAttribute("data-researching")).toBe("false");
+    expect(glow.className).not.toContain("animate-research-glow");
+    // Static state still tints the edges — it just stops moving.
+    expect(glow.getAttribute("style") ?? "").toContain("box-shadow");
+  });
+
+  it("stops breathing when research completes mid-view", () => {
+    const { rerender } = renderView([RICH], true);
+    expect(screen.getByTestId("screen-glow").className).toContain("animate-research-glow");
+
+    rerender(
+      <ImmersiveNuggetView
+        nuggets={[RICH]}
+        sources={new Map([["src-1", SOURCE]])}
+        coverArtUrl="https://example.com/art.jpg"
+        trackTitle="KIKI"
+        artist="Cherele"
+        onClose={() => {}}
+        isFresh
+        researching={false}
+      />,
+    );
+
+    expect(screen.getByTestId("screen-glow").className).not.toContain("animate-research-glow");
   });
 });

--- a/src/test/LatestFactsDeepLink.test.tsx
+++ b/src/test/LatestFactsDeepLink.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock());
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import LatestFactsSection from "@/components/LatestFactsSection";
+
+const FACT: ArtistUpdate = {
+  artistId: "a1",
+  artistName: "Turnover",
+  artistImageUrl: "https://example.com/t.jpg",
+  kind: "fact",
+  headline: "Turnover tracked the record with their live engineer.",
+  body: "They brought him into the studio to capture the room.",
+  nuggetId: "fact-42",
+};
+
+const OTHER: ArtistUpdate = { ...FACT, nuggetId: "fact-99", headline: "A different fact." };
+
+function renderAt(search: string, updates: ArtistUpdate[] = [FACT, OTHER]) {
+  return render(
+    <MemoryRouter initialEntries={[`/artist/spotify::a1::Turnover${search}`]}>
+      <LatestFactsSection updates={updates} loading={false} artistName="Turnover" />
+    </MemoryRouter>,
+  );
+}
+
+const dialog = () => screen.queryByRole("dialog");
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("artist page — arriving from a fact card", () => {
+  // Pete: "it takes me to the profile but the fact card stays open or
+  // re-opens on top of the artist profile instead of letting me see the
+  // artist profile." The card was never lingering — this component was
+  // calling setExpandedKey on arrival and opening it again.
+  it("does not open the referenced fact over the page", () => {
+    renderAt("?nugget=fact-42");
+    expect(dialog()).toBeNull();
+  });
+
+  // Scrolling is deferred a frame so the card exists before we target it.
+  it("scrolls the referenced fact into view instead", async () => {
+    renderAt("?nugget=fact-42");
+    await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled());
+  });
+
+  it("leaves the page clear when there is no deep link", () => {
+    renderAt("");
+    expect(dialog()).toBeNull();
+  });
+
+  it("ignores a deep link that matches nothing", () => {
+    renderAt("?nugget=does-not-exist");
+    expect(dialog()).toBeNull();
+  });
+
+  // The card must still be openable — this fixes an unwanted auto-open,
+  // not the ability to read a fact on the artist page.
+  it("still opens the card when the user taps it", () => {
+    renderAt("?nugget=fact-42");
+    expect(dialog()).toBeNull();
+
+    fireEvent.click(screen.getByText(FACT.headline));
+
+    expect(dialog()).not.toBeNull();
+  });
+
+  it("opens the tapped card, not the deep-linked one", () => {
+    renderAt("?nugget=fact-42");
+    fireEvent.click(screen.getByText(OTHER.headline));
+
+    const dlg = dialog()!;
+    expect(dlg.textContent).toContain(OTHER.headline);
+  });
+});

--- a/src/test/ProfileSavedNugget.test.tsx
+++ b/src/test/ProfileSavedNugget.test.tsx
@@ -141,3 +141,69 @@ describe("Profile — deciding where to go", () => {
     expect(within(openDialog()!).queryByRole("link", { name: /source/i })).toBeNull();
   });
 });
+
+// ── Keyboard access ───────────────────────────────────────────────────
+// Flagged in review: this dialog was written to "match the Browse
+// expanded card" but shipped without any of that card's focus
+// management, so a keyboard user could Tab through the backdrop into the
+// page behind with no way to dismiss. Both now share
+// useDialogFocusTrap, and these assert the behaviour rather than the
+// sharing.
+describe("Profile — saved-nugget dialog keyboard access", () => {
+  it("dismisses on Escape", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+    expect(openDialog()).not.toBeNull();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(openDialog()).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("moves focus into the dialog on open", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it("returns focus to the card that opened it", () => {
+    renderProfile();
+    // Focus the trigger first — that's the keyboard path, and jsdom's
+    // click alone doesn't move focus the way a real browser does.
+    const trigger = screen.getByText(BOOKMARK.headline).closest("button")!;
+    trigger.focus();
+    fireEvent.click(trigger);
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /close/i }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    // Focus goes back where the user left it, not stranded on the body.
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("keeps Tab inside the dialog rather than reaching the page behind", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const dialog = openDialog()!;
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    expect(focusable.length).toBeGreaterThan(1);
+
+    // Tabbing forward off the last element wraps to the first.
+    focusable[focusable.length - 1].focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(focusable[0]);
+
+    // Shift+Tab off the first wraps to the last.
+    focusable[0].focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
+  });
+});

--- a/src/test/ProfileSavedNugget.test.tsx
+++ b/src/test/ProfileSavedNugget.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { Bookmark } from "@/hooks/useBookmarks";
+
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock());
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const toggleMock = vi.fn();
+let bookmarks: Bookmark[] = [];
+vi.mock("@/hooks/useBookmarks", () => ({
+  useBookmarks: () => ({
+    bookmarks,
+    loading: false,
+    signedIn: true,
+    toggle: toggleMock,
+    isBookmarked: () => true,
+    findBookmark: () => undefined,
+    adding: false,
+    removing: false,
+  }),
+}));
+
+vi.mock("@/hooks/useMusicNerdState", () => ({
+  useUserProfile: () => ({ profile: { displayName: "Pete" } }),
+}));
+
+import Profile from "@/pages/Profile";
+
+const BOOKMARK: Bookmark = {
+  id: "bm-1",
+  service: "spotify",
+  track_id: "real::Turnover::Humming",
+  artist: "Turnover",
+  title: "Humming",
+  album: null,
+  nugget_kind: "artist",
+  headline: "Turnover tracked the record with their front-of-house engineer.",
+  body: "They brought him into the studio to capture the live sound.",
+  source: { url: "https://brooklynvegan.com/turnover" },
+  image_url: "https://example.com/art.jpg",
+  created_at: new Date().toISOString(),
+};
+
+function renderProfile() {
+  return render(<MemoryRouter><Profile /></MemoryRouter>);
+}
+
+const openDialog = () => screen.queryByRole("dialog");
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  toggleMock.mockReset();
+  bookmarks = [BOOKMARK];
+});
+
+describe("Profile — opening a saved nugget", () => {
+  // Pete: "when I click on one of my saved nuggets it just goes straight to
+  // playing the song. I want to be able to open the card and then make the
+  // decision if I want to go to the song or artist."
+  it("opens the nugget instead of jumping straight to playback", () => {
+    renderProfile();
+    expect(openDialog()).toBeNull();
+
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    expect(openDialog()).not.toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the full saved nugget once open", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const dialog = openDialog()!;
+    expect(within(dialog).getByText(BOOKMARK.body)).toBeTruthy();
+  });
+
+  it("closes without navigating anywhere", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(openDialog()).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("Profile — deciding where to go", () => {
+  it("plays the track when the play control is used", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+    fireEvent.click(screen.getByRole("button", { name: /play humming by turnover/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      `/listen/${encodeURIComponent(BOOKMARK.track_id)}`,
+    );
+  });
+
+  // The other half of the ask — the saved nugget is about an artist, so
+  // reaching them has to be a real option, not just the song.
+  it("opens the artist when the artist link is used", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const dialog = openDialog()!;
+    fireEvent.click(within(dialog).getByRole("button", { name: /^turnover$/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/artist/real::Turnover");
+  });
+
+  it("links out to the citation when one was saved", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const link = within(openDialog()!).getByRole("link", { name: /source/i });
+    expect(link.getAttribute("href")).toBe("https://brooklynvegan.com/turnover");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  // The saved body is Exa/Gemini-derived, so the stored URL is untrusted.
+  it("omits the source link when the saved URL is unsafe", () => {
+    bookmarks = [{ ...BOOKMARK, source: { url: "javascript:alert(1)" } }];
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    expect(within(openDialog()!).queryByRole("link", { name: /source/i })).toBeNull();
+  });
+
+  it("omits the source link when nothing was saved", () => {
+    bookmarks = [{ ...BOOKMARK, source: null }];
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    expect(within(openDialog()!).queryByRole("link", { name: /source/i })).toBeNull();
+  });
+});

--- a/src/test/RemoteImage.test.tsx
+++ b/src/test/RemoteImage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import RemoteImage from "@/components/RemoteImage";
+
+const SRC = "https://i.scdn.co/image/abc123";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("RemoteImage — deferring the request", () => {
+  // THE ROOT FIX. Browse fired ~53 simultaneous requests at i.scdn.co,
+  // Spotify throttled the burst, and most came back 503. Deferring
+  // offscreen artwork is what stops that; everything else here is
+  // recovery for the few that still fail.
+  it("defers loading by default", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    expect(screen.getByAltText("cover").getAttribute("loading")).toBe("lazy");
+  });
+
+  it("decodes off the main thread", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    expect(screen.getByAltText("cover").getAttribute("decoding")).toBe("async");
+  });
+
+  // Above-the-fold artwork is already being looked at; deferring it only
+  // delays what the user can see.
+  it("loads eagerly when asked", () => {
+    render(<RemoteImage src={SRC} alt="cover" eager />);
+    expect(screen.getByAltText("cover").getAttribute("loading")).toBe("eager");
+  });
+});
+
+describe("RemoteImage — recovering from a throttled request", () => {
+  it("retries once after a backoff", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    const img = screen.getByAltText("cover");
+    expect(img.getAttribute("src")).toBe(SRC);
+
+    fireEvent.error(img);
+    // Immediately retrying would rejoin the burst that caused the throttle.
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(SRC);
+
+    act(() => { vi.advanceTimersByTime(800); });
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${SRC}?r=1`);
+  });
+
+  it("cache-busts the retry so the browser cannot replay the failure", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+
+    expect(screen.getByAltText("cover").getAttribute("src")).not.toBe(SRC);
+  });
+
+  it("falls back to the placeholder once the retry also fails", () => {
+    render(<RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />);
+
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+    fireEvent.error(screen.getByAltText("cover"));
+
+    expect(screen.queryByAltText("cover")).toBeNull();
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+
+  it("does not retry forever", () => {
+    render(<RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />);
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(5000); });
+
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+});
+
+describe("RemoteImage — no artwork", () => {
+  it("renders the fallback when src is missing", () => {
+    render(<RemoteImage src={undefined} fallback={<div data-testid="ph" />} />);
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+
+  it("renders the fallback when src is null", () => {
+    render(<RemoteImage src={null} fallback={<div data-testid="ph" />} />);
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+
+  // A failed URL must not poison the next one — artist rows swap images
+  // as content resolves.
+  it("recovers when a new src replaces a failed one", () => {
+    const { rerender } = render(
+      <RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />,
+    );
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+    fireEvent.error(screen.getByAltText("cover"));
+    expect(screen.getByTestId("ph")).toBeTruthy();
+
+    rerender(
+      <RemoteImage src="https://i.scdn.co/image/def456" alt="cover" fallback={<div data-testid="ph" />} />,
+    );
+
+    const img = screen.getByAltText("cover");
+    expect(img.getAttribute("src")).toBe("https://i.scdn.co/image/def456");
+  });
+});

--- a/src/test/RemoteImage.test.tsx
+++ b/src/test/RemoteImage.test.tsx
@@ -41,7 +41,7 @@ describe("RemoteImage — recovering from a throttled request", () => {
     expect(screen.getByAltText("cover").getAttribute("src")).toBe(SRC);
 
     act(() => { vi.advanceTimersByTime(800); });
-    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${SRC}?r=1`);
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${SRC}?_retry=1`);
   });
 
   it("cache-busts the retry so the browser cannot replay the failure", () => {
@@ -102,5 +102,55 @@ describe("RemoteImage — no artwork", () => {
 
     const img = screen.getByAltText("cover");
     expect(img.getAttribute("src")).toBe("https://i.scdn.co/image/def456");
+  });
+});
+
+// ── src changing mid-backoff ──────────────────────────────────────────
+// Flagged in review. A scheduled retry closes over the PREVIOUS src; if
+// the prop moves on before it fires, the stale timer writes the old URL
+// over the new one ~700ms later. That collision is likeliest during
+// exactly the burst this component exists for — several images sit
+// mid-backoff while ArtistRow's heroImg recomputes as facts stream in.
+describe("RemoteImage — src changes while a retry is pending", () => {
+  const NEXT = "https://i.scdn.co/image/def456";
+
+  it("does not let a stale retry clobber the new image", () => {
+    const { rerender } = render(<RemoteImage src={SRC} alt="cover" />);
+    fireEvent.error(screen.getByAltText("cover"));
+
+    // New artwork arrives mid-backoff.
+    rerender(<RemoteImage src={NEXT} alt="cover" />);
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(NEXT);
+
+    // The old retry would have fired around here.
+    act(() => { vi.advanceTimersByTime(2000); });
+
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(NEXT);
+  });
+
+  it("still shows the new image rather than falling back", () => {
+    const { rerender } = render(
+      <RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />,
+    );
+    fireEvent.error(screen.getByAltText("cover"));
+    rerender(<RemoteImage src={NEXT} alt="cover" fallback={<div data-testid="ph" />} />);
+    act(() => { vi.advanceTimersByTime(2000); });
+
+    expect(screen.queryByTestId("ph")).toBeNull();
+    expect(screen.getByAltText("cover")).toBeTruthy();
+  });
+
+  // The new image gets its own full retry budget — it must not inherit
+  // the previous URL's spent attempt.
+  it("gives the new image its own retry", () => {
+    const { rerender } = render(<RemoteImage src={SRC} alt="cover" />);
+    fireEvent.error(screen.getByAltText("cover"));
+    rerender(<RemoteImage src={NEXT} alt="cover" />);
+    act(() => { vi.advanceTimersByTime(2000); });
+
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${NEXT}?_retry=1`);
   });
 });

--- a/src/test/SpotifyReconnectBanner.test.tsx
+++ b/src/test/SpotifyReconnectBanner.test.tsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, screen, act } from "@testing-library/react";
+// Imported rather than hardcoded: a literal here would keep dispatching
+// an event the banner no longer listens for if the name is ever renamed,
+// and the test would pass against a component that never opens.
+import { RECONNECT_REQUIRED_EVENT } from "@/lib/spotifyTokenStore";
 
 vi.mock("@/hooks/useSpotifyAuth", () => ({
   signInWithSpotify: vi.fn().mockResolvedValue(undefined),
@@ -21,7 +25,7 @@ describe("SpotifyReconnectBanner", () => {
   it("shows on the spotify-reconnect-required event", () => {
     render(<SpotifyReconnectBanner />);
     act(() => {
-      window.dispatchEvent(new Event("spotify-reconnect-required"));
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     });
     expect(screen.getByText(/session expired/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /reconnect/i })).toBeInTheDocument();
@@ -30,7 +34,7 @@ describe("SpotifyReconnectBanner", () => {
   it("invokes signInWithSpotify when Reconnect is clicked", () => {
     render(<SpotifyReconnectBanner />);
     act(() => {
-      window.dispatchEvent(new Event("spotify-reconnect-required"));
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     });
     fireEvent.click(screen.getByRole("button", { name: /reconnect/i }));
     expect(signInWithSpotify).toHaveBeenCalledOnce();
@@ -39,7 +43,7 @@ describe("SpotifyReconnectBanner", () => {
   it("hides on Dismiss click", () => {
     render(<SpotifyReconnectBanner />);
     act(() => {
-      window.dispatchEvent(new Event("spotify-reconnect-required"));
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     });
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(screen.queryByText(/session expired/i)).toBeNull();

--- a/src/test/artistFactToNugget.test.ts
+++ b/src/test/artistFactToNugget.test.ts
@@ -260,17 +260,17 @@ describe("buildArtistUpdatesCacheKey", () => {
   // — `artist::${artistName.trim().toLowerCase()}::${tier}`. Drift here
   // reads nothing and fails silently, with no error anywhere.
   it("matches the edge function's key format exactly", () => {
-    expect(buildArtistUpdatesCacheKey("Radiohead", "nerd")).toBe("artist::radiohead::nerd::v2");
+    expect(buildArtistUpdatesCacheKey("Radiohead", "nerd")).toBe("artist::radiohead::nerd::v3");
   });
 
   it("lowercases and trims like the edge function does", () => {
     expect(buildArtistUpdatesCacheKey("  Pete Rango  ", "casual"))
-      .toBe("artist::pete rango::casual::v2");
+      .toBe("artist::pete rango::casual::v3");
   });
 
   it("scopes by tier", () => {
     expect(buildArtistUpdatesCacheKey("Flozigg", "curious"))
-      .toBe("artist::flozigg::curious::v2");
+      .toBe("artist::flozigg::curious::v3");
   });
 
   // Rows live 7 days, so without a version segment a SHAPE change stays

--- a/src/test/helpers/framerMotionMock.tsx
+++ b/src/test/helpers/framerMotionMock.tsx
@@ -23,7 +23,15 @@ const ANIMATION_PROPS = new Set([
   "dragElastic", "dragMomentum", "onDragEnd", "onDragStart", "custom",
 ]);
 
-export function makeFramerMotionMock() {
+/**
+ * `exposeLayoutId` surfaces layoutId as a `data-layout-id` attribute.
+ * Framer Motion consumes layoutId to compute a shared-element morph and
+ * never writes it to the DOM, so without this a test cannot see whether
+ * both ends of a morph agree on the id — and a morph wired up on only
+ * one end hard-cuts silently rather than failing. Opt-in, because it is
+ * not a real DOM attribute and would be noise in every other suite.
+ */
+export function makeFramerMotionMock({ exposeLayoutId = false } = {}) {
   const cache = new Map<string, React.ElementType>();
 
   const passthrough = (tag: string) =>
@@ -34,6 +42,9 @@ export function makeFramerMotionMock() {
       const domProps: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(props)) {
         if (!ANIMATION_PROPS.has(key)) domProps[key] = value;
+      }
+      if (exposeLayoutId && props.layoutId !== undefined) {
+        domProps["data-layout-id"] = props.layoutId;
       }
       return React.createElement(tag, { ...domProps, ref }, children);
     });

--- a/src/test/latestFactsFiltering.test.ts
+++ b/src/test/latestFactsFiltering.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+import { isReadableUpdate } from "@/lib/artistUpdateKind";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { functions: { invoke: vi.fn() } },
+}));
+
+import { useArtistLatestFacts } from "@/hooks/useArtistLatestFacts";
+import { supabase } from "@/integrations/supabase/client";
+
+const base = {
+  artistId: "a1",
+  artistName: "BADBADNOTGOOD",
+  artistImageUrl: "https://i.scdn.co/image/abc",
+};
+
+const FACT: ArtistUpdate = {
+  ...base,
+  kind: "fact",
+  headline: "BADBADNOTGOOD started their collaboration with Kaytranada.",
+  body: "Alex Sowinski noted Kaytranada, whom the band met on tour.",
+  nuggetId: "fact-1",
+};
+
+// What the edge function actually builds for Browse's play targets:
+// track name as headline, empty body (artist-updates/index.ts:381).
+const TRACK: ArtistUpdate = {
+  ...base,
+  kind: "track",
+  headline: "Time Moves Slow",
+  body: "",
+  relatedTrackUri: "spotify:track:xyz",
+  relatedTrackTitle: "Time Moves Slow",
+  nuggetId: "track-spotify:track:xyz",
+};
+
+describe("isReadableUpdate", () => {
+  it("keeps a fact that has a body", () => {
+    expect(isReadableUpdate(FACT)).toBe(true);
+  });
+
+  it("drops a catalog track", () => {
+    expect(isReadableUpdate(TRACK)).toBe(false);
+  });
+
+  // The kind is the rule, not just the empty body — a track is a play
+  // target regardless of what the server puts in it.
+  it("drops a track even if it somehow carries a body", () => {
+    expect(isReadableUpdate({ ...TRACK, body: "A song about something." })).toBe(false);
+  });
+
+  it("keeps a new release with a body", () => {
+    expect(isReadableUpdate({ ...FACT, kind: "new-release" })).toBe(true);
+  });
+
+  it("keeps a collab with a body", () => {
+    expect(isReadableUpdate({ ...FACT, kind: "collab" })).toBe(true);
+  });
+
+  // An empty-bodied fact would render exactly as broken as a track tile.
+  it("drops an empty-bodied fact", () => {
+    expect(isReadableUpdate({ ...FACT, body: "" })).toBe(false);
+  });
+
+  it("drops a whitespace-only body", () => {
+    expect(isReadableUpdate({ ...FACT, body: "   \n  " })).toBe(false);
+  });
+});
+
+// ── The wiring ────────────────────────────────────────────────────────
+// The predicate passing proves nothing on its own; the bug was that
+// nothing called it. These pin that the hook feeding "Latest Facts"
+// actually applies it.
+describe("useArtistLatestFacts — what reaches Latest Facts", () => {
+  const invoke = supabase.functions.invoke as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => invoke.mockReset());
+
+  it("hands the section only readable updates", async () => {
+    invoke.mockResolvedValue({ data: { updates: [FACT, TRACK, TRACK] }, error: null });
+
+    const { result } = renderHook(() => useArtistLatestFacts("BADBADNOTGOOD", "nerd"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.updates).toEqual([FACT]);
+  });
+
+  it("leaves the section empty rather than showing bare tiles", async () => {
+    invoke.mockResolvedValue({ data: { updates: [TRACK, TRACK, TRACK] }, error: null });
+
+    const { result } = renderHook(() => useArtistLatestFacts("BADBADNOTGOOD", "nerd"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // LatestFactsSection renders nothing at all when this is empty,
+    // which is the right outcome — better than a heading over tiles.
+    expect(result.current.updates).toEqual([]);
+  });
+
+  it("keeps every fact when the server sends no tracks", async () => {
+    const second = { ...FACT, nuggetId: "fact-2", headline: "A second fact." };
+    invoke.mockResolvedValue({ data: { updates: [FACT, second] }, error: null });
+
+    const { result } = renderHook(() => useArtistLatestFacts("BADBADNOTGOOD", "nerd"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.updates).toHaveLength(2);
+  });
+});

--- a/src/test/nuggetClaimRelease.test.tsx
+++ b/src/test/nuggetClaimRelease.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// Does a generation claim get released when the run does NOT finish?
+//
+// A `status='generating'` row in nugget_cache is a lock: other clients
+// poll it rather than starting their own generation. Releasing it used
+// to live at the end of the try block, so only the two paths that
+// reached the bottom ever cleaned up. Thirteen earlier exits did not —
+// including every `if (cancelledRef.current) return` and the AbortError
+// catch, which is exactly what the hook's own effect cleanup triggers
+// when a user skips a track a few seconds in.
+//
+// Nothing else ever cleared those rows, so an affected track showed
+// "researching" and no facts to every later listener, permanently.
+// Twelve had accumulated since May 2026, including Turnover's "Humming"
+// (claimed 2026-07-30) which Pete reported as never resolving.
+
+const getNuggetCache = vi.fn(() => null);
+const setNuggetCache = vi.fn();
+const getTrackListenCount = vi.fn(() => 1);
+const setTrackListenCount = vi.fn();
+
+vi.mock("@/contexts/PlayerContext", () => ({
+  usePlayer: () => ({
+    getNuggetCache, setNuggetCache, getTrackListenCount, setTrackListenCount,
+    currentTime: 0, isPlaying: false,
+  }),
+}));
+
+vi.mock("@/data/seedNuggets", () => ({
+  getSeedListenNuggets: vi.fn(async () => null),
+}));
+
+/** Every nugget_cache write the hook attempts, in order. */
+const dbOps: { op: string; key?: string }[] = [];
+
+vi.mock("@/integrations/supabase/client", () => {
+  // Chainable stand-in for the PostgREST builder. `.eq()` has to be both
+  // chainable (after .select()) and awaitable (after .delete()), which
+  // is how the hook actually calls it.
+  const makeQuery = () => {
+    let deleting = false;
+    const q: Record<string, unknown> = {
+      select: () => q,
+      maybeSingle: async () => ({ data: null }),
+      insert: async () => { dbOps.push({ op: "insert" }); return { error: null }; },
+      delete: () => { deleting = true; return q; },
+      eq: (_col: string, val: string) => {
+        if (deleting) {
+          dbOps.push({ op: "delete", key: val });
+          return Promise.resolve({ error: null });
+        }
+        return q;
+      },
+    };
+    return q;
+  };
+  return {
+    supabase: {
+      auth: { getSession: vi.fn(async () => ({ data: { session: null } })) },
+      from: vi.fn(() => makeQuery()),
+      functions: { invoke: vi.fn(async () => ({ data: null, error: null })) },
+    },
+    SUPABASE_URL: "https://example.supabase.co",
+    SUPABASE_ANON_KEY: "anon",
+  };
+});
+
+import { useAINuggets } from "@/hooks/useAINuggets";
+
+const TRACK = "real::Turnover::Humming";
+
+function renderHookForTrack() {
+  return renderHook(() => useAINuggets(
+    TRACK, "Turnover", "Humming", undefined, 200, 0,
+    "https://example.com/art.jpg", "", "curious", ["Turnover"], ["Humming"],
+  ));
+}
+
+/** Resolves once generation has reached the streaming request. */
+let reachedSse: Promise<void>;
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  dbOps.length = 0;
+  getNuggetCache.mockReturnValue(null);
+
+  let arrived: () => void;
+  reachedSse = new Promise<void>((res) => { arrived = res; });
+
+  // Hangs until aborted — the shape of a real generation the user
+  // walks away from mid-stream.
+  global.fetch = vi.fn((_url: string, opts: { signal: AbortSignal }) => {
+    arrived();
+    return new Promise((_resolve, reject) => {
+      opts.signal.addEventListener("abort", () => {
+        reject(new DOMException("The operation was aborted.", "AbortError"));
+      });
+    });
+  }) as unknown as typeof global.fetch;
+});
+
+afterEach(() => { global.fetch = realFetch; });
+
+const claimed = () => dbOps.some((o) => o.op === "insert");
+const released = () => dbOps.some((o) => o.op === "delete");
+
+describe("generation claims are released when the run does not finish", () => {
+  it("claims the track before generating", async () => {
+    renderHookForTrack();
+    await reachedSse;
+    expect(claimed()).toBe(true);
+  });
+
+  // THE REGRESSION. Unmounting mid-generation is the common case — a
+  // track skip — and it took the AbortError exit, which never reached
+  // the old cleanup.
+  it("releases the claim when unmounted mid-generation", async () => {
+    const { unmount } = renderHookForTrack();
+    await reachedSse;
+    expect(released()).toBe(false);
+
+    unmount();
+
+    await waitFor(() => expect(released()).toBe(true));
+  });
+
+  it("releases the claim for the track it claimed", async () => {
+    const { unmount } = renderHookForTrack();
+    await reachedSse;
+    unmount();
+
+    await waitFor(() => {
+      const del = dbOps.find((o) => o.op === "delete");
+      expect(del?.key).toContain("Turnover");
+    });
+  });
+
+  // Releasing twice would be a different bug: the second delete could
+  // land after another client had re-claimed the track.
+  it("releases exactly once", async () => {
+    const { unmount } = renderHookForTrack();
+    await reachedSse;
+    unmount();
+
+    await waitFor(() => expect(released()).toBe(true));
+    expect(dbOps.filter((o) => o.op === "delete")).toHaveLength(1);
+  });
+});

--- a/src/test/spotifyTokenBridge.test.ts
+++ b/src/test/spotifyTokenBridge.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   bridgeSpotifyProviderTokens,
   SPOTIFY_STORAGE_KEY,
+  RECONNECT_REQUIRED_EVENT,
   type StoredSpotifyToken,
 } from "@/lib/spotifyTokenStore";
 
@@ -109,5 +110,130 @@ describe("bridgeSpotifyProviderTokens", () => {
       localStorage.getItem(SPOTIFY_STORAGE_KEY)!,
     ) as StoredSpotifyToken;
     expect(stored.accessToken).toBe("new-access");
+  });
+});
+
+// ── Unrecoverable credentials ─────────────────────────────────────────
+// Pete, on staging: "song is not playing... its working on main
+// production currently." The session was valid (expiring 40 minutes
+// out) but carried provider_token:false AND provider_refresh_token:
+// false, and localStorage held no spotify_playback_token. Supabase only
+// issues provider_token on a fresh OAuth and drops it on JWT refresh, so
+// there was nothing to refresh and nothing stored to fall back on.
+//
+// getValidToken returns null for a missing token WITHOUT raising the
+// reconnect event — that path only fires when a token exists and its
+// refresh fails. So the SDK had no credentials, the play button did
+// nothing, and no error appeared anywhere.
+//
+// The bridge is the only place that sees this: it runs on every session
+// hydration, including the refresh that drops the provider tokens.
+describe("bridgeSpotifyProviderTokens — unrecoverable credentials", () => {
+  let reconnects: number;
+  const count = () => { reconnects += 1; };
+
+  beforeEach(() => {
+    localStorage.clear();
+    reconnects = 0;
+    window.addEventListener(RECONNECT_REQUIRED_EVENT, count);
+  });
+  afterEach(() => {
+    window.removeEventListener(RECONNECT_REQUIRED_EVENT, count);
+  });
+
+  const strandedSession = {
+    provider_token: undefined,
+    provider_refresh_token: undefined,
+    expires_in: 3600,
+    user: { app_metadata: { provider: "spotify" } },
+  } as unknown as TestSession;
+
+  it("asks the user to reconnect when nothing can supply credentials", () => {
+    bridgeSpotifyProviderTokens(strandedSession);
+    expect(reconnects).toBe(1);
+  });
+
+  // The common case, and the reason the bridge no-ops rather than
+  // writing an empty token: post-refresh sessions routinely arrive
+  // without provider tokens while the stored one is still perfectly
+  // good. Crying reconnect here would push a working user through OAuth
+  // for nothing.
+  it("stays quiet when a stored token still covers us", () => {
+    const stored: StoredSpotifyToken = {
+      accessToken: "still-good",
+      refreshToken: "still-good-refresh",
+      expiresAt: Date.now() + 3600_000,
+    };
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(stored));
+
+    bridgeSpotifyProviderTokens(strandedSession);
+
+    expect(reconnects).toBe(0);
+    // and it must not clobber the token it just declined to replace
+    expect(JSON.parse(localStorage.getItem(SPOTIFY_STORAGE_KEY)!).accessToken)
+      .toBe("still-good");
+  });
+
+  // An expired stored token is still recoverable — getValidToken owns
+  // that path, refreshes it, and raises the event itself if the refresh
+  // chain fails. Firing here too would double up.
+  it("leaves an expired stored token to the refresh path", () => {
+    const stored: StoredSpotifyToken = {
+      accessToken: "expired",
+      refreshToken: "expired-refresh",
+      expiresAt: Date.now() - 60_000,
+    };
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(stored));
+
+    bridgeSpotifyProviderTokens(strandedSession);
+
+    expect(reconnects).toBe(0);
+  });
+
+  it("does not fire for an Apple / anonymous session", () => {
+    const session = {
+      provider_token: undefined,
+      provider_refresh_token: undefined,
+      user: { app_metadata: { provider: "anonymous" } },
+    } as unknown as TestSession;
+
+    bridgeSpotifyProviderTokens(session);
+
+    expect(reconnects).toBe(0);
+  });
+
+  it("does not fire when signed out", () => {
+    bridgeSpotifyProviderTokens(null);
+    expect(reconnects).toBe(0);
+  });
+
+  // Half a credential set is as useless as none — Spotify needs the
+  // refresh token to keep the SDK fed past the first hour.
+  it("fires when the access token is present but the refresh token is not", () => {
+    const session = {
+      provider_token: "spotify-access-abc",
+      provider_refresh_token: undefined,
+      expires_in: 3600,
+      user: { app_metadata: { provider: "spotify" } },
+    } as unknown as TestSession;
+
+    bridgeSpotifyProviderTokens(session);
+
+    expect(reconnects).toBe(1);
+    expect(localStorage.getItem(SPOTIFY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("stays quiet on a healthy sign-in", () => {
+    const session = {
+      provider_token: "spotify-access-abc",
+      provider_refresh_token: "spotify-refresh-xyz",
+      expires_in: 3600,
+      user: { app_metadata: { provider: "spotify" } },
+    } as unknown as TestSession;
+
+    bridgeSpotifyProviderTokens(session);
+
+    expect(reconnects).toBe(0);
+    expect(localStorage.getItem(SPOTIFY_STORAGE_KEY)).not.toBeNull();
   });
 });

--- a/src/test/spotifyTokenBridge.test.ts
+++ b/src/test/spotifyTokenBridge.test.ts
@@ -190,6 +190,24 @@ describe("bridgeSpotifyProviderTokens — unrecoverable credentials", () => {
     expect(reconnects).toBe(0);
   });
 
+  // Raised in review. A raw `getItem` truthiness check would see the key
+  // and conclude a fallback exists, while every real consumer parses and
+  // finds nothing — leaving the user stranded with no signal, which is
+  // the exact failure this whole path exists to catch. Both sides now go
+  // through readStoredSpotifyToken so they cannot disagree.
+  it("treats a corrupted stored token as no token at all", () => {
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, "{ not json");
+    bridgeSpotifyProviderTokens(strandedSession);
+    expect(reconnects).toBe(1);
+  });
+
+  // Parseable but useless — same reasoning.
+  it("treats a stored token with no access token as no token", () => {
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify({ refreshToken: "r", expiresAt: 1 }));
+    bridgeSpotifyProviderTokens(strandedSession);
+    expect(reconnects).toBe(1);
+  });
+
   it("does not fire for an Apple / anonymous session", () => {
     const session = {
       provider_token: undefined,

--- a/src/test/useAINuggetsLifecycle.test.tsx
+++ b/src/test/useAINuggetsLifecycle.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { Nugget, Source } from "@/mock/types";
+
+// Lifecycle tests for useAINuggets — WHEN generation runs, not what it
+// produces.
+//
+// Every bug reported in this feature has lived in this seam rather than
+// in any single function: generation re-firing on a value that merely
+// arrived late, state cleared out from under the reader, an in-flight
+// stream aborted by its own effect cleanup. The 500-odd unit tests
+// around this hook could not see any of it, because they test pure
+// helpers while the defects live in a dependency array.
+//
+// Observability trick: generate() consults the in-memory nugget cache
+// early and returns as soon as it hits. Seeding that cache makes every
+// run short and deterministic, and getNuggetCache call-count becomes an
+// exact measure of how many times generation actually fired.
+
+const getNuggetCache = vi.fn();
+const setNuggetCache = vi.fn();
+const getTrackListenCount = vi.fn(() => 1);
+const setTrackListenCount = vi.fn();
+
+vi.mock("@/contexts/PlayerContext", () => ({
+  usePlayer: () => ({
+    getNuggetCache,
+    setNuggetCache,
+    getTrackListenCount,
+    setTrackListenCount,
+    currentTime: 0,
+    isPlaying: false,
+  }),
+}));
+
+// Nothing below should be reached while the in-memory cache hits. If a
+// test ever trips one of these, generation went further than intended
+// and the test is no longer measuring what it claims to.
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: { getSession: vi.fn(async () => ({ data: { session: null } })) },
+    from: vi.fn(() => { throw new Error("DB hit — generation ran past the in-memory cache"); }),
+    functions: { invoke: vi.fn() },
+  },
+  SUPABASE_URL: "https://example.supabase.co",
+  SUPABASE_ANON_KEY: "anon",
+}));
+
+vi.mock("@/data/seedNuggets", () => ({
+  getSeedListenNuggets: vi.fn(async () => null),
+}));
+
+import { useAINuggets } from "@/hooks/useAINuggets";
+
+const NUGGET: Nugget = {
+  id: "n-1",
+  trackId: "real::Turnover::Humming",
+  timestampSec: 0,
+  durationMs: 7000,
+  headline: "A real fact about the track.",
+  text: "With a body that adds something.",
+  kind: "artist",
+  sourceId: "s-1",
+};
+
+const SOURCE: Source = {
+  id: "s-1", type: "article", title: "t", publisher: "p", url: "https://example.com/x",
+};
+
+/** The hook's positional signature, as a named shape so tests read clearly. */
+interface Args {
+  trackId: string;
+  artist: string;
+  title: string;
+  durationSec: number;
+  regenerateKey: number;
+  coverArtUrl?: string;
+  artistImageUrl?: string;
+  tier: "casual" | "curious" | "nerd";
+  topArtists?: string[];
+  topTracks?: string[];
+}
+
+const BASE: Args = {
+  trackId: "real::Turnover::Humming",
+  artist: "Turnover",
+  title: "Humming",
+  durationSec: 200,
+  regenerateKey: 0,
+  coverArtUrl: "https://example.com/art.jpg",
+  artistImageUrl: "",
+  tier: "curious",
+  topArtists: ["Turnover"],
+  topTracks: ["Humming"],
+};
+
+function render(initial: Args = BASE) {
+  return renderHook(
+    (a: Args) => useAINuggets(
+      a.trackId, a.artist, a.title, undefined, a.durationSec, a.regenerateKey,
+      a.coverArtUrl, a.artistImageUrl, a.tier, a.topArtists, a.topTracks,
+    ),
+    { initialProps: initial },
+  );
+}
+
+/** How many times generation has fired. */
+const generationCount = () => getNuggetCache.mock.calls.length;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Every lookup hits, so generation short-circuits deterministically.
+  getNuggetCache.mockReturnValue({
+    nuggets: [NUGGET],
+    sources: new Map([[SOURCE.id, SOURCE]]),
+    listenCount: 1,
+  });
+});
+
+describe("useAINuggets — when generation fires", () => {
+  it("generates once on mount", async () => {
+    render();
+    await waitFor(() => expect(generationCount()).toBeGreaterThan(0));
+    expect(generationCount()).toBe(1);
+  });
+
+  // ── THE REGRESSION ──────────────────────────────────────────────────
+  // Pete: "I had a track paused for a while, I unpaused, and all the
+  // facts disappeared and the researching pill showed up again."
+  //
+  // artistImageUrl resolves asynchronously from profile.artistImages;
+  // topArtists/topTracks get replaced by the background taste refresh.
+  // When those were in generate()'s dependency array, arriving late
+  // re-ran it — wiping state mid-listen and aborting any in-flight
+  // stream via the effect's own cleanup.
+
+  it("does NOT regenerate when the artist image resolves late", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, artistImageUrl: "https://example.com/artist.jpg" });
+    await Promise.resolve();
+
+    expect(generationCount()).toBe(1);
+  });
+
+  it("does NOT regenerate when cover art arrives late", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, coverArtUrl: "https://example.com/late-art.jpg" });
+    await Promise.resolve();
+
+    expect(generationCount()).toBe(1);
+  });
+
+  // The background taste refresh hands back fresh arrays — new identity,
+  // same meaning. That must not restart research.
+  it("does NOT regenerate when the taste refresh replaces top artists", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, topArtists: ["Turnover", "Citizen"], topTracks: ["Humming", "Sunny"] });
+    await Promise.resolve();
+
+    expect(generationCount()).toBe(1);
+  });
+
+  it("does NOT regenerate when several enrichment values land at once", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({
+      ...BASE,
+      artistImageUrl: "https://example.com/artist.jpg",
+      coverArtUrl: "https://example.com/late-art.jpg",
+      topArtists: ["Turnover", "Citizen"],
+    });
+    await Promise.resolve();
+
+    expect(generationCount()).toBe(1);
+  });
+
+  // The reader must keep what they were reading.
+  it("keeps the facts on screen when enrichment lands", async () => {
+    const { result, rerender } = render();
+    await waitFor(() => expect(result.current.nuggets.length).toBe(1));
+
+    rerender({ ...BASE, artistImageUrl: "https://example.com/artist.jpg" });
+    await Promise.resolve();
+
+    expect(result.current.nuggets).toHaveLength(1);
+    expect(result.current.nuggets[0].id).toBe("n-1");
+  });
+
+  // ── The other direction ─────────────────────────────────────────────
+  // Excluding enrichment must not make the hook inert. These guard
+  // against "fixing" the regression by never regenerating at all.
+
+  it("DOES regenerate on a track change", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, trackId: "real::Turnover::Sunshine", title: "Sunshine Type" });
+    await waitFor(() => expect(generationCount()).toBe(2));
+  });
+
+  it("DOES regenerate on a tier change", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, tier: "nerd" });
+    await waitFor(() => expect(generationCount()).toBe(2));
+  });
+
+  it("DOES regenerate when regenerateKey bumps for a deeper listen", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, regenerateKey: 1 });
+    await waitFor(() => expect(generationCount()).toBe(2));
+  });
+
+  it("DOES regenerate when the artist changes", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE, artist: "Citizen", trackId: "real::Citizen::Jet" });
+    await waitFor(() => expect(generationCount()).toBe(2));
+  });
+
+  it("stays put across an unrelated re-render with identical inputs", async () => {
+    const { rerender } = render();
+    await waitFor(() => expect(generationCount()).toBe(1));
+
+    rerender({ ...BASE });
+    rerender({ ...BASE });
+    await Promise.resolve();
+
+    expect(generationCount()).toBe(1);
+  });
+});

--- a/src/test/useSpotifyTokenRefresh.test.ts
+++ b/src/test/useSpotifyTokenRefresh.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+// Imported rather than hardcoded: a literal here would keep passing as a
+// listener for an event nobody dispatches if the name is ever renamed.
+import { RECONNECT_REQUIRED_EVENT } from "@/lib/spotifyTokenStore";
 
 const { invokeMock, refreshLegacyMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
@@ -107,7 +110,7 @@ describe("useSpotifyToken.getValidToken — refresh fallback chain", () => {
 
     const events: string[] = [];
     const listener = (e: Event) => events.push(e.type);
-    window.addEventListener("spotify-reconnect-required", listener);
+    window.addEventListener(RECONNECT_REQUIRED_EVENT, listener);
 
     const { result } = renderHook(() => useSpotifyToken());
     await act(async () => {
@@ -116,8 +119,8 @@ describe("useSpotifyToken.getValidToken — refresh fallback chain", () => {
     });
 
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
-    expect(events).toContain("spotify-reconnect-required");
+    expect(events).toContain(RECONNECT_REQUIRED_EVENT);
 
-    window.removeEventListener("spotify-reconnect-required", listener);
+    window.removeEventListener(RECONNECT_REQUIRED_EVENT, listener);
   });
 });

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -769,10 +769,14 @@ const POLL_INTERVAL_CAP_MS = 8_000;
 // missing whatever the new shape added.
 //
 // v2 — rows gained `kind: "track"` entries for the Browse play targets.
+// v3 — rows written before the searchArtist duplicate-entity fix hold data
+//      for the WRONG artist (lamboverrice resolved to a 1-follower stub with
+//      an empty catalog). Those rows are incorrect, not merely stale, so they
+//      must be invalidated rather than left to age out over 7 days.
 //
 // MUST stay in sync with buildArtistUpdatesCacheKey in
 // src/lib/artistFactToNugget.ts, which reads these rows from the client.
-const CACHE_VERSION = "v2";
+const CACHE_VERSION = "v3";
 
 function cacheKey(artistName: string, tier: string): string {
   // Normalized (lowercased + trimmed) so whitespace / case variations

--- a/supabase/migrations/20260804130000_nugget_cache_scope_writes.sql
+++ b/supabase/migrations/20260804130000_nugget_cache_scope_writes.sql
@@ -1,0 +1,72 @@
+-- Scope nugget_cache writes so a visitor cannot destroy or poison the cache.
+--
+-- The problem: the write policies added in 20260304180000 grant INSERT,
+-- UPDATE and DELETE to the `authenticated` role with NO row conditions.
+-- Anonymous sign-in (src/lib/ensureSupabaseSession.ts) hands that role to
+-- every visitor who reaches Connect, so in practice any visitor could
+-- overwrite or delete any cached nugget row in the table.
+--
+-- Why it was written that way: at the time the CLIENT wrote nugget_cache
+-- after generation, and that write failed for anon users. The fix chosen
+-- then was to widen the policy. In April 2026 the write moved server-side
+-- (generate-nuggets upserts with the admin key, bypassing RLS) and the
+-- policy was never narrowed again. That function's own comment records it:
+--
+--     "the server writes here using the admin key (bypasses RLS).
+--      Client's cache-write is now redundant but harmless."
+--
+-- So the broad grant is vestigial. What the client still genuinely needs
+-- is the generation LOCK, not the ability to write content:
+--
+--   INSERT status='generating'        claim a track. The unique index on
+--                                     track_id makes this atomic across
+--                                     clients — a second claim gets 23505
+--                                     and that client waits instead of
+--                                     paying for duplicate generation.
+--   DELETE WHERE status='generating'  release the claim, or clear a stale
+--                                     one after the poll timeout when the
+--                                     claiming client died mid-generation.
+--
+-- This migration keeps exactly that and removes the rest. A ready row —
+-- real nuggets someone paid Exa and Gemini to produce — becomes writable
+-- only by the server.
+--
+-- Residual exposure, stated plainly: a visitor can still create or clear
+-- generation claims. Worst case they force duplicate generation, or make
+-- other clients wait out the poll timeout on a track. Both are bounded and
+-- self-healing, and closing them would mean moving the lock server-side —
+-- a generate-nuggets deploy, which is guarded for unrelated reasons. This
+-- migration deliberately takes the part that needs no deploy.
+
+DROP POLICY IF EXISTS "nugget_cache_write" ON public.nugget_cache;
+DROP POLICY IF EXISTS "nugget_cache_update" ON public.nugget_cache;
+DROP POLICY IF EXISTS "nugget_cache_delete" ON public.nugget_cache;
+
+-- INSERT: a bare claim, or anything from the server.
+-- `nuggets = '[]'` is what stops this being a content-planting hole: a
+-- claim row carries no facts, so it cannot be used to serve fabricated
+-- nuggets to other listeners.
+CREATE POLICY "nugget_cache_claim"
+  ON public.nugget_cache FOR INSERT
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR (
+      auth.role() = 'authenticated'
+      AND status = 'generating'
+      AND nuggets = '[]'::jsonb
+    )
+  );
+
+-- UPDATE: server only. The client has no reason to modify a row in place —
+-- it resolves its own claim by letting the server's upsert overwrite it.
+CREATE POLICY "nugget_cache_update"
+  ON public.nugget_cache FOR UPDATE
+  USING (auth.role() = 'service_role');
+
+-- DELETE: an in-flight claim only. Ready rows are durable cache.
+CREATE POLICY "nugget_cache_delete"
+  ON public.nugget_cache FOR DELETE
+  USING (
+    auth.role() = 'service_role'
+    OR (auth.role() = 'authenticated' AND status = 'generating')
+  );

--- a/supabase/migrations/20260804200000_clear_stale_generation_claims.sql
+++ b/supabase/migrations/20260804200000_clear_stale_generation_claims.sql
@@ -1,0 +1,32 @@
+-- Clear stale generation claims from nugget_cache.
+--
+-- A `status='generating'` row is a lock, not content. A client claims a
+-- track before generating so a second client waits instead of paying for
+-- duplicate Exa/Gemini work, and the claim is released when generation
+-- finishes (the server upserts status='ready' over it) or fails (the
+-- client deletes it).
+--
+-- Twelve claims were never released — the oldest dates to 2026-05-15.
+-- Any listener who lands on one of those tracks polls the row, waits out
+-- the timeout, and sees nothing. Pete hit this on "Turnover — Humming"
+-- (claimed 2026-07-30) and reported that the researching state never
+-- resolved and no facts appeared.
+--
+-- Deleting them is safe and self-healing. A claim row holds no facts
+-- (`nuggets` is '[]'), so nothing cached is lost — the next listener
+-- regenerates from scratch, which is what would have happened had the
+-- claim been released properly.
+--
+-- Bounded by age so this can never delete a claim that is legitimately
+-- in flight: generation completes in roughly 15-60s, so anything older
+-- than an hour is abandoned by definition.
+--
+-- This clears the backlog but does not stop new claims from leaking.
+-- Whatever path drops them — a tab closed mid-generation, an unhandled
+-- failure between claim and release — still needs finding, and the
+-- durable fix is a server-side TTL or reaping stale claims on read
+-- rather than trusting a client to clean up after itself.
+
+DELETE FROM public.nugget_cache
+ WHERE status = 'generating'
+   AND created_at < now() - interval '1 hour';

--- a/supabase/migrations/20260804210000_nugget_cache_claim_empty_sources.sql
+++ b/supabase/migrations/20260804210000_nugget_cache_claim_empty_sources.sql
@@ -1,0 +1,31 @@
+-- Constrain `sources` on the claim policy, not just `nuggets`.
+--
+-- 20260804130000 limited a client INSERT to a bare claim by requiring
+-- status='generating' AND nuggets='[]'. It left `sources` unconstrained,
+-- so a claim row could carry an arbitrary sources payload.
+--
+-- That is not exploitable today: every read path gates on
+-- status === 'ready' before trusting nuggets or sources
+-- (useAINuggets.ts:638, :746, :1179, and pollForReadyNuggets at :274).
+-- But that safety depends on every present and future read site
+-- remembering the gate, which is the weaker guarantee — raised in review
+-- on #125. The constraint costs nothing and moves the guarantee into the
+-- database, where forgetting is not an option.
+--
+-- Matches what the client actually sends when claiming a track
+-- (useAINuggets.ts:709): { track_id, status: 'generating', nuggets: [],
+-- sources: {} }.
+
+DROP POLICY IF EXISTS "nugget_cache_claim" ON public.nugget_cache;
+
+CREATE POLICY "nugget_cache_claim"
+  ON public.nugget_cache FOR INSERT
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR (
+      auth.role() = 'authenticated'
+      AND status = 'generating'
+      AND nuggets = '[]'::jsonb
+      AND sources = '{}'::jsonb
+    )
+  );


### PR DESCRIPTION
Second release of the session. Follows #113.

## What ships

**`useAINuggets` lifecycle tests (#116)** — covers the seam where every bug this session actually lived: *when* generation fires, not what it produces. Proven against the real defect — restoring the dependency array that let a late-arriving artist image wipe the reader's facts fails four of these tests.

**Saved-nugget detail view (#117)** — tapping a saved nugget opened it straight into playback, committing the user before they could re-read it or choose the artist. It now opens with the full nugget and three destinations: play the track, open the artist, or follow the citation. Same action shape as the Browse expanded card.

**Research glow (#117)** — the screen-edge glow breathes while generation or wave-2 is in flight and settles when it finishes. Driven by the same `aiLoading || waveLoading` signal as the pulsating logo, so the two agree by construction. Reduced-motion holds a raised static glow.

**Cache `v3` (#119)** — found during the `artist-updates` deploy. Rows written before the `searchArtist` duplicate-entity fix hold data for the WRONG artist (lamboverrice resolved to a 1-follower stub with an empty catalog). Those rows are incorrect rather than merely stale, so the key had to change or they'd serve for up to the 7-day TTL.

## ⚠️ Repo/production drift this closes

`artist-updates` is **already deployed** with `v3`. The deploy is what exposed the stale-row problem, and leaving wrong-artist data serving while a PR waited seemed worse than shipping first and reconciling after. This PR brings the repo in line with what's live — flagging it explicitly rather than letting anyone discover the drift.

Verified against production after deploying: lamboverrice regenerates fresh and returns 4 playable tracks (`weapons & accessories`, `Blood, Sweat & Shears`, `koolaid kids`, `summer in broward`) where `v2` returned none.

## Notes

- Both #117 changes are mutation-verified: reverting the tap to navigate-straight-to-Listen fails all 8 Profile tests; removing the glow animation class fails 2.
- The saved-nugget artist link uses the search-by-name route, since bookmarks store no artist id. Storing one is a schema change, tracked separately.

## Verification

- `npm test` — 543 passing
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline