### PR TITLE
fix(spotify): surface a reconnect prompt when credentials are unrecoverable

### DIFF
--- a/src/components/SpotifyReconnectBanner.tsx
+++ b/src/components/SpotifyReconnectBanner.tsx
@@ -1,21 +1,28 @@
 import { useEffect, useState } from "react";
 import { signInWithSpotify } from "@/hooks/useSpotifyAuth";
+import { RECONNECT_REQUIRED_EVENT } from "@/lib/spotifyTokenStore";
 
 /**
- * Surfaces a reconnect banner when useSpotifyToken's refresh chain fails
- * (both the server-side edge function and the legacy client-side path
- * returned null). Before this banner existed, the user was silently
- * logged out of Spotify on the next ProtectedRoute check with no
- * indication why. Dispatched via `spotify-reconnect-required` from
- * useSpotifyToken.getValidToken.
+ * Surfaces a reconnect banner when playback credentials are gone and
+ * cannot be recovered without a new OAuth round trip. Before this banner
+ * existed, the user was silently logged out of Spotify on the next
+ * ProtectedRoute check with no indication why.
+ *
+ * Two paths raise RECONNECT_REQUIRED_EVENT:
+ *   - useSpotifyToken.getValidToken, when the refresh chain fails (both
+ *     the server-side edge function and the legacy client-side path
+ *     returned null).
+ *   - bridgeSpotifyProviderTokens, when a Spotify session arrives with
+ *     no provider tokens and localStorage has none either — nothing to
+ *     refresh, so the failure never reaches getValidToken at all.
  */
 export default function SpotifyReconnectBanner() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     const onReconnect = () => setVisible(true);
-    window.addEventListener("spotify-reconnect-required", onReconnect);
-    return () => window.removeEventListener("spotify-reconnect-required", onReconnect);
+    window.addEventListener(RECONNECT_REQUIRED_EVENT, onReconnect);
+    return () => window.removeEventListener(RECONNECT_REQUIRED_EVENT, onReconnect);
   }, []);
 
   if (!visible) return null;

--- a/src/hooks/useSpotifyToken.ts
+++ b/src/hooks/useSpotifyToken.ts
@@ -3,6 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import {
   SPOTIFY_STORAGE_KEY,
   TOKEN_CHANGED_EVENT,
+  RECONNECT_REQUIRED_EVENT,
   type StoredSpotifyToken,
 } from "@/lib/spotifyTokenStore";
 import { refreshSpotifyToken } from "./useSpotifyAuth";
@@ -133,7 +134,7 @@ export function useSpotifyToken() {
       // the next ProtectedRoute check — no signal that anything failed.
       localStorage.removeItem(STORAGE_KEY);
       if (typeof window !== "undefined") {
-        window.dispatchEvent(new Event("spotify-reconnect-required"));
+        window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
       }
       return null;
     }

--- a/src/hooks/useSpotifyToken.ts
+++ b/src/hooks/useSpotifyToken.ts
@@ -4,6 +4,7 @@ import {
   SPOTIFY_STORAGE_KEY,
   TOKEN_CHANGED_EVENT,
   RECONNECT_REQUIRED_EVENT,
+  readStoredSpotifyToken,
   type StoredSpotifyToken,
 } from "@/lib/spotifyTokenStore";
 import { refreshSpotifyToken } from "./useSpotifyAuth";
@@ -40,15 +41,11 @@ async function refreshViaEdgeFunction(refreshToken: string): Promise<{
   }
 }
 
-function readToken(): StoredToken | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw) as StoredToken;
-  } catch {
-    return null;
-  }
-}
+// Delegates to the store so "is there a usable token?" has exactly one
+// answer. The bridge asks the same question when deciding whether the
+// user is stranded; two implementations could disagree on a corrupted
+// value and leave that dead end unsignalled.
+const readToken = (): StoredToken | null => readStoredSpotifyToken();
 
 // writeToken persists to localStorage AND dispatches TOKEN_CHANGED_EVENT so
 // every mounted useSpotifyToken hook instance re-reads and re-sets state. All

--- a/src/lib/spotifyTokenStore.ts
+++ b/src/lib/spotifyTokenStore.ts
@@ -22,6 +22,12 @@ import type { Session } from "@supabase/supabase-js";
 
 export const SPOTIFY_STORAGE_KEY = "spotify_playback_token";
 export const TOKEN_CHANGED_EVENT = "spotify-token-changed";
+/** Playback credentials are gone and cannot be recovered without a new
+ *  OAuth round trip. SpotifyReconnectBanner listens for this and offers
+ *  the user a way back. Two things raise it: a refresh chain that failed
+ *  (useSpotifyToken), and a session that never had credentials to begin
+ *  with (the bridge below). */
+export const RECONNECT_REQUIRED_EVENT = "spotify-reconnect-required";
 
 export interface StoredSpotifyToken {
   accessToken: string;
@@ -44,13 +50,32 @@ export interface StoredSpotifyToken {
  * Exported for unit testing.
  */
 export function bridgeSpotifyProviderTokens(session: Session | null): void {
-  if (!session?.provider_token) return;
+  if (!session) return;
   if (session.user?.app_metadata?.provider !== "spotify") return;
-  // Skip the write if the session has no refresh token. Spotify requires
-  // a refresh token to issue new access tokens, so persisting without one
-  // would leave the Web Playback SDK stuck once the first access token
-  // expires (~1h) with no path forward.
-  if (!session.provider_refresh_token) return;
+
+  // A Spotify session carrying no usable provider tokens cannot establish
+  // playback credentials on its own. Routine in itself — Supabase issues
+  // provider_token only on a fresh OAuth and drops it on every JWT
+  // refresh — and harmless while localStorage still holds what was
+  // written at sign-in. Skipping the write is deliberate: an access token
+  // without a refresh token strands the SDK at the first expiry (~1h),
+  // and overwriting a good stored token with an empty one is worse than
+  // doing nothing.
+  //
+  // But when localStorage is empty too, nothing is left to fall back on:
+  // no access token, no refresh token, and no way to obtain either
+  // without sending the user back through OAuth. That state used to be
+  // entirely silent — getValidToken returns null for a missing token
+  // without raising anything — so the Web Playback SDK simply had no
+  // credentials and the play button did nothing at all. Pete hit exactly
+  // this on staging: valid session, correct track, dead transport, no
+  // error anywhere in the console.
+  if (!session.provider_token || !session.provider_refresh_token) {
+    if (typeof window !== "undefined" && !localStorage.getItem(SPOTIFY_STORAGE_KEY)) {
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
+    }
+    return;
+  }
 
   // `session.expires_in` is strictly the Supabase JWT's TTL, not the
   // Spotify access token's TTL — the two refresh on independent

--- a/src/lib/spotifyTokenStore.ts
+++ b/src/lib/spotifyTokenStore.ts
@@ -36,13 +36,42 @@ export interface StoredSpotifyToken {
 }
 
 /**
+ * The stored token, or null if there isn't a usable one.
+ *
+ * "Usable" deliberately means parseable with an access token present —
+ * NOT merely "the key exists". A corrupted value would satisfy a raw
+ * `getItem` truthiness check while every real consumer, which parses,
+ * would find nothing. Anything deciding "do we still have credentials?"
+ * must agree with the reader, or it will conclude there is a fallback
+ * that isn't there — which is the exact silent dead end this module's
+ * reconnect signalling exists to prevent.
+ *
+ * An expired token still counts as usable here: it carries the refresh
+ * token, and useSpotifyToken.getValidToken can trade it for a live one.
+ */
+export function readStoredSpotifyToken(): StoredSpotifyToken | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(SPOTIFY_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredSpotifyToken;
+    return parsed?.accessToken ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Copy Spotify provider tokens from a Supabase session into localStorage.
  * Idempotent + defensive:
  *   - no-op if the session is null or not from the Spotify provider
  *   - no-op if the session lacks a provider_token (post-JWT-refresh
  *     sessions DROP the provider token; Supabase doesn't persist it,
  *     so we must not overwrite what's already in localStorage with an
- *     empty string)
+ *     empty string) — but NOT a silent one: if nothing usable is stored
+ *     either, there is no path back to credentials without a new OAuth
+ *     round trip, so this dispatches RECONNECT_REQUIRED_EVENT rather
+ *     than leaving playback dead with no signal
  *   - skips the write if an existing token has a longer expiry, so a
  *     freshly-refreshed client-side token isn't clobbered by a stale
  *     session-bound one on re-hydration
@@ -71,7 +100,7 @@ export function bridgeSpotifyProviderTokens(session: Session | null): void {
   // this on staging: valid session, correct track, dead transport, no
   // error anywhere in the console.
   if (!session.provider_token || !session.provider_refresh_token) {
-    if (typeof window !== "undefined" && !localStorage.getItem(SPOTIFY_STORAGE_KEY)) {
+    if (typeof window !== "undefined" && !readStoredSpotifyToken()) {
       window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     }
     return;

--- a/src/test/SpotifyReconnectBanner.test.tsx
+++ b/src/test/SpotifyReconnectBanner.test.tsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, screen, act } from "@testing-library/react";
+// Imported rather than hardcoded: a literal here would keep dispatching
+// an event the banner no longer listens for if the name is ever renamed,
+// and the test would pass against a component that never opens.
+import { RECONNECT_REQUIRED_EVENT } from "@/lib/spotifyTokenStore";
 
 vi.mock("@/hooks/useSpotifyAuth", () => ({
   signInWithSpotify: vi.fn().mockResolvedValue(undefined),
@@ -21,7 +25,7 @@ describe("SpotifyReconnectBanner", () => {
   it("shows on the spotify-reconnect-required event", () => {
     render(<SpotifyReconnectBanner />);
     act(() => {
-      window.dispatchEvent(new Event("spotify-reconnect-required"));
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     });
     expect(screen.getByText(/session expired/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /reconnect/i })).toBeInTheDocument();
@@ -30,7 +34,7 @@ describe("SpotifyReconnectBanner", () => {
   it("invokes signInWithSpotify when Reconnect is clicked", () => {
     render(<SpotifyReconnectBanner />);
     act(() => {
-      window.dispatchEvent(new Event("spotify-reconnect-required"));
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     });
     fireEvent.click(screen.getByRole("button", { name: /reconnect/i }));
     expect(signInWithSpotify).toHaveBeenCalledOnce();
@@ -39,7 +43,7 @@ describe("SpotifyReconnectBanner", () => {
   it("hides on Dismiss click", () => {
     render(<SpotifyReconnectBanner />);
     act(() => {
-      window.dispatchEvent(new Event("spotify-reconnect-required"));
+      window.dispatchEvent(new Event(RECONNECT_REQUIRED_EVENT));
     });
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(screen.queryByText(/session expired/i)).toBeNull();

--- a/src/test/spotifyTokenBridge.test.ts
+++ b/src/test/spotifyTokenBridge.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   bridgeSpotifyProviderTokens,
   SPOTIFY_STORAGE_KEY,
+  RECONNECT_REQUIRED_EVENT,
   type StoredSpotifyToken,
 } from "@/lib/spotifyTokenStore";
 
@@ -109,5 +110,130 @@ describe("bridgeSpotifyProviderTokens", () => {
       localStorage.getItem(SPOTIFY_STORAGE_KEY)!,
     ) as StoredSpotifyToken;
     expect(stored.accessToken).toBe("new-access");
+  });
+});
+
+// ── Unrecoverable credentials ─────────────────────────────────────────
+// Pete, on staging: "song is not playing... its working on main
+// production currently." The session was valid (expiring 40 minutes
+// out) but carried provider_token:false AND provider_refresh_token:
+// false, and localStorage held no spotify_playback_token. Supabase only
+// issues provider_token on a fresh OAuth and drops it on JWT refresh, so
+// there was nothing to refresh and nothing stored to fall back on.
+//
+// getValidToken returns null for a missing token WITHOUT raising the
+// reconnect event — that path only fires when a token exists and its
+// refresh fails. So the SDK had no credentials, the play button did
+// nothing, and no error appeared anywhere.
+//
+// The bridge is the only place that sees this: it runs on every session
+// hydration, including the refresh that drops the provider tokens.
+describe("bridgeSpotifyProviderTokens — unrecoverable credentials", () => {
+  let reconnects: number;
+  const count = () => { reconnects += 1; };
+
+  beforeEach(() => {
+    localStorage.clear();
+    reconnects = 0;
+    window.addEventListener(RECONNECT_REQUIRED_EVENT, count);
+  });
+  afterEach(() => {
+    window.removeEventListener(RECONNECT_REQUIRED_EVENT, count);
+  });
+
+  const strandedSession = {
+    provider_token: undefined,
+    provider_refresh_token: undefined,
+    expires_in: 3600,
+    user: { app_metadata: { provider: "spotify" } },
+  } as unknown as TestSession;
+
+  it("asks the user to reconnect when nothing can supply credentials", () => {
+    bridgeSpotifyProviderTokens(strandedSession);
+    expect(reconnects).toBe(1);
+  });
+
+  // The common case, and the reason the bridge no-ops rather than
+  // writing an empty token: post-refresh sessions routinely arrive
+  // without provider tokens while the stored one is still perfectly
+  // good. Crying reconnect here would push a working user through OAuth
+  // for nothing.
+  it("stays quiet when a stored token still covers us", () => {
+    const stored: StoredSpotifyToken = {
+      accessToken: "still-good",
+      refreshToken: "still-good-refresh",
+      expiresAt: Date.now() + 3600_000,
+    };
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(stored));
+
+    bridgeSpotifyProviderTokens(strandedSession);
+
+    expect(reconnects).toBe(0);
+    // and it must not clobber the token it just declined to replace
+    expect(JSON.parse(localStorage.getItem(SPOTIFY_STORAGE_KEY)!).accessToken)
+      .toBe("still-good");
+  });
+
+  // An expired stored token is still recoverable — getValidToken owns
+  // that path, refreshes it, and raises the event itself if the refresh
+  // chain fails. Firing here too would double up.
+  it("leaves an expired stored token to the refresh path", () => {
+    const stored: StoredSpotifyToken = {
+      accessToken: "expired",
+      refreshToken: "expired-refresh",
+      expiresAt: Date.now() - 60_000,
+    };
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(stored));
+
+    bridgeSpotifyProviderTokens(strandedSession);
+
+    expect(reconnects).toBe(0);
+  });
+
+  it("does not fire for an Apple / anonymous session", () => {
+    const session = {
+      provider_token: undefined,
+      provider_refresh_token: undefined,
+      user: { app_metadata: { provider: "anonymous" } },
+    } as unknown as TestSession;
+
+    bridgeSpotifyProviderTokens(session);
+
+    expect(reconnects).toBe(0);
+  });
+
+  it("does not fire when signed out", () => {
+    bridgeSpotifyProviderTokens(null);
+    expect(reconnects).toBe(0);
+  });
+
+  // Half a credential set is as useless as none — Spotify needs the
+  // refresh token to keep the SDK fed past the first hour.
+  it("fires when the access token is present but the refresh token is not", () => {
+    const session = {
+      provider_token: "spotify-access-abc",
+      provider_refresh_token: undefined,
+      expires_in: 3600,
+      user: { app_metadata: { provider: "spotify" } },
+    } as unknown as TestSession;
+
+    bridgeSpotifyProviderTokens(session);
+
+    expect(reconnects).toBe(1);
+    expect(localStorage.getItem(SPOTIFY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("stays quiet on a healthy sign-in", () => {
+    const session = {
+      provider_token: "spotify-access-abc",
+      provider_refresh_token: "spotify-refresh-xyz",
+      expires_in: 3600,
+      user: { app_metadata: { provider: "spotify" } },
+    } as unknown as TestSession;
+
+    bridgeSpotifyProviderTokens(session);
+
+    expect(reconnects).toBe(0);
+    expect(localStorage.getItem(SPOTIFY_STORAGE_KEY)).not.toBeNull();
   });
 });

--- a/src/test/spotifyTokenBridge.test.ts
+++ b/src/test/spotifyTokenBridge.test.ts
@@ -190,6 +190,24 @@ describe("bridgeSpotifyProviderTokens — unrecoverable credentials", () => {
     expect(reconnects).toBe(0);
   });
 
+  // Raised in review. A raw `getItem` truthiness check would see the key
+  // and conclude a fallback exists, while every real consumer parses and
+  // finds nothing — leaving the user stranded with no signal, which is
+  // the exact failure this whole path exists to catch. Both sides now go
+  // through readStoredSpotifyToken so they cannot disagree.
+  it("treats a corrupted stored token as no token at all", () => {
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, "{ not json");
+    bridgeSpotifyProviderTokens(strandedSession);
+    expect(reconnects).toBe(1);
+  });
+
+  // Parseable but useless — same reasoning.
+  it("treats a stored token with no access token as no token", () => {
+    localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify({ refreshToken: "r", expiresAt: 1 }));
+    bridgeSpotifyProviderTokens(strandedSession);
+    expect(reconnects).toBe(1);
+  });
+
   it("does not fire for an Apple / anonymous session", () => {
     const session = {
       provider_token: undefined,

--- a/src/test/useSpotifyTokenRefresh.test.ts
+++ b/src/test/useSpotifyTokenRefresh.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+// Imported rather than hardcoded: a literal here would keep passing as a
+// listener for an event nobody dispatches if the name is ever renamed.
+import { RECONNECT_REQUIRED_EVENT } from "@/lib/spotifyTokenStore";
 
 const { invokeMock, refreshLegacyMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
@@ -107,7 +110,7 @@ describe("useSpotifyToken.getValidToken — refresh fallback chain", () => {
 
     const events: string[] = [];
     const listener = (e: Event) => events.push(e.type);
-    window.addEventListener("spotify-reconnect-required", listener);
+    window.addEventListener(RECONNECT_REQUIRED_EVENT, listener);
 
     const { result } = renderHook(() => useSpotifyToken());
     await act(async () => {
@@ -116,8 +119,8 @@ describe("useSpotifyToken.getValidToken — refresh fallback chain", () => {
     });
 
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
-    expect(events).toContain("spotify-reconnect-required");
+    expect(events).toContain(RECONNECT_REQUIRED_EVENT);
 
-    window.removeEventListener("spotify-reconnect-required", listener);
+    window.removeEventListener(RECONNECT_REQUIRED_EVENT, listener);
   });
 });


### PR DESCRIPTION
Task #13, from today's staging incident: *"song is not playing. You need to fix this immediately"* — while production played fine.

## What was actually wrong

Staging's Supabase session was **valid** (another 40 minutes on it) but carried `provider_token: false` **and** `provider_refresh_token: false`, and localStorage held no `spotify_playback_token`.

Supabase issues `provider_token` only on a fresh OAuth and drops it on every JWT refresh. That is routine, and harmless while localStorage still holds what was written at sign-in. With localStorage empty too, nothing is left: no access token, no refresh token, and no way to get either without another OAuth round trip.

**And the app said nothing.** `getValidToken` returns `null` for a missing token without raising anything — the reconnect event only fires when a token *exists* and its refresh chain fails:

```js
const token = readToken();
if (!token) return null;   // ← silent
```

So the SDK had no credentials, the play button did nothing, and the console was clean. Diagnosing it took reading localStorage against the live session; nothing in the UI pointed at auth.

**Not a staging regression** — identical code on `main`. Production only worked because that session was fresher. It will hit production the same way once its session refreshes.

## The fix

The recovery UI already existed: `SpotifyReconnectBanner` listens for `spotify-reconnect-required` and offers a Reconnect button. Nothing raised it for the no-credentials-at-all case.

`bridgeSpotifyProviderTokens` is the right place — it runs on every session hydration (initial `getSession` **and** `onAuthStateChange`, so it sees the very refresh that drops the tokens), and it is the only code that sees the session and the store together.

## Deliberately narrow

The failure mode to avoid is the opposite one: pushing a working user through OAuth for nothing. It stays silent when:

| Situation | Why silent |
|---|---|
| Stored token still valid | The common post-refresh case — exactly why the bridge no-ops instead of writing an empty token |
| Stored token merely expired | Recoverable; `getValidToken` owns that path and raises the event itself if refresh fails |
| Apple / anonymous session | Never had Spotify credentials to lose |
| Signed out | `ProtectedRoute` handles it |

It fires when the access token is present but the refresh token is not — half a credential set strands the SDK at the first expiry (~1h), which the bridge already refused to persist.

## Also

Centralized `RECONNECT_REQUIRED_EVENT` in `spotifyTokenStore` beside the storage key. It was a bare string literal in two files — precisely the drift that module's header says it exists to prevent.

## Tests

7 new (14 in the file), covering both directions rather than only the firing case.

**Mutation-verified, and the two directions are pinned independently:**
- dropping the dispatch → the two "fires" tests fail
- dropping the `localStorage` guard → the two "stays quiet" tests fail

That split matters here: a test suite that only proved it fires would pass a version that nags every user on every refresh.

## Verification

- `npm test` — 593 passing (was 586)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline
- `eslint` on all changed files — clean

## Not covered

This restores a way *out* of the dead state; it does not stop the state arising. Why localStorage was empty while the session lived on is still unexplained — a sign-out that cleared the key without ending the session, or a token write that never landed. Worth its own investigation.