### PR TITLE
fix(security): scope nugget_cache writes so visitors cannot poison it

### DIFF
--- a/supabase/migrations/20260804130000_nugget_cache_scope_writes.sql
+++ b/supabase/migrations/20260804130000_nugget_cache_scope_writes.sql
@@ -1,0 +1,72 @@
+-- Scope nugget_cache writes so a visitor cannot destroy or poison the cache.
+--
+-- The problem: the write policies added in 20260304180000 grant INSERT,
+-- UPDATE and DELETE to the `authenticated` role with NO row conditions.
+-- Anonymous sign-in (src/lib/ensureSupabaseSession.ts) hands that role to
+-- every visitor who reaches Connect, so in practice any visitor could
+-- overwrite or delete any cached nugget row in the table.
+--
+-- Why it was written that way: at the time the CLIENT wrote nugget_cache
+-- after generation, and that write failed for anon users. The fix chosen
+-- then was to widen the policy. In April 2026 the write moved server-side
+-- (generate-nuggets upserts with the admin key, bypassing RLS) and the
+-- policy was never narrowed again. That function's own comment records it:
+--
+--     "the server writes here using the admin key (bypasses RLS).
+--      Client's cache-write is now redundant but harmless."
+--
+-- So the broad grant is vestigial. What the client still genuinely needs
+-- is the generation LOCK, not the ability to write content:
+--
+--   INSERT status='generating'        claim a track. The unique index on
+--                                     track_id makes this atomic across
+--                                     clients — a second claim gets 23505
+--                                     and that client waits instead of
+--                                     paying for duplicate generation.
+--   DELETE WHERE status='generating'  release the claim, or clear a stale
+--                                     one after the poll timeout when the
+--                                     claiming client died mid-generation.
+--
+-- This migration keeps exactly that and removes the rest. A ready row —
+-- real nuggets someone paid Exa and Gemini to produce — becomes writable
+-- only by the server.
+--
+-- Residual exposure, stated plainly: a visitor can still create or clear
+-- generation claims. Worst case they force duplicate generation, or make
+-- other clients wait out the poll timeout on a track. Both are bounded and
+-- self-healing, and closing them would mean moving the lock server-side —
+-- a generate-nuggets deploy, which is guarded for unrelated reasons. This
+-- migration deliberately takes the part that needs no deploy.
+
+DROP POLICY IF EXISTS "nugget_cache_write" ON public.nugget_cache;
+DROP POLICY IF EXISTS "nugget_cache_update" ON public.nugget_cache;
+DROP POLICY IF EXISTS "nugget_cache_delete" ON public.nugget_cache;
+
+-- INSERT: a bare claim, or anything from the server.
+-- `nuggets = '[]'` is what stops this being a content-planting hole: a
+-- claim row carries no facts, so it cannot be used to serve fabricated
+-- nuggets to other listeners.
+CREATE POLICY "nugget_cache_claim"
+  ON public.nugget_cache FOR INSERT
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR (
+      auth.role() = 'authenticated'
+      AND status = 'generating'
+      AND nuggets = '[]'::jsonb
+    )
+  );
+
+-- UPDATE: server only. The client has no reason to modify a row in place —
+-- it resolves its own claim by letting the server's upsert overwrite it.
+CREATE POLICY "nugget_cache_update"
+  ON public.nugget_cache FOR UPDATE
+  USING (auth.role() = 'service_role');
+
+-- DELETE: an in-flight claim only. Ready rows are durable cache.
+CREATE POLICY "nugget_cache_delete"
+  ON public.nugget_cache FOR DELETE
+  USING (
+    auth.role() = 'service_role'
+    OR (auth.role() = 'authenticated' AND status = 'generating')
+  );


### PR DESCRIPTION
Top item from the July audit. **Already applied to production** (2026-08-04) — this PR records it in the repo.

## The hole

`nugget_cache` granted INSERT/UPDATE/DELETE to `authenticated` with **no row conditions** (`20260304180000`). Spotify OAuth is open registration, so anyone with a Spotify account could sign in and overwrite or delete any cached nugget row.

## Why it was there

It was widened because the CLIENT used to write the cache after generation, which failed for anon users. That write moved server-side in April (`generate-nuggets` upserts with the admin key) and nobody narrowed the policy afterward. The function says so itself:

> the server writes here using the admin key (bypasses RLS). Client's cache-write is now **redundant but harmless**.

## The fix

The client still needs the generation **lock**, not content writes:

| Op | New rule |
|---|---|
| INSERT | bare claim only — `status='generating'` **and** `nuggets='[]'`; server unrestricted |
| UPDATE | server only |
| DELETE | claims only; server unrestricted |

`nuggets='[]'` is what stops a claim being used to plant fabricated facts.

**No `generate-nuggets` deploy** — so this carries zero exposure to the unvalidated prompt work behind that function's deploy guard.

## Every call site, mapped before applying

| Line | Op | Result |
|---|---|---|
| 687, 1228, 1234 | DELETE claim | allowed |
| 708 | INSERT claim | allowed |
| 1001, 1119, 1435 | UPSERT `ready` | blocked — redundant, server writes it |
| 269, 633, 732, 1175, usePreGeneratedStories:188 | SELECT | unaffected |

The three blocked upserts do not check their result and clear `sentinelClaimed` unconditionally, so no claim is stranded. On any path where the DELETE is now refused, the row is already `ready` — the cache is correct and the delete was the harmful action.

## Residual exposure

Stated rather than glossed: a client can still create and clear *claims*, so it can force duplicate generation or make others wait out a poll timeout. Both bounded and self-healing. Closing them means moving the lock server-side — a guarded deploy.

## Two findings while verifying

1. **Anonymous sign-ins are disabled** in the project (`anonymous_provider_disabled`). The audit assumed they were on, which made this "any visitor." It actually required a sign-in — still open to anyone, but narrower than reported.
2. **Apple Music onboarding is broken in production** as a direct consequence — `Connect.tsx:334` calls `ensureSupabaseSession()`, which throws when anonymous sign-in is disabled, so users get *"Couldn't start your session. Try again?"* and cannot connect. Filed separately; unrelated to this change.

## Verification

`supabase migration list` showed a second pending migration — `20260423040000_nugget_bookmarks` — unapplied since April. Probing confirmed the table exists in production (returns `[]`, versus `PGRST205` for a table that does not exist), so it had been applied by hand and never recorded. Marked applied with `migration repair` rather than re-run, so `db push` applied exactly one migration, confirmed by `--dry-run`.

I could not mint an `authenticated` JWT to exercise the client paths directly, because anonymous sign-in is disabled and Spotify OAuth needs a real browser — so the call-site mapping above is reasoned from the code, not executed. Rollback SQL restoring the previous policies is staged and ready.