### PR TITLE
fix(artist): keep Browse play targets out of Latest Facts

### DIFF
--- a/src/hooks/useArtistLatestFacts.ts
+++ b/src/hooks/useArtistLatestFacts.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+import { isReadableUpdate } from "@/lib/artistUpdateKind";
 
 /**
  * Fetches the `ArtistUpdate[]` for a single artist. Hits the same
@@ -15,6 +16,11 @@ import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
  * via a Browse nugget tap); a cold artist (e.g. navigated from "Fans
  * Also Like") triggers a fresh edge-function call with the usual
  * generation latency.
+ *
+ * Returns only updates with something to read. The same response also
+ * carries Browse's `kind: "track"` play targets, which have no body —
+ * see isReadableUpdate. Filtering here rather than in the component
+ * means the hook's name matches what it returns.
  */
 export function useArtistLatestFacts(
   artistName: string | null,
@@ -45,7 +51,10 @@ export function useArtistLatestFacts(
           return;
         }
         const next = (data?.updates as ArtistUpdate[] | undefined) ?? [];
-        setUpdates(next);
+        // The edge function returns Browse's play targets in the same
+        // array. Those have no body, so "Latest Facts" would render
+        // them as titles with nothing underneath.
+        setUpdates(next.filter(isReadableUpdate));
       } catch (e) {
         if (import.meta.env.DEV) {
           console.warn(`[artist-latest-facts] ${artistName} threw:`, e);

--- a/src/lib/artistUpdateKind.ts
+++ b/src/lib/artistUpdateKind.ts
@@ -18,6 +18,30 @@ export interface ArtistUpdateKindMeta {
   KindIcon: typeof Sparkles;
 }
 
+/**
+ * Whether an update has something to read.
+ *
+ * `kind: "track"` entries are play targets, not content: the edge
+ * function builds them with the track name as the headline and
+ * `body: ""` (artist-updates/index.ts:381 — the only empty body it
+ * produces). They exist for the Browse "Get into" lane, which renders
+ * them as artwork tiles.
+ *
+ * The artist profile's "Latest Facts" reads the same array and rendered
+ * them as readable cards, so the section promised facts and delivered
+ * bare catalog artwork — duplicating the "Popular" list directly below
+ * it. Pete: "I don't understand what the track cards are doing here in
+ * latest facts, when there is no facts in each of those cards."
+ *
+ * Also drops any other empty-bodied update, which would render the same
+ * broken way. Filtering here rather than in the component keeps the
+ * rule in one place for the next surface that reads these.
+ */
+export function isReadableUpdate(u: ArtistUpdate): boolean {
+  if (u.kind === "track") return false;
+  return u.body.trim().length > 0;
+}
+
 export function getArtistUpdateKindMeta(kind: ArtistUpdate["kind"]): ArtistUpdateKindMeta {
   switch (kind) {
     case "new-release":

--- a/src/test/latestFactsFiltering.test.ts
+++ b/src/test/latestFactsFiltering.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ArtistUpdate } from "@/hooks/useArtistUpdates";
+import { isReadableUpdate } from "@/lib/artistUpdateKind";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { functions: { invoke: vi.fn() } },
+}));
+
+import { useArtistLatestFacts } from "@/hooks/useArtistLatestFacts";
+import { supabase } from "@/integrations/supabase/client";
+
+const base = {
+  artistId: "a1",
+  artistName: "BADBADNOTGOOD",
+  artistImageUrl: "https://i.scdn.co/image/abc",
+};
+
+const FACT: ArtistUpdate = {
+  ...base,
+  kind: "fact",
+  headline: "BADBADNOTGOOD started their collaboration with Kaytranada.",
+  body: "Alex Sowinski noted Kaytranada, whom the band met on tour.",
+  nuggetId: "fact-1",
+};
+
+// What the edge function actually builds for Browse's play targets:
+// track name as headline, empty body (artist-updates/index.ts:381).
+const TRACK: ArtistUpdate = {
+  ...base,
+  kind: "track",
+  headline: "Time Moves Slow",
+  body: "",
+  relatedTrackUri: "spotify:track:xyz",
+  relatedTrackTitle: "Time Moves Slow",
+  nuggetId: "track-spotify:track:xyz",
+};
+
+describe("isReadableUpdate", () => {
+  it("keeps a fact that has a body", () => {
+    expect(isReadableUpdate(FACT)).toBe(true);
+  });
+
+  it("drops a catalog track", () => {
+    expect(isReadableUpdate(TRACK)).toBe(false);
+  });
+
+  // The kind is the rule, not just the empty body — a track is a play
+  // target regardless of what the server puts in it.
+  it("drops a track even if it somehow carries a body", () => {
+    expect(isReadableUpdate({ ...TRACK, body: "A song about something." })).toBe(false);
+  });
+
+  it("keeps a new release with a body", () => {
+    expect(isReadableUpdate({ ...FACT, kind: "new-release" })).toBe(true);
+  });
+
+  it("keeps a collab with a body", () => {
+    expect(isReadableUpdate({ ...FACT, kind: "collab" })).toBe(true);
+  });
+
+  // An empty-bodied fact would render exactly as broken as a track tile.
+  it("drops an empty-bodied fact", () => {
+    expect(isReadableUpdate({ ...FACT, body: "" })).toBe(false);
+  });
+
+  it("drops a whitespace-only body", () => {
+    expect(isReadableUpdate({ ...FACT, body: "   \n  " })).toBe(false);
+  });
+});
+
+// ── The wiring ────────────────────────────────────────────────────────
+// The predicate passing proves nothing on its own; the bug was that
+// nothing called it. These pin that the hook feeding "Latest Facts"
+// actually applies it.
+describe("useArtistLatestFacts — what reaches Latest Facts", () => {
+  const invoke = supabase.functions.invoke as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => invoke.mockReset());
+
+  it("hands the section only readable updates", async () => {
+    invoke.mockResolvedValue({ data: { updates: [FACT, TRACK, TRACK] }, error: null });
+
+    const { result } = renderHook(() => useArtistLatestFacts("BADBADNOTGOOD", "nerd"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.updates).toEqual([FACT]);
+  });
+
+  it("leaves the section empty rather than showing bare tiles", async () => {
+    invoke.mockResolvedValue({ data: { updates: [TRACK, TRACK, TRACK] }, error: null });
+
+    const { result } = renderHook(() => useArtistLatestFacts("BADBADNOTGOOD", "nerd"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // LatestFactsSection renders nothing at all when this is empty,
+    // which is the right outcome — better than a heading over tiles.
+    expect(result.current.updates).toEqual([]);
+  });
+
+  it("keeps every fact when the server sends no tracks", async () => {
+    const second = { ...FACT, nuggetId: "fact-2", headline: "A second fact." };
+    invoke.mockResolvedValue({ data: { updates: [FACT, second] }, error: null });
+
+    const { result } = renderHook(() => useArtistLatestFacts("BADBADNOTGOOD", "nerd"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.updates).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Pete, testing the staging deploy: *"I don't understand what the track cards are doing here in latest facts, when there is no facts in each of those cards."*


## What was happening

The artist profile's "Latest Facts" rendered `kind: "track"` entries as readable cards — a title with nothing underneath — and those same tracks are already listed under **Popular** immediately below the section.

## Root cause

Mine, from the "Your Artists, Lately" redesign. I added `kind: "track"` to `artist-updates` as **play targets for Browse's "Get into" lane**, which renders them as artwork tiles. The edge function builds them with the track name as the headline and `body: ""` — the only empty body it produces (`artist-updates/index.ts:381`).

What I missed is that `useArtistLatestFacts` reads the **same response** and passed it straight through. The shared kind helper already said so out loud:

> Catalog tracks render as artwork tiles in the "Get into" lane, **not as readable cards**

LatestFactsSection was rendering them as readable cards.

## Fix

`isReadableUpdate` in the shared kind helper, applied in `useArtistLatestFacts`.

Filtered in the hook rather than the component for two reasons: the hook is named for facts, so its return should match its name; and the rule now lives in one place instead of waiting to be rediscovered by the next surface that reads these. Browse is unaffected — it uses `useArtistUpdatesContext`, a different path.

Also drops any other empty-bodied update, since one would render exactly as broken. Today only tracks qualify.

When an artist has nothing readable, `LatestFactsSection` already returns `null`, so the section disappears rather than showing a heading over an empty list.

## Tests

10 new, in two layers, because the predicate passing proves nothing about whether anything calls it — which was the actual bug:

- `isReadableUpdate` — keeps fact/new-release/collab with bodies; drops tracks, empty bodies, whitespace-only bodies; drops a track *even if it carries a body*, pinning that the kind is the rule
- `useArtistLatestFacts` — the wiring: only readable updates reach the section, an all-track response yields an empty list, facts are untouched when no tracks are present

**Mutation-verified:** removing `.filter(isReadableUpdate)` fails both wiring tests while all 7 predicate tests still pass — which is precisely the gap that let this ship.

## Verification

- `npm test` — 586 passing (was 576)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline

Client-only change; no edge-function deploy required.
