### PR TITLE
fix(artist): stop the deep link re-opening the fact you came from

### DIFF
--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -153,13 +153,13 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
               const key = layoutIdFor(u);
               return (
                 <div key={key} ref={(el) => { cardRefs.current[key] = el; }}>
-                <UpdateCard
-                  layoutId={key}
-                  update={u}
-                  onClick={() => setExpandedKey(key)}
-                  sizeClass="w-full h-44 md:h-48"
-                  pulsing={pulseKey === key}
-                />
+                  <UpdateCard
+                    layoutId={key}
+                    update={u}
+                    onClick={() => setExpandedKey(key)}
+                    sizeClass="w-full h-44 md:h-48"
+                    pulsing={pulseKey === key}
+                  />
                 </div>
               );
             })}

--- a/src/components/LatestFactsSection.tsx
+++ b/src/components/LatestFactsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { AnimatePresence } from "framer-motion";
 import { Loader2 } from "lucide-react";
@@ -21,8 +21,12 @@ import {
  * a horizontal-scroll rail across multiple artists).
  *
  * If the URL has a `?nugget=<id>` query (Browse → Artist Profile tap-
- * through), this component auto-opens the matching fact in the modal
- * and silently strips the param so a refresh doesn't re-open.
+ * through), this component scrolls the matching fact into view and
+ * pulses it, then silently strips the param so a refresh doesn't repeat
+ * it. It deliberately does NOT open the modal — the user pressed "Open
+ * {Artist}" to see the artist, and re-opening the card they just came
+ * from puts a full-screen overlay between them and the page they asked
+ * for.
  */
 
 interface Props {
@@ -32,12 +36,21 @@ interface Props {
   artistName: string;
 }
 
+/** Respect motion sensitivity for the deep-link scroll. */
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined"
+    && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}
+
 export default function LatestFactsSection({ updates, loading, artistName }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
   const targetNuggetId = searchParams.get("nugget");
   const navigate = useNavigate();
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const [pulseKey, setPulseKey] = useState<string | null>(null);
+  // Card nodes by layoutId, so the deep-link can scroll to the referenced
+  // fact rather than opening it.
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   // layoutId namespace prefix. Both this section and Browse's
   // "Your artists, lately" rail render UpdateCard with the same
@@ -55,17 +68,28 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
     return updates.find((u) => layoutIdFor(u) === expandedKey) ?? null;
   }, [expandedKey, updates]);
 
-  // Deep-link from Browse: auto-open the matching nugget in the modal.
-  // We open immediately on data arrival, then pulse the underlying
-  // card briefly so the user sees which fact was referenced when they
-  // close the modal.
+  // Deep-link from Browse: point AT the referenced fact without covering
+  // the page with it. Pete: "it takes me to the profile but the fact card
+  // stays open or re-opens on top of the artist profile instead of
+  // letting me see the artist profile." That was this effect calling
+  // setExpandedKey — the card was never lingering, it was being opened
+  // again on arrival.
+  //
+  // Scroll it into view and pulse it instead, which is what the artist
+  // page already documented this param as doing.
   useEffect(() => {
     if (!targetNuggetId || updates.length === 0) return;
     const match = updates.find((u) => u.nuggetId === targetNuggetId);
     if (!match) return;
     const key = layoutIdFor(match);
-    setExpandedKey(key);
     setPulseKey(key);
+    // Next frame, so the card exists before we scroll to it.
+    const scrollFrame = requestAnimationFrame(() => {
+      cardRefs.current[key]?.scrollIntoView({
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+        block: "center",
+      });
+    });
     const pulseTimer = setTimeout(() => setPulseKey(null), 1800);
     const stripTimer = setTimeout(() => {
       // Quietly remove the ?nugget= param so reload doesn't re-open.
@@ -74,6 +98,7 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
       setSearchParams(next, { replace: true });
     }, 200);
     return () => {
+      cancelAnimationFrame(scrollFrame);
       clearTimeout(pulseTimer);
       clearTimeout(stripTimer);
     };
@@ -127,14 +152,15 @@ export default function LatestFactsSection({ updates, loading, artistName }: Pro
           : updates.map((u) => {
               const key = layoutIdFor(u);
               return (
+                <div key={key} ref={(el) => { cardRefs.current[key] = el; }}>
                 <UpdateCard
-                  key={key}
                   layoutId={key}
                   update={u}
                   onClick={() => setExpandedKey(key)}
                   sizeClass="w-full h-44 md:h-48"
                   pulsing={pulseKey === key}
                 />
+                </div>
               );
             })}
       </div>

--- a/src/test/LatestFactsDeepLink.test.tsx
+++ b/src/test/LatestFactsDeepLink.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+
+vi.mock("framer-motion", async () =>
+  (await import("./helpers/framerMotionMock")).makeFramerMotionMock());
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+import LatestFactsSection from "@/components/LatestFactsSection";
+
+const FACT: ArtistUpdate = {
+  artistId: "a1",
+  artistName: "Turnover",
+  artistImageUrl: "https://example.com/t.jpg",
+  kind: "fact",
+  headline: "Turnover tracked the record with their live engineer.",
+  body: "They brought him into the studio to capture the room.",
+  nuggetId: "fact-42",
+};
+
+const OTHER: ArtistUpdate = { ...FACT, nuggetId: "fact-99", headline: "A different fact." };
+
+function renderAt(search: string, updates: ArtistUpdate[] = [FACT, OTHER]) {
+  return render(
+    <MemoryRouter initialEntries={[`/artist/spotify::a1::Turnover${search}`]}>
+      <LatestFactsSection updates={updates} loading={false} artistName="Turnover" />
+    </MemoryRouter>,
+  );
+}
+
+const dialog = () => screen.queryByRole("dialog");
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("artist page — arriving from a fact card", () => {
+  // Pete: "it takes me to the profile but the fact card stays open or
+  // re-opens on top of the artist profile instead of letting me see the
+  // artist profile." The card was never lingering — this component was
+  // calling setExpandedKey on arrival and opening it again.
+  it("does not open the referenced fact over the page", () => {
+    renderAt("?nugget=fact-42");
+    expect(dialog()).toBeNull();
+  });
+
+  // Scrolling is deferred a frame so the card exists before we target it.
+  it("scrolls the referenced fact into view instead", async () => {
+    renderAt("?nugget=fact-42");
+    await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled());
+  });
+
+  it("leaves the page clear when there is no deep link", () => {
+    renderAt("");
+    expect(dialog()).toBeNull();
+  });
+
+  it("ignores a deep link that matches nothing", () => {
+    renderAt("?nugget=does-not-exist");
+    expect(dialog()).toBeNull();
+  });
+
+  // The card must still be openable — this fixes an unwanted auto-open,
+  // not the ability to read a fact on the artist page.
+  it("still opens the card when the user taps it", () => {
+    renderAt("?nugget=fact-42");
+    expect(dialog()).toBeNull();
+
+    fireEvent.click(screen.getByText(FACT.headline));
+
+    expect(dialog()).not.toBeNull();
+  });
+
+  it("opens the tapped card, not the deep-linked one", () => {
+    renderAt("?nugget=fact-42");
+    fireEvent.click(screen.getByText(OTHER.headline));
+
+    const dlg = dialog()!;
+    expect(dlg.textContent).toContain(OTHER.headline);
+  });
+});


### PR DESCRIPTION
## My earlier diagnosis was wrong

I attributed this to the page transition and shipped #121 (500ms exit → 180ms). That was a real improvement, but **it wasn't the cause** — the symptom persisted, which it should have.

The word that gave it away in the second report was **"re-opens."**

## Actual cause

`openArtistAtNugget` navigates to `/artist/…?nugget=<id>`. `LatestFactsSection` reads that param and calls `setExpandedKey` on arrival — **the destination page opens the card again**.

The card was never lingering. A full-screen overlay was being placed between the user and the page they'd just asked for.

## The intent had already drifted

`ArtistProfile.tsx:483` documents the param as one that *"scrolls the matching card into view and pulses it."* That's the right behaviour, and it's what it does now:

- pulse — already existed
- scroll into view — new, respects `prefers-reduced-motion`
- auto-open — **gone**

Pressing "Open {Artist}" means *show me the artist*.

## Tests

Six: no dialog on arrival, the referenced card gets scrolled to, no deep link leaves the page clear, an unmatched id is ignored, the card is still openable by tapping, and tapping a *different* card opens that one rather than the deep-linked one.

Mutation-verified — restoring `setExpandedKey` fails two.

## Verification

- `npm test` — 557 passing (6 new)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline