### PR TITLE
fix(nav): stop the old page lingering after the URL changes

### DIFF
--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -6,7 +6,18 @@ export default function PageTransition({ children }: { children: ReactNode }) {
     <motion.div
       initial={{ opacity: 0, scale: 0.98, y: 10 }}
       animate={{ opacity: 1, scale: 1, y: 0 }}
-      exit={{ opacity: 0, scale: 0.98, y: -10 }}
+      // Per-variant transition — a top-level `transition` prop would be
+      // overridden by nothing and an `exitTransition` prop does not exist
+      // in framer-motion, so the override has to live inside the variant.
+      exit={{ opacity: 0, scale: 0.98, y: -10, transition: { duration: 0.18, ease: "easeIn" } }}
+      // App.tsx wraps routes in <AnimatePresence mode="wait">, so the
+      // incoming page cannot mount until this exit finishes. At 0.5s the
+      // user watched the OLD page for half a second after the URL had
+      // already changed — most visible when leaving a full-screen modal,
+      // where the card appeared to stay open on the new page (Pete: "it
+      // takes me to the artist page but the card stays open so I don't
+      // see that I'm in the artist page"). Exits are dead time; only the
+      // entrance needs to feel considered.
       transition={{ duration: 0.5, ease: "easeOut" }}
       className="min-h-screen w-full"
     >

--- a/src/test/ArtistUpdatesModal.test.tsx
+++ b/src/test/ArtistUpdatesModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ArtistUpdateGroup } from "@/hooks/useArtistUpdates";
+
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock());
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import ArtistUpdatesSection from "@/components/ArtistUpdatesSection";
+
+const GROUP: ArtistUpdateGroup = {
+  artistName: "Turnover",
+  updates: [
+    {
+      artistId: "art-1",
+      artistName: "Turnover",
+      artistImageUrl: "https://example.com/turnover.jpg",
+      kind: "fact",
+      headline: "Turnover tracked the record with their live engineer.",
+      body: "They brought him into the studio to capture the room.",
+      nuggetId: "n-1",
+      source: { type: "article", title: "t", publisher: "BrooklynVegan", url: "https://bv.com/x" },
+    },
+    {
+      artistId: "art-1",
+      artistName: "Turnover",
+      artistImageUrl: "https://example.com/cover.jpg",
+      kind: "track",
+      headline: "Humming",
+      body: "",
+      relatedTrackTitle: "Humming",
+      relatedAlbumName: "Peripheral Vision",
+      relatedTrackUri: "spotify:track:abc123",
+    },
+  ],
+};
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <ArtistUpdatesSection
+        groups={[GROUP]}
+        profile={{ streamingService: "Spotify" } as never}
+        artistIds={{ Turnover: "art-1" }}
+        totalCount={1}
+        readyCount={1}
+      />
+    </MemoryRouter>,
+  );
+}
+
+const dialog = () => screen.queryByRole("dialog");
+
+beforeEach(() => navigateMock.mockReset());
+
+describe("Browse expanded card — leaving it", () => {
+  it("opens when a card is tapped", () => {
+    renderSection();
+    expect(dialog()).toBeNull();
+
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    expect(dialog()).not.toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  // Pete: "when I click to go to an artist page from a card in the browse
+  // page, it takes me to the artist page but the card stays open so I
+  // don't see that I'm in the artist page."
+  //
+  // The dominant cause was the 500ms page exit under AnimatePresence
+  // mode="wait", which held Browse on screen after the URL changed. But
+  // the modal must also actually close — if it only navigated, the card
+  // would sit over the new page for as long as the transition ran.
+  it("closes the card when navigating to the artist", () => {
+    renderSection();
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    fireEvent.click(within(dialog()!).getByRole("button", { name: /^turnover$/i }));
+
+    expect(dialog()).toBeNull();
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0][0]).toContain("/artist/");
+  });
+
+  it("closes the card when starting playback", () => {
+    renderSection();
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    fireEvent.click(within(dialog()!).getByRole("button", { name: /play humming by turnover/i }));
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0][0]).toContain("/listen/");
+  });
+
+  it("closes without navigating when dismissed", () => {
+    renderSection();
+    fireEvent.click(screen.getByText(GROUP.updates![0].headline));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(dialog()).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Cause

`App.tsx` wraps routes in `<AnimatePresence mode="wait">`. That means the **incoming page cannot mount until the outgoing one finishes exiting** — and `PageTransition`'s exit ran **500ms**.

So on every navigation the URL changed and you kept looking at the old page for half a second. Most obvious when leaving a full-screen modal: the card is `fixed inset-0`, so it sat on top for the whole transition and read as *"the card stayed open on the artist page."*

## Fix

Exits are dead time — only the entrance needs to feel considered. Exit drops to **180ms**; the entrance keeps its 500ms.

One trap worth recording: the override has to live **inside the `exit` variant**. framer-motion has no `exitTransition` prop, and my first attempt used one — it would have been silently ignored while looking correct in the diff.

## Tests

The modal's own dismissal was already correct (`modalOnOpen` clears the key before navigating) but **had no test**, so nothing stopped a future change from navigating with the card still up.

Four tests now cover leaving the expanded card: opening, closing on artist navigation, closing on playback, dismissing without navigating. Mutation-verified — removing the close-before-navigate fails one.

## ⚠️ Caveat

**Diagnosed from code, not reproduced.** The localhost session had expired (redirected to `/connect`), so I couldn't drive the actual flow. The mechanism is confirmed in source — `mode="wait"` plus a 500ms exit — but I haven't watched the fix land in a browser.

Worth a look on staging before trusting it.

## Verification

- `npm test` — 547 passing (4 new)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline