### PR TITLE
fix(security): require an empty sources payload on a cache claim

### DIFF
--- a/supabase/migrations/20260804210000_nugget_cache_claim_empty_sources.sql
+++ b/supabase/migrations/20260804210000_nugget_cache_claim_empty_sources.sql
@@ -1,0 +1,31 @@
+-- Constrain `sources` on the claim policy, not just `nuggets`.
+--
+-- 20260804130000 limited a client INSERT to a bare claim by requiring
+-- status='generating' AND nuggets='[]'. It left `sources` unconstrained,
+-- so a claim row could carry an arbitrary sources payload.
+--
+-- That is not exploitable today: every read path gates on
+-- status === 'ready' before trusting nuggets or sources
+-- (useAINuggets.ts:638, :746, :1179, and pollForReadyNuggets at :274).
+-- But that safety depends on every present and future read site
+-- remembering the gate, which is the weaker guarantee — raised in review
+-- on #125. The constraint costs nothing and moves the guarantee into the
+-- database, where forgetting is not an option.
+--
+-- Matches what the client actually sends when claiming a track
+-- (useAINuggets.ts:709): { track_id, status: 'generating', nuggets: [],
+-- sources: {} }.
+
+DROP POLICY IF EXISTS "nugget_cache_claim" ON public.nugget_cache;
+
+CREATE POLICY "nugget_cache_claim"
+  ON public.nugget_cache FOR INSERT
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR (
+      auth.role() = 'authenticated'
+      AND status = 'generating'
+      AND nuggets = '[]'::jsonb
+      AND sources = '{}'::jsonb
+    )
+  );


### PR DESCRIPTION
Follow-up to #125, taking the hardening raised in its review. **Already applied to production** — this PR records it.

## The gap

`20260804130000` limited a client INSERT to a bare claim via `status='generating' AND nuggets='[]'`, but left `sources` unconstrained. A claim row could carry an arbitrary sources payload.

Not exploitable today — every read path gates on `status === "ready"` before trusting `nuggets` or `sources` (`useAINuggets.ts:638`, `:746`, `:1179`, and `pollForReadyNuggets` at `:274`). The reviewer's point stands anyway: that safety depends on every present **and future** read site remembering the gate. The constraint costs nothing and puts the guarantee in the database, where forgetting is not an option.

Matches exactly what the client sends when claiming a track (`useAINuggets.ts:709`):

```js
.insert({ track_id: dbCacheKey, status: "generating", nuggets: [], sources: {} })
```

## Verified against production

Exercised as a real anonymous visitor (the role every visitor now holds, since anonymous sign-ins were enabled today for Apple Music onboarding):

| Attempt | HTTP | Outcome |
|---|---|---|
| Real claim, `sources={}` | 201 | allowed — the lock still works |
| Claim carrying `sources={"fake":"payload"}` | **403** | blocked |
| Probe rows afterwards | — | removed |

Checking the permissive case matters as much as the blocked one: an over-tight policy here would silently break the generation lock and cause duplicate Exa/Gemini spend rather than anything visible.

## Not in this PR

The wave-cache regression #125's review found — `useAINuggets.ts:1435` was not redundant, and blocking it means a multi-wave track's cached row keeps only its most recent wave. Confirmed and tracked separately; the fix is server-side (have `generate-nuggets` read and merge rather than overwrite) and rides with that function's guarded deploy.