### PR TITLE
fix(a11y): share the dialog focus trap instead of half-copying it

### DIFF
--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader2, X, ExternalLink, Play } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -8,6 +8,7 @@ import { buildListenRoute } from "@/lib/listenRoute";
 import { serviceParamFromProfile, withAppleStorefront } from "@/lib/appleStorefront";
 import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
 import { isSafeUrl } from "@/lib/urlSafety";
+import { useDialogFocusTrap } from "@/hooks/useDialogFocusTrap";
 import type { UserProfile } from "@/mock/types";
 
 /**
@@ -388,8 +389,6 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen, playTarget = n
   const { kindLabel, KindIcon } = getArtistUpdateKindMeta(update.kind);
   const { chipClass } = kindStyle(update.kind);
   const img = update.artistImageUrl;
-  const closeBtnRef = useRef<HTMLButtonElement>(null);
-  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   // Lock document scroll while the modal is open. Without this, the
   // Browse page scrolls behind the open modal on mobile/trackpad —
@@ -404,47 +403,8 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen, playTarget = n
 
   const titleId = `expanded-${layoutId.replace(/[^a-zA-Z0-9_-]/g, "_")}-title`;
 
-  // WCAG focus management: Esc dismisses, focus moves to close button
-  // on open and restores on close, Tab/Shift+Tab cycles within the
-  // dialog only.
-  useEffect(() => {
-    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
-    closeBtnRef.current?.focus();
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      // role="dialog" lives on the inner pointer-events-auto card; the
-      // outer flex wrapper is just a centering layer.
-      const root = closeBtnRef.current?.closest('[role="dialog"]');
-      // (closest('[role="dialog"]') still finds the inner card after
-      // the ARIA move because the close button is a descendant.)
-      if (!root) return;
-      const focusable = Array.from(
-        root.querySelectorAll<HTMLElement>(
-          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    }
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("keydown", onKey);
-      previouslyFocusedRef.current?.focus?.();
-    };
-  }, [onClose]);
+  // Shared with Profile's saved-nugget dialog — see useDialogFocusTrap.
+  const closeBtnRef = useDialogFocusTrap(onClose);
 
   return (
     <>

--- a/src/hooks/useDialogFocusTrap.ts
+++ b/src/hooks/useDialogFocusTrap.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * WCAG focus management for a modal dialog: Escape dismisses, focus moves
+ * to the close button on open and returns to the triggering element on
+ * close, and Tab/Shift+Tab cycle within the dialog only.
+ *
+ * Extracted from ArtistUpdatesSection's ExpandedUpdateModal, which had
+ * the only correct implementation in the app. A second dialog (the saved
+ * nugget on Profile) was written to "match" it visually and shipped
+ * without any of this — a keyboard user could Tab straight through the
+ * backdrop into the page behind, with no way to dismiss. Copying the
+ * behaviour a second time would have set that trap again for the third
+ * dialog, so it lives here now.
+ *
+ * Returns a ref to attach to the dialog's close button. The dialog root
+ * is found from that button via `closest('[role="dialog"]')`, so the
+ * element carrying the role can be an ancestor at any depth.
+ *
+ * `active` exists because callers mount differently. ArtistUpdatesSection
+ * puts its dialog in a child component that mounts when it opens, so the
+ * effect naturally fires at the right moment. Profile renders its dialog
+ * inline from the page, where the hook would otherwise run once at page
+ * load — with no close button to focus — and never again. Pass whether
+ * the dialog is currently open and the effect tracks it.
+ */
+export function useDialogFocusTrap(onClose: () => void, active = true) {
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    closeBtnRef.current?.focus();
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const root = closeBtnRef.current?.closest('[role="dialog"]');
+      if (!root) return;
+      const focusable = Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      // Send focus back where the user left it, not to document.body.
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [onClose, active]);
+
+  return closeBtnRef;
+}

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1771,7 +1771,7 @@ export default function Listen() {
               onNext={handleNext}
               spotifyAlbumArt={spotifyStateTrack?.albumArtUrl}
               researching={aiLoading || waveLoading}
-            isFresh={!aiFromCache}
+              isFresh={!aiFromCache}
             />
           </Suspense>
         )}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeft, Heart, Music, Share2, Trash2, Check, Play, X, ExternalLink } from "lucide-react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
 import { useBookmarks, type Bookmark } from "@/hooks/useBookmarks";
 import PageTransition from "@/components/PageTransition";
 import { AnimatePresence, motion } from "framer-motion";
+import { useDialogFocusTrap } from "@/hooks/useDialogFocusTrap";
 import { isSafeUrl } from "@/lib/urlSafety";
 
 // Group bookmarks into date buckets for a scannable profile page. Exact
@@ -58,6 +59,14 @@ export default function Profile() {
     () => bookmarks.find((b) => b.id === openId) ?? null,
     [bookmarks, openId],
   );
+  // Validated once rather than on each render branch that needs it.
+  const sourceUrl = openBookmark ? sourceUrlOf(openBookmark) : null;
+  const closeDetail = useCallback(() => setOpenId(null), []);
+  // Same Escape / focus-trap / focus-restore behaviour as the Browse
+  // expanded card. This dialog was written to match that one visually
+  // and shipped without any of it, so a keyboard user could Tab straight
+  // through the backdrop with no way to dismiss.
+  const closeBtnRef = useDialogFocusTrap(closeDetail, !!openBookmark);
 
   async function handleShare(bm: Bookmark) {
     const url = `${window.location.origin}${listenUrlFor(bm)}`;
@@ -254,13 +263,13 @@ export default function Profile() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={() => setOpenId(null)}
-            role="dialog"
-            aria-modal="true"
-            aria-label={openBookmark.headline}
+            onClick={closeDetail}
           >
             <motion.div
               className="relative w-full max-w-md bg-neutral-950 rounded-2xl overflow-hidden ring-1 ring-white/10 max-h-[85vh] flex flex-col"
+              role="dialog"
+              aria-modal="true"
+              aria-label={openBookmark.headline}
               initial={{ y: 24, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: 24, opacity: 0 }}
@@ -275,7 +284,8 @@ export default function Profile() {
               )}
 
               <button
-                onClick={() => setOpenId(null)}
+                ref={closeBtnRef}
+                onClick={closeDetail}
                 aria-label="Close"
                 className="absolute top-3 right-3 z-10 w-9 h-9 rounded-full bg-black/50 backdrop-blur-sm ring-1 ring-white/20 flex items-center justify-center active:scale-95 transition-transform"
               >
@@ -309,9 +319,9 @@ export default function Profile() {
                       <span className="truncate">{openBookmark.artist}</span>
                       <ExternalLink className="w-3 h-3 shrink-0" />
                     </button>
-                    {sourceUrlOf(openBookmark) && (
+                    {sourceUrl && (
                       <a
-                        href={sourceUrlOf(openBookmark)!}
+                        href={sourceUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors"

--- a/src/test/ProfileSavedNugget.test.tsx
+++ b/src/test/ProfileSavedNugget.test.tsx
@@ -141,3 +141,69 @@ describe("Profile — deciding where to go", () => {
     expect(within(openDialog()!).queryByRole("link", { name: /source/i })).toBeNull();
   });
 });
+
+// ── Keyboard access ───────────────────────────────────────────────────
+// Flagged in review: this dialog was written to "match the Browse
+// expanded card" but shipped without any of that card's focus
+// management, so a keyboard user could Tab through the backdrop into the
+// page behind with no way to dismiss. Both now share
+// useDialogFocusTrap, and these assert the behaviour rather than the
+// sharing.
+describe("Profile — saved-nugget dialog keyboard access", () => {
+  it("dismisses on Escape", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+    expect(openDialog()).not.toBeNull();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(openDialog()).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("moves focus into the dialog on open", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it("returns focus to the card that opened it", () => {
+    renderProfile();
+    // Focus the trigger first — that's the keyboard path, and jsdom's
+    // click alone doesn't move focus the way a real browser does.
+    const trigger = screen.getByText(BOOKMARK.headline).closest("button")!;
+    trigger.focus();
+    fireEvent.click(trigger);
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /close/i }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    // Focus goes back where the user left it, not stranded on the body.
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("keeps Tab inside the dialog rather than reaching the page behind", () => {
+    renderProfile();
+    fireEvent.click(screen.getByText(BOOKMARK.headline));
+
+    const dialog = openDialog()!;
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    expect(focusable.length).toBeGreaterThan(1);
+
+    // Tabbing forward off the last element wraps to the first.
+    focusable[focusable.length - 1].focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(focusable[0]);
+
+    // Shift+Tab off the first wraps to the last.
+    focusable[0].focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
+  });
+});


### PR DESCRIPTION
## From review on #118

The saved-nugget dialog was described as matching the Browse expanded card. It matched it **visually only**.

Browse's `ExpandedUpdateModal` implements Escape-to-close, focus-into-dialog on open, a Tab/Shift+Tab trap, and focus restoration on close. Profile's had **none** — a keyboard user could Tab straight through the backdrop into the page behind, with no way to dismiss it.

The reviewer was right that the claim and the code disagreed.

## Fix

Extract Browse's implementation into `useDialogFocusTrap` and use it in both, so they agree by construction rather than by assertion. Copying it a second time would have set the same trap for the third dialog.

**One thing the wiring exposed:** the hook needed an `active` flag, because the callers mount differently. Browse renders its dialog in a child component that mounts on open, so the effect fires at the right moment. Profile renders inline from the page — the effect ran once at page load, with no close button to focus, and never again. A test caught it: focus-on-open failed until the effect tracked open state.

## Also from review

- `sourceUrlOf` was validating the same URL twice per render — computed once now
- `isFresh` had lost two spaces of indentation

## Tests

Four, covering the behaviour rather than the sharing: Escape dismisses, focus lands in the dialog on open, focus returns to the card that opened it, and Tab wraps inside the dialog in both directions.

Mutation-verified: removing Escape handling and focus restoration fails two of them.

## Verification

- `npm test` — 547 passing (4 new)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline