### PR TITLE
fix(cache): clear stale generation claims

### DIFF
--- a/supabase/migrations/20260804130000_nugget_cache_scope_writes.sql
+++ b/supabase/migrations/20260804130000_nugget_cache_scope_writes.sql
@@ -1,0 +1,72 @@
+-- Scope nugget_cache writes so a visitor cannot destroy or poison the cache.
+--
+-- The problem: the write policies added in 20260304180000 grant INSERT,
+-- UPDATE and DELETE to the `authenticated` role with NO row conditions.
+-- Anonymous sign-in (src/lib/ensureSupabaseSession.ts) hands that role to
+-- every visitor who reaches Connect, so in practice any visitor could
+-- overwrite or delete any cached nugget row in the table.
+--
+-- Why it was written that way: at the time the CLIENT wrote nugget_cache
+-- after generation, and that write failed for anon users. The fix chosen
+-- then was to widen the policy. In April 2026 the write moved server-side
+-- (generate-nuggets upserts with the admin key, bypassing RLS) and the
+-- policy was never narrowed again. That function's own comment records it:
+--
+--     "the server writes here using the admin key (bypasses RLS).
+--      Client's cache-write is now redundant but harmless."
+--
+-- So the broad grant is vestigial. What the client still genuinely needs
+-- is the generation LOCK, not the ability to write content:
+--
+--   INSERT status='generating'        claim a track. The unique index on
+--                                     track_id makes this atomic across
+--                                     clients — a second claim gets 23505
+--                                     and that client waits instead of
+--                                     paying for duplicate generation.
+--   DELETE WHERE status='generating'  release the claim, or clear a stale
+--                                     one after the poll timeout when the
+--                                     claiming client died mid-generation.
+--
+-- This migration keeps exactly that and removes the rest. A ready row —
+-- real nuggets someone paid Exa and Gemini to produce — becomes writable
+-- only by the server.
+--
+-- Residual exposure, stated plainly: a visitor can still create or clear
+-- generation claims. Worst case they force duplicate generation, or make
+-- other clients wait out the poll timeout on a track. Both are bounded and
+-- self-healing, and closing them would mean moving the lock server-side —
+-- a generate-nuggets deploy, which is guarded for unrelated reasons. This
+-- migration deliberately takes the part that needs no deploy.
+
+DROP POLICY IF EXISTS "nugget_cache_write" ON public.nugget_cache;
+DROP POLICY IF EXISTS "nugget_cache_update" ON public.nugget_cache;
+DROP POLICY IF EXISTS "nugget_cache_delete" ON public.nugget_cache;
+
+-- INSERT: a bare claim, or anything from the server.
+-- `nuggets = '[]'` is what stops this being a content-planting hole: a
+-- claim row carries no facts, so it cannot be used to serve fabricated
+-- nuggets to other listeners.
+CREATE POLICY "nugget_cache_claim"
+  ON public.nugget_cache FOR INSERT
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR (
+      auth.role() = 'authenticated'
+      AND status = 'generating'
+      AND nuggets = '[]'::jsonb
+    )
+  );
+
+-- UPDATE: server only. The client has no reason to modify a row in place —
+-- it resolves its own claim by letting the server's upsert overwrite it.
+CREATE POLICY "nugget_cache_update"
+  ON public.nugget_cache FOR UPDATE
+  USING (auth.role() = 'service_role');
+
+-- DELETE: an in-flight claim only. Ready rows are durable cache.
+CREATE POLICY "nugget_cache_delete"
+  ON public.nugget_cache FOR DELETE
+  USING (
+    auth.role() = 'service_role'
+    OR (auth.role() = 'authenticated' AND status = 'generating')
+  );

--- a/supabase/migrations/20260804200000_clear_stale_generation_claims.sql
+++ b/supabase/migrations/20260804200000_clear_stale_generation_claims.sql
@@ -1,0 +1,32 @@
+-- Clear stale generation claims from nugget_cache.
+--
+-- A `status='generating'` row is a lock, not content. A client claims a
+-- track before generating so a second client waits instead of paying for
+-- duplicate Exa/Gemini work, and the claim is released when generation
+-- finishes (the server upserts status='ready' over it) or fails (the
+-- client deletes it).
+--
+-- Twelve claims were never released — the oldest dates to 2026-05-15.
+-- Any listener who lands on one of those tracks polls the row, waits out
+-- the timeout, and sees nothing. Pete hit this on "Turnover — Humming"
+-- (claimed 2026-07-30) and reported that the researching state never
+-- resolved and no facts appeared.
+--
+-- Deleting them is safe and self-healing. A claim row holds no facts
+-- (`nuggets` is '[]'), so nothing cached is lost — the next listener
+-- regenerates from scratch, which is what would have happened had the
+-- claim been released properly.
+--
+-- Bounded by age so this can never delete a claim that is legitimately
+-- in flight: generation completes in roughly 15-60s, so anything older
+-- than an hour is abandoned by definition.
+--
+-- This clears the backlog but does not stop new claims from leaking.
+-- Whatever path drops them — a tab closed mid-generation, an unhandled
+-- failure between claim and release — still needs finding, and the
+-- durable fix is a server-side TTL or reaping stale claims on read
+-- rather than trusting a client to clean up after itself.
+
+DELETE FROM public.nugget_cache
+ WHERE status = 'generating'
+   AND created_at < now() - interval '1 hour';


### PR DESCRIPTION
Pete: *"just clear the stuck tracks, they'll just generate when someone gets to them again."* **Already applied to production** — this PR records it.

## What was stuck

A `status='generating'` row in `nugget_cache` is a **lock, not content**. A client claims a track before generating so a second client waits instead of paying for duplicate Exa/Gemini work. The claim is released when the server upserts `status='ready'` over it, or the client deletes it on failure.

**Twelve claims were never released** — oldest from **2026-05-15**. Any listener landing on one of those tracks polls the row, waits out the timeout, and sees nothing.

That is the root cause of a bug reported earlier in this session: `real::Turnover::Humming` was claimed 2026-07-30 and never released — *"it said it was doing research and then it never showed up with any facts."* It would have stayed broken for that track indefinitely.

## Why deleting is safe

A claim row holds no facts (`nuggets` is `'[]'`), so nothing cached is lost. The next listener regenerates from scratch — exactly what would have happened had the claim been released properly.

Bounded to `created_at < now() - interval '1 hour'` so a legitimately in-flight generation (15-60s) can never be deleted. Verified after applying: the 12 stale rows are gone, and one claim from 19:28 was correctly spared by the age guard.

## What this does NOT fix

The backlog is cleared; the **leak is not**. Whatever drops claims — a tab closed mid-generation, an unhandled failure between claim and release — will keep producing them, and they accumulate silently until someone happens to play that exact track.

The durable fix is server-side: a TTL on claims, or reaping stale ones on read, rather than trusting a client that may never come back to clean up after itself. Worth its own issue.

Note the client-side stale-sentinel cleanup at `useAINuggets.ts:687` still works under the RLS scoping in #125 — deleting a `status='generating'` row is explicitly still permitted.