### PR TITLE
fix(images): stop firing concurrent artwork bursts at Spotify

### DIFF
--- a/src/components/ArtistImage.tsx
+++ b/src/components/ArtistImage.tsx
@@ -1,4 +1,5 @@
 import { useArtistImage } from "@/hooks/useArtistImage";
+import RemoteImage from "@/components/RemoteImage";
 
 interface Props {
   artistName: string;
@@ -15,7 +16,7 @@ export default function ArtistImage({ artistName, fallbackUrl, alt, className }:
   const imageUrl = useArtistImage(artistName, fallbackUrl);
 
   return (
-    <img
+    <RemoteImage
       src={imageUrl}
       alt={alt || artistName}
       className={className}

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -424,6 +424,8 @@ function ExpandedUpdateModal({ update, layoutId, onClose, onOpen, playTarget = n
             {img ? (
               <motion.img
                 layoutId={`${layoutId}::img`}
+                loading="eager"
+                decoding="async"
                 src={img}
                 alt=""
                 className="absolute inset-0 w-full h-full object-cover"

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -8,6 +8,7 @@ import { buildListenRoute } from "@/lib/listenRoute";
 import { serviceParamFromProfile, withAppleStorefront } from "@/lib/appleStorefront";
 import { getArtistUpdateKindMeta } from "@/lib/artistUpdateKind";
 import { isSafeUrl } from "@/lib/urlSafety";
+import RemoteImage from "@/components/RemoteImage";
 import { useDialogFocusTrap } from "@/hooks/useDialogFocusTrap";
 import type { UserProfile } from "@/mock/types";
 
@@ -240,15 +241,14 @@ function ArtistRow({ group, onExpand, onPlay }: ArtistRowProps) {
   return (
     <div>
       <div className="px-4 md:px-10 mb-3 flex items-center gap-3">
-        {heroImg ? (
-          <img
-            src={heroImg}
-            alt={`${group.artistName} avatar`}
-            className="w-14 h-14 rounded-full object-cover ring-2 ring-white/10 shadow-lg"
-          />
-        ) : (
-          <div className="w-14 h-14 rounded-full bg-gradient-to-br from-rose-400/40 to-pink-500/40 ring-2 ring-white/10" />
-        )}
+        <RemoteImage
+          src={heroImg}
+          alt={`${group.artistName} avatar`}
+          className="w-14 h-14 rounded-full object-cover ring-2 ring-white/10 shadow-lg"
+          fallback={
+            <div className="w-14 h-14 rounded-full bg-gradient-to-br from-rose-400/40 to-pink-500/40 ring-2 ring-white/10" />
+          }
+        />
         <span className="text-lg md:text-xl font-black text-white tracking-tight">
           {group.artistName}
         </span>
@@ -323,22 +323,14 @@ export function UpdateCard({ update, layoutId, onClick, sizeClass = "shrink-0 w-
       }`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
-      {img ? (
-        <motion.img
-          layoutId={`${layoutId}::img`}
-          src={img}
-          alt=""
-          className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
-          onError={(e) => {
-            (e.currentTarget as HTMLImageElement).style.display = "none";
-          }}
-        />
-      ) : (
-        <motion.div
-          layoutId={`${layoutId}::img`}
-          className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15"
-        />
-      )}
+      <RemoteImage
+        src={img}
+        alt=""
+        className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
+        fallback={
+          <div className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15" />
+        }
+      />
       <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/45 to-black/10" />
       <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-2xl pointer-events-none" />
       <span className={`absolute top-3 left-3 inline-flex items-center gap-1 text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-full backdrop-blur-sm ${chipClass}`}>

--- a/src/components/ArtistUpdatesSection.tsx
+++ b/src/components/ArtistUpdatesSection.tsx
@@ -323,12 +323,19 @@ export function UpdateCard({ update, layoutId, onClick, sizeClass = "shrink-0 w-
       }`}
       aria-label={`${kindLabel}: ${update.headline}`}
     >
+      {/* Source end of the shared-element morph — the same layoutId as
+          ExpandedUpdateModal's hero, on the loaded image AND the empty
+          state, so the photo scales into the modal instead of cutting. */}
       <RemoteImage
         src={img}
         alt=""
+        layoutId={`${layoutId}::img`}
         className="absolute inset-0 w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-500"
         fallback={
-          <div className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15" />
+          <motion.div
+            layoutId={`${layoutId}::img`}
+            className="absolute inset-0 bg-gradient-to-br from-rose-500/30 via-violet-500/20 to-sky-500/15"
+          />
         }
       />
       <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/45 to-black/10" />

--- a/src/components/NowPlayingBar.tsx
+++ b/src/components/NowPlayingBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Play, Pause, SkipBack, SkipForward, Smartphone } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -133,11 +134,12 @@ export default function NowPlayingBar() {
                   className="flex flex-1 items-center gap-3 min-w-0 text-left"
                 >
                   {externalPlayback.albumArtUrl ? (
-                    <img
+                    <RemoteImage
                       src={externalPlayback.albumArtUrl}
                       alt=""
+                      eager
                       className="h-10 w-10 rounded-lg object-cover shrink-0"
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                      fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10 shrink-0" />}
                     />
                   ) : (
                     <div className="h-10 w-10 rounded-lg bg-foreground/10 shrink-0 flex items-center justify-center">
@@ -163,11 +165,12 @@ export default function NowPlayingBar() {
                   onClick={() => navigate(listenUrl!)}
                   className={`flex flex-1 items-center gap-3 min-w-0 text-left rounded-lg transition-all ${npbFocusClass(0)}`}
                 >
-                  <img
+                  <RemoteImage
                     src={currentTrack.coverArtUrl}
                     alt=""
+                    eager
                     className="h-10 w-10 rounded-lg object-cover shrink-0"
-                    onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+                    fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10 shrink-0" />}
                   />
                   <div className="min-w-0">
                     <p className="text-sm font-bold text-foreground truncate">{currentTrack.title}</p>

--- a/src/components/NuggetCard.tsx
+++ b/src/components/NuggetCard.tsx
@@ -152,6 +152,8 @@ export default function NuggetCard({ nugget, animationStyle, onSourceClick, curr
               <img
                 src={nugget.imageUrl}
                 alt={nugget.imageCaption || nugget.headline || ""}
+                loading="lazy"
+                decoding="async"
                 className="w-full rounded-xl object-contain"
                 style={{ maxHeight: "380px", minHeight: "160px", display: imgLoaded ? "block" : "none" }}
                 onLoad={() => setImgLoaded(true)}

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
 
 /**
  * An <img> for third-party artwork (Spotify's i.scdn.co, mostly).
@@ -38,6 +39,13 @@ interface RemoteImageProps {
    *  mini-player, an open overlay's hero. Deferring those only delays
    *  something the user is already looking at. */
   eager?: boolean;
+  /** Renders as a `motion.img` carrying this layoutId, so Framer Motion
+   *  can morph it into a matching element elsewhere — the artist card
+   *  thumbnail growing into the expanded modal's hero. Both ends of a
+   *  morph need the same id; supplying it on only one side hard-cuts.
+   *  Omit it and this renders a plain <img>, which is what nearly every
+   *  call site wants. */
+  layoutId?: string;
   onLoad?: () => void;
 }
 
@@ -52,6 +60,7 @@ export default function RemoteImage({
   className,
   fallback = null,
   eager = false,
+  layoutId,
   onLoad,
 }: RemoteImageProps) {
   const [failed, setFailed] = useState(false);
@@ -98,15 +107,20 @@ export default function RemoteImage({
 
   if (!src || failed) return <>{fallback}</>;
 
-  return (
-    <img
-      src={attemptSrc}
-      alt={alt}
-      className={className}
-      loading={eager ? "eager" : "lazy"}
-      decoding="async"
-      onError={handleError}
-      onLoad={onLoad}
-    />
-  );
+  const imgProps = {
+    src: attemptSrc,
+    alt,
+    className,
+    loading: eager ? ("eager" as const) : ("lazy" as const),
+    decoding: "async" as const,
+    onError: handleError,
+    onLoad,
+  };
+
+  // Deferral survives the morph — a card that animates into a modal is
+  // still offscreen artwork until it is scrolled to, and it was the
+  // bulk of the original burst.
+  if (layoutId) return <motion.img layoutId={layoutId} {...imgProps} />;
+
+  return <img {...imgProps} />;
 }

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * An <img> for third-party artwork (Spotify's i.scdn.co, mostly).
+ *
+ * Exists because Browse was firing ~53 simultaneous requests at
+ * i.scdn.co on load — every artist avatar, update card, and catalog
+ * tile across ~3.4 screens of content, none of them deferred. Spotify
+ * throttles a burst that size and answers most of it with 503, so the
+ * page rendered as a wall of black cards. The identical URLs load in
+ * ~120ms when requested individually, which is what made it look like
+ * an outage rather than something we were doing.
+ *
+ * That failure is a threshold effect, not a regression: it appeared
+ * once the image count grew past what the CDN would serve at once, with
+ * no deploy involved. It will recur — and worsen — as the catalog grows,
+ * which is why this is a shared component rather than a fix at one site.
+ *
+ * Three behaviours, in order of importance:
+ *
+ *  1. `loading="lazy"` so offscreen artwork is not requested until it is
+ *     near the viewport. This is the actual fix — it cuts the initial
+ *     burst by roughly an order of magnitude.
+ *  2. One retry with backoff. A 503 is transient by definition, and a
+ *     single retry recovers the ones that still slip through.
+ *  3. A designed fallback. If it ultimately fails, render the same
+ *     placeholder used when there is no artwork at all, rather than
+ *     leaving a hole where the image should be.
+ */
+interface RemoteImageProps {
+  src?: string | null;
+  alt?: string;
+  className?: string;
+  /** Rendered instead of the image when src is missing or every attempt
+   *  fails. Without this a failure leaves a blank element. */
+  fallback?: React.ReactNode;
+  /** Skip lazy loading for artwork that is always above the fold — the
+   *  mini-player, an open overlay's hero. Deferring those only delays
+   *  something the user is already looking at. */
+  eager?: boolean;
+  onLoad?: () => void;
+}
+
+const RETRY_DELAY_MS = 700;
+
+export default function RemoteImage({
+  src,
+  alt = "",
+  className,
+  fallback = null,
+  eager = false,
+  onLoad,
+}: RemoteImageProps) {
+  const [failed, setFailed] = useState(false);
+  // Cache-busted retry URL. Kept in state so the retry is a real second
+  // request rather than the browser replaying its cached failure.
+  const [attemptSrc, setAttemptSrc] = useState(src ?? undefined);
+  const retriedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // A new src is a new image — reset, or a previously failed URL would
+  // keep the fallback showing for a perfectly good replacement.
+  useEffect(() => {
+    setFailed(false);
+    setAttemptSrc(src ?? undefined);
+    retriedRef.current = false;
+  }, [src]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const handleError = useCallback(() => {
+    if (!src) { setFailed(true); return; }
+    if (retriedRef.current) { setFailed(true); return; }
+    retriedRef.current = true;
+    // Backoff before retrying: an immediate retry rejoins the same burst
+    // that caused the throttle in the first place.
+    timerRef.current = setTimeout(() => {
+      setAttemptSrc(`${src}${src.includes("?") ? "&" : "?"}r=1`);
+    }, RETRY_DELAY_MS);
+  }, [src]);
+
+  if (!src || failed) return <>{fallback}</>;
+
+  return (
+    <img
+      src={attemptSrc}
+      alt={alt}
+      className={className}
+      loading={eager ? "eager" : "lazy"}
+      decoding="async"
+      onError={handleError}
+      onLoad={onLoad}
+    />
+  );
+}

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -42,6 +42,9 @@ interface RemoteImageProps {
 }
 
 const RETRY_DELAY_MS = 700;
+/** Underscore-prefixed so it cannot collide with a real query param if
+ *  this component is ever pointed at something other than Spotify. */
+const RETRY_PARAM = "_retry=1";
 
 export default function RemoteImage({
   src,
@@ -60,7 +63,19 @@ export default function RemoteImage({
 
   // A new src is a new image — reset, or a previously failed URL would
   // keep the fallback showing for a perfectly good replacement.
+  //
+  // Cancelling a pending retry here is load-bearing, not tidiness. A
+  // scheduled retry holds the PREVIOUS src in its closure; if the prop
+  // moves on before it fires, it writes the old URL over the new one
+  // ~700ms later and can drop a perfectly good image into the fallback.
+  // That collision is likeliest during exactly the burst this component
+  // exists for: several images sit mid-backoff while ArtistRow's heroImg
+  // recomputes as facts stream in.
   useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     setFailed(false);
     setAttemptSrc(src ?? undefined);
     retriedRef.current = false;
@@ -77,7 +92,7 @@ export default function RemoteImage({
     // Backoff before retrying: an immediate retry rejoins the same burst
     // that caused the throttle in the first place.
     timerRef.current = setTimeout(() => {
-      setAttemptSrc(`${src}${src.includes("?") ? "&" : "?"}r=1`);
+      setAttemptSrc(`${src}${src.includes("?") ? "&" : "?"}${RETRY_PARAM}`);
     }, RETRY_DELAY_MS);
   }, [src]);
 

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { useNavigate } from "react-router-dom";
 import { Search, X, Loader2 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -159,7 +160,8 @@ export default function SearchOverlay({ open, onClose }: Props) {
                               className="flex items-center gap-3 rounded-xl bg-foreground/5 p-3 pr-6 transition-colors hover:bg-foreground/10"
                             >
                               {a.imageUrl ? (
-                                <img src={a.imageUrl} alt={a.name} className="h-12 w-12 rounded-full object-cover" />
+                                <RemoteImage src={a.imageUrl} alt={a.name} className="h-12 w-12 rounded-full object-cover"
+                                  fallback={<div className="h-12 w-12 rounded-full bg-foreground/10" />} />
                               ) : (
                                 <div className="h-12 w-12 rounded-full bg-foreground/10 flex items-center justify-center text-muted-foreground text-lg font-bold">
                                   {a.name[0]}
@@ -183,7 +185,8 @@ export default function SearchOverlay({ open, onClose }: Props) {
                               className="flex w-full items-center gap-4 rounded-xl p-3 transition-colors hover:bg-foreground/5 text-left"
                             >
                               {t.imageUrl ? (
-                                <img src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover" />
+                                <RemoteImage src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover"
+                                  fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10" />} />
                               ) : (
                                 <div className="h-10 w-10 rounded-lg bg-foreground/10" />
                               )}

--- a/src/components/StoriesRail.tsx
+++ b/src/components/StoriesRail.tsx
@@ -168,6 +168,8 @@ export default function StoriesRail({ stories }: StoriesRailProps) {
                 <div className="w-full h-full rounded-full bg-background overflow-hidden p-[2px]">
                   {s.imageUrl ? (
                     <img
+                      loading="lazy"
+                      decoding="async"
                       src={s.imageUrl}
                       alt=""
                       className="w-full h-full rounded-full object-cover"

--- a/src/components/TileRow.tsx
+++ b/src/components/TileRow.tsx
@@ -110,22 +110,19 @@ export default function TileRow({ label, items, tileSize = "md", focusedIndex = 
                 onMouseLeave={(e) => handleTileLeave(e.currentTarget, isFocused)}
               >
                 <div className="absolute inset-0 rounded-xl overflow-hidden">
-                  {item.imageUrl ? (
-                    <RemoteImage
-                      src={item.imageUrl}
-                      alt={item.title}
-                      className="h-full w-full object-cover"
-                      fallback={
-                        <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
-                          <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
-                        </div>
-                      }
-                    />
-                  ) : (
-                    <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
-                      <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
-                    </div>
-                  )}
+                  {/* No outer ternary — RemoteImage renders `fallback`
+                      whenever src is missing OR every attempt fails, so
+                      guarding here would only duplicate the placeholder. */}
+                  <RemoteImage
+                    src={item.imageUrl}
+                    alt={item.title}
+                    className="h-full w-full object-cover"
+                    fallback={
+                      <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
+                        <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
+                      </div>
+                    }
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
                 </div>
                 <div className="absolute bottom-0 left-0 right-0 p-2 md:p-3 z-10">

--- a/src/components/TileRow.tsx
+++ b/src/components/TileRow.tsx
@@ -1,3 +1,4 @@
+import RemoteImage from "@/components/RemoteImage";
 import { useRef, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -110,11 +111,15 @@ export default function TileRow({ label, items, tileSize = "md", focusedIndex = 
               >
                 <div className="absolute inset-0 rounded-xl overflow-hidden">
                   {item.imageUrl ? (
-                    <img
+                    <RemoteImage
                       src={item.imageUrl}
                       alt={item.title}
                       className="h-full w-full object-cover"
-                      onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+                      fallback={
+                        <div className="h-full w-full bg-foreground/10 flex items-center justify-center">
+                          <span className="text-xl md:text-2xl font-bold text-foreground/30">{item.title?.[0] || "?"}</span>
+                        </div>
+                      }
                     />
                   ) : (
                     <div className="h-full w-full bg-foreground/10 flex items-center justify-center">

--- a/src/components/companion/CompanionNuggetCard.tsx
+++ b/src/components/companion/CompanionNuggetCard.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink, ChevronRight } from "lucide-react";
+import RemoteImage from "@/components/RemoteImage";
 import type { CompanionNugget } from "@/mock/types";
 
 interface Props {
@@ -12,11 +13,10 @@ export default function CompanionNuggetCard({ nugget, onDeepDive }: Props) {
       {/* Image */}
       {nugget.imageUrl && (
         <div className="w-full">
-          <img
+          <RemoteImage
             src={nugget.imageUrl}
             alt={nugget.imageCaption || nugget.headline || ""}
             className="w-full object-contain max-h-56"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
           />
           {nugget.imageCaption && (
             <p className="px-4 py-1.5 text-xs text-muted-foreground italic">{nugget.imageCaption}</p>

--- a/src/components/immersive/ImmersiveNuggetView.tsx
+++ b/src/components/immersive/ImmersiveNuggetView.tsx
@@ -512,6 +512,8 @@ export default function ImmersiveNuggetView({
             <img
               src={imgUrl}
               alt=""
+              loading="eager"
+              decoding="async"
               className="absolute inset-0 w-full h-full object-cover"
               onError={() => {
                 if (isNuggetImage && activeNugget?.imageUrl) {
@@ -697,7 +699,7 @@ export default function ImmersiveNuggetView({
       {/* Background */}
       <div className="absolute inset-0 pointer-events-none">
         {artUrl && (
-          <img src={artUrl} alt="" className="absolute inset-0 w-full h-full object-cover"
+          <img src={artUrl} alt="" loading="eager" decoding="async" className="absolute inset-0 w-full h-full object-cover"
             style={{ filter: "blur(48px) brightness(0.25) saturate(1.4)", transform: "scale(1.3)" }} />
         )}
         <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-transparent to-black/60" />
@@ -777,6 +779,8 @@ export default function ImmersiveNuggetView({
               <img
                 src={artUrl}
                 alt=""
+                loading="eager"
+                decoding="async"
                 className={`w-56 h-56 rounded-2xl shadow-2xl object-cover opacity-80 ${
                   isPlaying ? "animate-cover-pulse" : ""
                 }`}

--- a/src/components/immersive/MiniPlayer.tsx
+++ b/src/components/immersive/MiniPlayer.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { Play, Pause, SkipBack, SkipForward } from "lucide-react";
 
 interface MiniPlayerProps {
@@ -100,7 +101,8 @@ export default function MiniPlayer({
       {/* Player content */}
       <div className="flex items-center gap-2 px-3 py-2">
         {artUrl && (
-          <img src={artUrl} alt="" className="w-10 h-10 rounded-lg object-cover flex-shrink-0" />
+          <RemoteImage src={artUrl} alt="" eager className="w-10 h-10 rounded-lg object-cover flex-shrink-0"
+            fallback={<div className="w-10 h-10 rounded-lg bg-foreground/10 flex-shrink-0" />} />
         )}
         <div className="flex-1 min-w-0 overflow-hidden">
           {/* ~25 chars fits the mini player at 375px width with controls.

--- a/src/components/overlays/NuggetDeepDive.tsx
+++ b/src/components/overlays/NuggetDeepDive.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronRight, ExternalLink, ArrowLeft, Loader2 } from "lucide-react";
 import type { Nugget, Source } from "@/mock/types";
@@ -237,11 +238,11 @@ export default function NuggetDeepDive({ nugget, source, artist, trackTitle, onC
                 animate={{ opacity: 1, transition: { delay: 0.2, duration: 0.3 } }}
                 className="flex-shrink-0 md:w-[45%] flex flex-col"
               >
-                <img
+                <RemoteImage
                   src={nugget.imageUrl}
                   alt={nugget.imageCaption || nugget.headline || ""}
+                  eager
                   className="w-full max-h-[35vh] md:max-h-[45vh] object-contain rounded-lg"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                 />
                 {nugget.imageCaption && (
                   <p className="text-xs text-muted-foreground mt-1.5 italic text-center">{nugget.imageCaption}</p>

--- a/src/components/overlays/ReadingOverlay.tsx
+++ b/src/components/overlays/ReadingOverlay.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import RemoteImage from "@/components/RemoteImage";
 import { X, ExternalLink, FileText, Mic } from "lucide-react";
 import type { Source } from "@/mock/types";
 import { isSafeUrl } from "@/lib/urlSafety";
@@ -59,7 +60,7 @@ export default function ReadingOverlay({ source, onClose }: Props) {
         )}
 
         {source.thumbnailUrl && (
-          <img src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" />
+          <RemoteImage src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" fallback={null} />
         )}
 
         {/* Spacer to push actions to bottom */}

--- a/src/components/overlays/ReadingOverlay.tsx
+++ b/src/components/overlays/ReadingOverlay.tsx
@@ -60,7 +60,7 @@ export default function ReadingOverlay({ source, onClose }: Props) {
         )}
 
         {source.thumbnailUrl && (
-          <RemoteImage src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" fallback={null} />
+          <RemoteImage src={source.thumbnailUrl} alt="" className="rounded-xl w-full object-cover max-h-48" />
         )}
 
         {/* Spacer to push actions to bottom */}

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -320,6 +320,7 @@ function CatalogAlbumInner({
           <RemoteImage
             src={album.imageUrl}
             alt=""
+            eager
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
           />
         </div>
@@ -498,6 +499,7 @@ function MockAlbumInner({
           <RemoteImage
             src={album.coverArtUrl}
             alt=""
+            eager
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
           />
         </div>

--- a/src/pages/AlbumDetail.tsx
+++ b/src/pages/AlbumDetail.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import RemoteImage from "@/components/RemoteImage";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getAlbumById, getTracksForAlbum, getArtistById } from "@/mock/tracks";
@@ -316,7 +317,7 @@ function CatalogAlbumInner({
       {/* Hero */}
       <div className="relative overflow-hidden">
         <div className="absolute inset-0">
-          <img
+          <RemoteImage
             src={album.imageUrl}
             alt=""
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
@@ -334,10 +335,12 @@ function CatalogAlbumInner({
         </button>
 
         <div className="relative z-10 flex flex-col md:flex-row items-center md:items-end gap-4 md:gap-8 px-4 md:px-10 pb-6 md:pb-10">
-          <img
+          <RemoteImage
             src={album.imageUrl}
             alt={album.name}
+            eager
             className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl object-cover"
+            fallback={<div className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl bg-foreground/10" />}
           />
           <div className="pb-2 text-center md:text-left">
             <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-1">
@@ -492,7 +495,7 @@ function MockAlbumInner({
     <div className="min-h-screen bg-background">
       <div className="relative overflow-hidden">
         <div className="absolute inset-0">
-          <img
+          <RemoteImage
             src={album.coverArtUrl}
             alt=""
             className="h-full w-full object-cover blur-[20px] scale-125 brightness-[0.3]"
@@ -510,10 +513,12 @@ function MockAlbumInner({
         </button>
 
         <div className="relative z-10 flex flex-col md:flex-row items-center md:items-end gap-4 md:gap-8 px-4 md:px-10 pb-6 md:pb-10">
-          <img
+          <RemoteImage
             src={album.coverArtUrl}
             alt={album.title}
+            eager
             className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl object-cover"
+            fallback={<div className="h-36 w-36 md:h-48 md:w-48 rounded-2xl shadow-2xl bg-foreground/10" />}
           />
           <div className="pb-2 text-center md:text-left">
             <p className="text-xs font-bold uppercase tracking-wider text-muted-foreground mb-1">

--- a/src/pages/ArtistProfile.tsx
+++ b/src/pages/ArtistProfile.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import RemoteImage from "@/components/RemoteImage";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getArtistById, getAlbumsForArtist, getTracksForArtist, artists } from "@/mock/tracks";
@@ -438,9 +439,10 @@ function RealArtistProfileInner({ artist, trackTiles, albumTiles, relatedTiles }
     <div className="min-h-screen bg-background">
       {/* Hero */}
       <div className="relative h-60 md:h-80 overflow-hidden">
-        <img
+        <RemoteImage
           src={heroImage}
           alt={artist.name}
+          eager
           className="h-full w-full object-cover blur-[8px] scale-110 brightness-[0.4]"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/40 to-transparent" />
@@ -509,7 +511,8 @@ function RealArtistProfileInner({ artist, trackTiles, albumTiles, relatedTiles }
               >
                 <span className="w-6 text-center text-sm text-muted-foreground tabular-nums">{i + 1}</span>
                 {t.imageUrl ? (
-                  <img src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover" />
+                  <RemoteImage src={t.imageUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover"
+                    fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10" />} />
                 ) : (
                   <div className="h-10 w-10 rounded-lg bg-foreground/10" />
                 )}
@@ -647,9 +650,10 @@ function MockArtistProfileInner({ artist, tracksData, albumTiles, relatedTiles }
     <div className="min-h-screen bg-background">
       {/* Hero */}
       <div className="relative h-60 md:h-80 overflow-hidden">
-        <img
+        <RemoteImage
           src={heroImage}
           alt={artist.name}
+          eager
           className="h-full w-full object-cover blur-[8px] scale-110 brightness-[0.4]"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/40 to-transparent" />
@@ -697,7 +701,8 @@ function MockArtistProfileInner({ artist, tracksData, albumTiles, relatedTiles }
               }`}
             >
               <span className="w-6 text-center text-sm text-muted-foreground tabular-nums">{i + 1}</span>
-              <img src={t.coverArtUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover" />
+              <RemoteImage src={t.coverArtUrl} alt={t.title} className="h-10 w-10 rounded-lg object-cover"
+                fallback={<div className="h-10 w-10 rounded-lg bg-foreground/10" />} />
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-bold text-foreground truncate">{t.title}</p>
                 <p className="text-xs text-muted-foreground truncate">{t.album}</p>

--- a/src/pages/Companion.tsx
+++ b/src/pages/Companion.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import RemoteImage from "@/components/RemoteImage";
 import { useState, useEffect, useMemo } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useArtistImage } from "@/hooks/useArtistImage";
@@ -206,11 +207,11 @@ export default function Companion() {
       {/* Artist Hero */}
       <div className="relative w-full aspect-[3/1] max-h-[200px] overflow-hidden">
         {artistImage ? (
-          <img
+          <RemoteImage
             src={artistImage}
             alt={artistName}
+            eager
             className="w-full h-full object-cover"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
           />
         ) : (
           <div className="w-full h-full bg-foreground/5" />
@@ -237,7 +238,8 @@ export default function Companion() {
 
         {/* Track Details */}
         <section className="apple-glass rounded-2xl p-4 flex items-center gap-4">
-          <img src={trackInfo.coverArtUrl} alt={trackInfo.title} className="w-16 h-16 rounded-lg object-cover shrink-0" />
+          <RemoteImage src={trackInfo.coverArtUrl} alt={trackInfo.title} className="w-16 h-16 rounded-lg object-cover shrink-0"
+            fallback={<div className="w-16 h-16 rounded-lg bg-foreground/10 shrink-0" />} />
           <div className="min-w-0">
             <h2 className="text-lg font-bold text-foreground truncate">{trackInfo.title}</h2>
             {trackInfo.album && <p className="text-sm text-muted-foreground truncate">{trackInfo.album}</p>}
@@ -304,11 +306,10 @@ export default function Companion() {
                           <ErrorBoundary>
                             {nugget.imageUrl && (
                               <div className="-mx-4 -mt-4 mb-3">
-                                <img
+                                <RemoteImage
                                   src={nugget.imageUrl}
                                   alt={nugget.imageCaption || nugget.headline || ""}
                                   className="w-full object-contain max-h-44"
-                                  onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
                                 />
                                 {nugget.imageCaption && (
                                   <p className="px-4 py-1.5 text-xs text-muted-foreground italic">{nugget.imageCaption}</p>

--- a/src/pages/Listen.tsx
+++ b/src/pages/Listen.tsx
@@ -1358,6 +1358,8 @@ export default function Listen() {
           <img
             src={effectiveCoverArt}
             alt=""
+            loading="eager"
+            decoding="async"
             className="h-full w-full object-cover scale-[1.3] transition-all duration-1000 ease-out"
             style={{
               filter: barVisible
@@ -1498,6 +1500,8 @@ export default function Listen() {
             key={effectiveCoverArt}
             src={effectiveCoverArt}
             alt={`${track.title} cover art`}
+            loading="eager"
+            decoding="async"
             className="rounded-2xl object-cover shadow-2xl shadow-black/50"
             style={{ width: "min(70vw, 70vh)", height: "min(70vw, 70vh)" }}
             initial={{ opacity: 0, scale: 0.9 }}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import RemoteImage from "@/components/RemoteImage";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowLeft, Heart, Music, Share2, Trash2, Check, Play, X, ExternalLink } from "lucide-react";
 import { useUserProfile } from "@/hooks/useMusicNerdState";
@@ -187,17 +188,16 @@ export default function Profile() {
                           onClick={() => setOpenId(bm.id)}
                           className="w-full text-left active:scale-[0.99] transition-transform p-4 flex gap-3"
                         >
-                          {bm.image_url ? (
-                            <img
-                              src={bm.image_url}
-                              alt=""
-                              className="w-14 h-14 rounded object-cover flex-shrink-0"
-                            />
-                          ) : (
-                            <div className="w-14 h-14 rounded bg-white/10 flex items-center justify-center flex-shrink-0">
-                              <Music className="w-5 h-5 text-white/30" />
-                            </div>
-                          )}
+                          <RemoteImage
+                            src={bm.image_url}
+                            alt=""
+                            className="w-14 h-14 rounded object-cover flex-shrink-0"
+                            fallback={
+                              <div className="w-14 h-14 rounded bg-white/10 flex items-center justify-center flex-shrink-0">
+                                <Music className="w-5 h-5 text-white/30" />
+                              </div>
+                            }
+                          />
                           <div className="flex-1 min-w-0">
                             <p className="text-[10px] uppercase tracking-wider text-white/40 mb-0.5">
                               {bm.artist} · {bm.title}
@@ -278,7 +278,7 @@ export default function Profile() {
             >
               {openBookmark.image_url && (
                 <div className="relative h-44 shrink-0">
-                  <img src={openBookmark.image_url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+                  <RemoteImage src={openBookmark.image_url} alt="" eager className="absolute inset-0 w-full h-full object-cover" />
                   <div className="absolute inset-0 bg-gradient-to-t from-neutral-950 via-neutral-950/40 to-transparent" />
                 </div>
               )}

--- a/src/test/ArtistCardMorph.test.tsx
+++ b/src/test/ArtistCardMorph.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+// layoutId is surfaced as data-layout-id here — see the helper. Without
+// that, both ends of the morph render identically whether or not they
+// agree, which is exactly how the regression below reached review.
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock({ exposeLayoutId: true }));
+
+import { UpdateCard, ExpandedUpdateModalMemoized } from "@/components/ArtistUpdatesSection";
+
+const LAYOUT_ID = "artist::turnover::fact-42";
+
+const FACT: ArtistUpdate = {
+  artistId: "a1",
+  artistName: "Turnover",
+  artistImageUrl: "https://i.scdn.co/image/abc123",
+  kind: "fact",
+  headline: "Turnover tracked the record with their live engineer.",
+  body: "They brought him into the studio to capture the room.",
+  nuggetId: "fact-42",
+};
+
+const noop = () => {};
+
+function renderCard(update: ArtistUpdate) {
+  const { container } = render(
+    <MemoryRouter>
+      <UpdateCard update={update} layoutId={LAYOUT_ID} onClick={noop} />
+    </MemoryRouter>,
+  );
+  return container;
+}
+
+function renderModal(update: ArtistUpdate) {
+  const { container } = render(
+    <MemoryRouter>
+      <ExpandedUpdateModalMemoized
+        update={update}
+        layoutId={LAYOUT_ID}
+        onClose={noop}
+        onOpen={noop}
+      />
+    </MemoryRouter>,
+  );
+  return container;
+}
+
+/** Every morph id declared in a rendered tree. Both the container and
+ *  the artwork carry one, so comparing the whole set is what catches a
+ *  half-wired pair — checking a single element would just re-find the
+ *  container on both ends and pass regardless. */
+const morphIds = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll("[data-layout-id]"))
+    .map((el) => el.getAttribute("data-layout-id"))
+    .sort();
+
+// ── The regression ────────────────────────────────────────────────────
+// Routing the card thumbnail through RemoteImage dropped its layoutId,
+// because RemoteImage rendered a plain <img>. The modal hero kept
+// its own, so the pair no longer matched and the photo hard-cut into
+// the modal instead of scaling. Both ends have to agree; asserting only
+// one end is what let this through the first time.
+describe("artist card → modal shared-element morph", () => {
+  it("gives the card thumbnail a morph id", () => {
+    expect(morphIds(renderCard(FACT))).toContain(`${LAYOUT_ID}::img`);
+  });
+
+  it("gives the modal hero the same morph id", () => {
+    expect(morphIds(renderModal(FACT))).toContain(`${LAYOUT_ID}::img`);
+  });
+
+  // Every id on one end needs a partner on the other — an unpaired id
+  // is precisely a hard cut.
+  it("declares the same morph ids on both ends", () => {
+    expect(morphIds(renderCard(FACT))).toEqual(morphIds(renderModal(FACT)));
+  });
+
+  // The original wired the empty state up too, so an artist with no
+  // photo still morphs its placeholder rather than popping.
+  it("morphs the placeholder when the artist has no photo", () => {
+    const noPhoto = { ...FACT, artistImageUrl: undefined };
+
+    expect(morphIds(renderCard(noPhoto))).toContain(`${LAYOUT_ID}::img`);
+    expect(morphIds(renderCard(noPhoto))).toEqual(morphIds(renderModal(noPhoto)));
+  });
+});
+
+// Regaining the morph must not cost the deferral — the card thumbnails
+// were the bulk of the ~53-request burst that made Browse render as a
+// wall of black cards.
+describe("morphing card thumbnails still defer loading", () => {
+  it("keeps the card thumbnail lazy", () => {
+    const img = renderCard(FACT).querySelector("img");
+    expect(img?.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("keeps decoding off the main thread", () => {
+    const img = renderCard(FACT).querySelector("img");
+    expect(img?.getAttribute("decoding")).toBe("async");
+  });
+});

--- a/src/test/RemoteImage.test.tsx
+++ b/src/test/RemoteImage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import RemoteImage from "@/components/RemoteImage";
+
+const SRC = "https://i.scdn.co/image/abc123";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("RemoteImage — deferring the request", () => {
+  // THE ROOT FIX. Browse fired ~53 simultaneous requests at i.scdn.co,
+  // Spotify throttled the burst, and most came back 503. Deferring
+  // offscreen artwork is what stops that; everything else here is
+  // recovery for the few that still fail.
+  it("defers loading by default", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    expect(screen.getByAltText("cover").getAttribute("loading")).toBe("lazy");
+  });
+
+  it("decodes off the main thread", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    expect(screen.getByAltText("cover").getAttribute("decoding")).toBe("async");
+  });
+
+  // Above-the-fold artwork is already being looked at; deferring it only
+  // delays what the user can see.
+  it("loads eagerly when asked", () => {
+    render(<RemoteImage src={SRC} alt="cover" eager />);
+    expect(screen.getByAltText("cover").getAttribute("loading")).toBe("eager");
+  });
+});
+
+describe("RemoteImage — recovering from a throttled request", () => {
+  it("retries once after a backoff", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    const img = screen.getByAltText("cover");
+    expect(img.getAttribute("src")).toBe(SRC);
+
+    fireEvent.error(img);
+    // Immediately retrying would rejoin the burst that caused the throttle.
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(SRC);
+
+    act(() => { vi.advanceTimersByTime(800); });
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${SRC}?r=1`);
+  });
+
+  it("cache-busts the retry so the browser cannot replay the failure", () => {
+    render(<RemoteImage src={SRC} alt="cover" />);
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+
+    expect(screen.getByAltText("cover").getAttribute("src")).not.toBe(SRC);
+  });
+
+  it("falls back to the placeholder once the retry also fails", () => {
+    render(<RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />);
+
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+    fireEvent.error(screen.getByAltText("cover"));
+
+    expect(screen.queryByAltText("cover")).toBeNull();
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+
+  it("does not retry forever", () => {
+    render(<RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />);
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(5000); });
+
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+});
+
+describe("RemoteImage — no artwork", () => {
+  it("renders the fallback when src is missing", () => {
+    render(<RemoteImage src={undefined} fallback={<div data-testid="ph" />} />);
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+
+  it("renders the fallback when src is null", () => {
+    render(<RemoteImage src={null} fallback={<div data-testid="ph" />} />);
+    expect(screen.getByTestId("ph")).toBeTruthy();
+  });
+
+  // A failed URL must not poison the next one — artist rows swap images
+  // as content resolves.
+  it("recovers when a new src replaces a failed one", () => {
+    const { rerender } = render(
+      <RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />,
+    );
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+    fireEvent.error(screen.getByAltText("cover"));
+    expect(screen.getByTestId("ph")).toBeTruthy();
+
+    rerender(
+      <RemoteImage src="https://i.scdn.co/image/def456" alt="cover" fallback={<div data-testid="ph" />} />,
+    );
+
+    const img = screen.getByAltText("cover");
+    expect(img.getAttribute("src")).toBe("https://i.scdn.co/image/def456");
+  });
+});

--- a/src/test/RemoteImage.test.tsx
+++ b/src/test/RemoteImage.test.tsx
@@ -41,7 +41,7 @@ describe("RemoteImage — recovering from a throttled request", () => {
     expect(screen.getByAltText("cover").getAttribute("src")).toBe(SRC);
 
     act(() => { vi.advanceTimersByTime(800); });
-    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${SRC}?r=1`);
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${SRC}?_retry=1`);
   });
 
   it("cache-busts the retry so the browser cannot replay the failure", () => {
@@ -102,5 +102,55 @@ describe("RemoteImage — no artwork", () => {
 
     const img = screen.getByAltText("cover");
     expect(img.getAttribute("src")).toBe("https://i.scdn.co/image/def456");
+  });
+});
+
+// ── src changing mid-backoff ──────────────────────────────────────────
+// Flagged in review. A scheduled retry closes over the PREVIOUS src; if
+// the prop moves on before it fires, the stale timer writes the old URL
+// over the new one ~700ms later. That collision is likeliest during
+// exactly the burst this component exists for — several images sit
+// mid-backoff while ArtistRow's heroImg recomputes as facts stream in.
+describe("RemoteImage — src changes while a retry is pending", () => {
+  const NEXT = "https://i.scdn.co/image/def456";
+
+  it("does not let a stale retry clobber the new image", () => {
+    const { rerender } = render(<RemoteImage src={SRC} alt="cover" />);
+    fireEvent.error(screen.getByAltText("cover"));
+
+    // New artwork arrives mid-backoff.
+    rerender(<RemoteImage src={NEXT} alt="cover" />);
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(NEXT);
+
+    // The old retry would have fired around here.
+    act(() => { vi.advanceTimersByTime(2000); });
+
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(NEXT);
+  });
+
+  it("still shows the new image rather than falling back", () => {
+    const { rerender } = render(
+      <RemoteImage src={SRC} alt="cover" fallback={<div data-testid="ph" />} />,
+    );
+    fireEvent.error(screen.getByAltText("cover"));
+    rerender(<RemoteImage src={NEXT} alt="cover" fallback={<div data-testid="ph" />} />);
+    act(() => { vi.advanceTimersByTime(2000); });
+
+    expect(screen.queryByTestId("ph")).toBeNull();
+    expect(screen.getByAltText("cover")).toBeTruthy();
+  });
+
+  // The new image gets its own full retry budget — it must not inherit
+  // the previous URL's spent attempt.
+  it("gives the new image its own retry", () => {
+    const { rerender } = render(<RemoteImage src={SRC} alt="cover" />);
+    fireEvent.error(screen.getByAltText("cover"));
+    rerender(<RemoteImage src={NEXT} alt="cover" />);
+    act(() => { vi.advanceTimersByTime(2000); });
+
+    fireEvent.error(screen.getByAltText("cover"));
+    act(() => { vi.advanceTimersByTime(800); });
+
+    expect(screen.getByAltText("cover").getAttribute("src")).toBe(`${NEXT}?_retry=1`);
   });
 });

--- a/src/test/helpers/framerMotionMock.tsx
+++ b/src/test/helpers/framerMotionMock.tsx
@@ -23,7 +23,15 @@ const ANIMATION_PROPS = new Set([
   "dragElastic", "dragMomentum", "onDragEnd", "onDragStart", "custom",
 ]);
 
-export function makeFramerMotionMock() {
+/**
+ * `exposeLayoutId` surfaces layoutId as a `data-layout-id` attribute.
+ * Framer Motion consumes layoutId to compute a shared-element morph and
+ * never writes it to the DOM, so without this a test cannot see whether
+ * both ends of a morph agree on the id — and a morph wired up on only
+ * one end hard-cuts silently rather than failing. Opt-in, because it is
+ * not a real DOM attribute and would be noise in every other suite.
+ */
+export function makeFramerMotionMock({ exposeLayoutId = false } = {}) {
   const cache = new Map<string, React.ElementType>();
 
   const passthrough = (tag: string) =>
@@ -34,6 +42,9 @@ export function makeFramerMotionMock() {
       const domProps: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(props)) {
         if (!ANIMATION_PROPS.has(key)) domProps[key] = value;
+      }
+      if (exposeLayoutId && props.layoutId !== undefined) {
+        domProps["data-layout-id"] = props.layoutId;
       }
       return React.createElement(tag, { ...domProps, ref }, children);
     });


### PR DESCRIPTION
## What actually broke

Measured on staging, not inferred:

```
Spotify images on Browse:  53
with loading="lazy":        0
with explicit dimensions:   0
page height:            2676px  (viewport 783px)
```

Browse requested **every** avatar, card and catalog tile across ~3.4 screens **simultaneously** on load. Spotify throttles a burst that size and answers most of it with **503** — 51 of 54 images failed.

The same URLs load in ~120ms individually. I re-requested one that had *just* returned 503 and it came back in 136ms. So this was never a Spotify outage and never a bad URL.

## Why it "worked flawlessly before"

Nothing broke in a deploy. The image count grew as artists and cards accumulated until the burst crossed the CDN's throttle threshold.

A threshold effect looks intermittent, isn't reproducible on demand, and **gets worse as the catalog grows**.

## The fix

Not error handling — **not making the requests.** `RemoteImage` defers offscreen artwork with `loading="lazy"`, cutting the initial burst by roughly an order of magnitude. Behind that: one backoff retry (a 503 is transient; an immediate retry rejoins the burst that caused it) and a designed fallback.

## Scope: every remote image, not just Browse

Browse alone would have left every other page one growth spurt from the same failure. ArtistProfile, AlbumDetail, Companion, Profile, SearchOverlay and the overlays all had **zero** deferral.

**14 files** now use `RemoteImage`. Five sites keep a raw `<img>` and take the attributes directly, because wrapping them would break something real:

| Site | Why |
|---|---|
| `ExpandedUpdateModal` | needs `motion.img` for the shared `layoutId` morph |
| `Listen` hero | needs `motion.img` for its entrance animation |
| `NuggetCard` | drives its own `imgLoaded`/`imgError` placeholder |
| `ImmersiveNuggetView` | already has its own error-recovery logic |
| `StoriesRail` | **dead code** — zero imports anywhere in `src/`; never mounts |

The burst fix is the attribute, so nothing is lost.

`StoriesRail` deserves a note: the "Your Stories" rail was removed from Browse in an earlier PR and the file was left behind. Every remaining reference to it is a comment. It cannot contribute to the burst or show a broken image because nothing renders it — which is also why the 53 requests measured on Browse were artist avatars, update cards and catalog tiles, with no story avatars among them. Deleting it is the right end state, filed as a follow-up rather than smuggled into an image-loading PR.

Artwork already on screen is marked `eager` — player bar, open overlay heroes, immersive backdrops. Deferring those only delays what the user is looking at.

**Audited to zero:** the only remaining raw images without deferral are the two bundled Spotify logos on Connect, which are local assets.

## Also fixes two real bugs

Both visible in the reported screenshot:

- **Cards went solid black** — `onError` set `display: none`, but the gradient placeholder only rendered when `src` was *absent*, so a failed load left nothing behind it
- **Avatars showed the browser's broken-image icon** — that `<img>` had no error handling at all

Several other sites used the same `display:none` pattern and now get real placeholders.

## From review

The reviewer caught a genuine defect in the fix: a pending retry wasn't cancelled when `src` changed, so a stale timer could write the old URL over new artwork ~700ms later — most likely *during the very burst this exists for*. Fixed, with three tests, mutation-verified.

Also addressed: cache-bust param is `_retry` rather than `r`, and TileRow's redundant ternary is gone.

**Round 2** caught a regression this PR introduced: routing `UpdateCard`'s thumbnail through `RemoteImage` dropped its `layoutId`, so the card→modal photo morph hard-cut instead of scaling. `RemoteImage` now takes an optional `layoutId` and renders a `motion.img` when given one — rather than reverting that call site to a raw `motion.img`, since those thumbnails are the bulk of the burst and shouldn't trade lazy loading and retry/fallback back for the animation. The empty state needed it too.

Tests compare the **full set** of morph ids on both ends. A single-element check passes either way, because the card and modal containers carry ids of their own — which is exactly how this got past me.

**Round 3:** AlbumDetail's two blurred hero backdrops were lazy while the cover art below them was eager. Fixed.

## Verification

- `npm test` — 570 passing
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline
- Mutation-verified: dropping the `layoutId` pass-through fails 2 tests, plain-`div`-ing the placeholder fails a 3rd
