### PR TITLE
fix(artist-updates): invalidate cache rows written before the resolution fix

### DIFF
--- a/src/lib/artistFactToNugget.ts
+++ b/src/lib/artistFactToNugget.ts
@@ -22,7 +22,7 @@ export const ARTIST_FACT_ID_PREFIX = "artistfact";
  * function — if the two drift, this silently reads nothing and the
  * feature degrades to "no seed" with no error anywhere.
  */
-export const ARTIST_UPDATES_CACHE_VERSION = "v2";
+export const ARTIST_UPDATES_CACHE_VERSION = "v3";
 
 export function buildArtistUpdatesCacheKey(artistName: string, tier: string): string {
   return `artist::${artistName.trim().toLowerCase()}::${tier}::${ARTIST_UPDATES_CACHE_VERSION}`;

--- a/src/test/artistFactToNugget.test.ts
+++ b/src/test/artistFactToNugget.test.ts
@@ -260,17 +260,17 @@ describe("buildArtistUpdatesCacheKey", () => {
   // — `artist::${artistName.trim().toLowerCase()}::${tier}`. Drift here
   // reads nothing and fails silently, with no error anywhere.
   it("matches the edge function's key format exactly", () => {
-    expect(buildArtistUpdatesCacheKey("Radiohead", "nerd")).toBe("artist::radiohead::nerd::v2");
+    expect(buildArtistUpdatesCacheKey("Radiohead", "nerd")).toBe("artist::radiohead::nerd::v3");
   });
 
   it("lowercases and trims like the edge function does", () => {
     expect(buildArtistUpdatesCacheKey("  Pete Rango  ", "casual"))
-      .toBe("artist::pete rango::casual::v2");
+      .toBe("artist::pete rango::casual::v3");
   });
 
   it("scopes by tier", () => {
     expect(buildArtistUpdatesCacheKey("Flozigg", "curious"))
-      .toBe("artist::flozigg::curious::v2");
+      .toBe("artist::flozigg::curious::v3");
   });
 
   // Rows live 7 days, so without a version segment a SHAPE change stays

--- a/supabase/functions/artist-updates/index.ts
+++ b/supabase/functions/artist-updates/index.ts
@@ -769,10 +769,14 @@ const POLL_INTERVAL_CAP_MS = 8_000;
 // missing whatever the new shape added.
 //
 // v2 — rows gained `kind: "track"` entries for the Browse play targets.
+// v3 — rows written before the searchArtist duplicate-entity fix hold data
+//      for the WRONG artist (lamboverrice resolved to a 1-follower stub with
+//      an empty catalog). Those rows are incorrect, not merely stale, so they
+//      must be invalidated rather than left to age out over 7 days.
 //
 // MUST stay in sync with buildArtistUpdatesCacheKey in
 // src/lib/artistFactToNugget.ts, which reads these rows from the client.
-const CACHE_VERSION = "v2";
+const CACHE_VERSION = "v3";
 
 function cacheKey(artistName: string, tier: string): string {
   // Normalized (lowercased + trimmed) so whitespace / case variations


### PR DESCRIPTION
## Found during the deploy

Deploying v2 surfaced a stale-data problem. lamboverrice returned **zero playable tracks** because its `v2` row was written *before* the `searchArtist` duplicate-entity fix — when we resolved to a 1-follower stub with an empty catalog.

Those rows aren't stale, they're **wrong**, and not just for lamboverrice: any artist with a duplicate Spotify entity could have another artist's data cached at `v2`. Left alone they'd serve incorrect facts and images for up to the 7-day TTL.

## Fix

Bump to `v3`. Same reasoning that justified `v2` — when a row's **content** is invalid rather than merely old, the key has to change so it can't be served.

Both the edge function and the client reader move together; a test asserts the exact literal so they can't drift.

## Verified against production

After deploying v3, lamboverrice regenerates fresh and returns 4 playable tracks — `weapons & accessories`, `Blood, Sweat & Shears`, `koolaid kids`, `summer in broward` — where v2 returned none.

## Cost

One more regeneration pass across every artist row. Small at 5 users, and the alternative is a week of wrong-artist data.

**Note:** the function is already deployed with this change — the deploy is what revealed the problem. This PR brings the repo in line with what's live.