### PR TITLE
fix(cache): release the generation claim on every exit path

### DIFF
--- a/src/hooks/useAINuggets.ts
+++ b/src/hooks/useAINuggets.ts
@@ -1223,17 +1223,33 @@ export function useAINuggets(
         // client), so leaving the in-mem cache empty means a future
         // mount will go through the full pipeline again.
         setError(null);
-        // Sentinel cleanup so a future tap retries the real pipeline.
-        if (sentinelClaimed) {
-          try { await supabase.from("nugget_cache").delete().eq("track_id", dbCacheKey); } catch { /* noop */ }
-        }
         return;
       }
-      // Remove the 'generating' sentinel so waiting clients don't poll indefinitely.
-      if (sentinelClaimed) {
-        try { await supabase.from("nugget_cache").delete().eq("track_id", dbCacheKey); } catch { /* noop */ }
-      }
     } finally {
+      // Release the generation claim on EVERY exit, not just the two
+      // paths that used to reach the end of the try block.
+      //
+      // A 'generating' row is a lock: other clients poll it instead of
+      // starting their own generation. Releasing it only on the way out
+      // of the happy path meant any of the thirteen earlier exits
+      // stranded it forever — most often `if (cancelledRef.current)
+      // return` and the AbortError catch, which is precisely what the
+      // unmount cleanup below triggers when a user skips a track a few
+      // seconds in. Nothing ever cleared those rows, so the affected
+      // track showed "researching" and no facts to every later listener,
+      // permanently. Twelve had accumulated since May, including
+      // Turnover's "Humming", claimed 2026-07-30.
+      //
+      // The success paths set sentinelClaimed = false once the row holds
+      // real content, so this is a no-op there. And a delete that races
+      // a server write cannot destroy anything: RLS only permits
+      // deleting a row that is still 'generating', so once the server
+      // has written 'ready' the statement matches nothing.
+      if (sentinelClaimed) {
+        try {
+          await supabase.from("nugget_cache").delete().eq("track_id", dbCacheKey);
+        } catch { /* best-effort — a stale claim is recoverable, a throw here is not */ }
+      }
       if (!cancelledRef.current) {
         setLoading(false);
       }

--- a/src/test/nuggetClaimRelease.test.tsx
+++ b/src/test/nuggetClaimRelease.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// Does a generation claim get released when the run does NOT finish?
+//
+// A `status='generating'` row in nugget_cache is a lock: other clients
+// poll it rather than starting their own generation. Releasing it used
+// to live at the end of the try block, so only the two paths that
+// reached the bottom ever cleaned up. Thirteen earlier exits did not —
+// including every `if (cancelledRef.current) return` and the AbortError
+// catch, which is exactly what the hook's own effect cleanup triggers
+// when a user skips a track a few seconds in.
+//
+// Nothing else ever cleared those rows, so an affected track showed
+// "researching" and no facts to every later listener, permanently.
+// Twelve had accumulated since May 2026, including Turnover's "Humming"
+// (claimed 2026-07-30) which Pete reported as never resolving.
+
+const getNuggetCache = vi.fn(() => null);
+const setNuggetCache = vi.fn();
+const getTrackListenCount = vi.fn(() => 1);
+const setTrackListenCount = vi.fn();
+
+vi.mock("@/contexts/PlayerContext", () => ({
+  usePlayer: () => ({
+    getNuggetCache, setNuggetCache, getTrackListenCount, setTrackListenCount,
+    currentTime: 0, isPlaying: false,
+  }),
+}));
+
+vi.mock("@/data/seedNuggets", () => ({
+  getSeedListenNuggets: vi.fn(async () => null),
+}));
+
+/** Every nugget_cache write the hook attempts, in order. */
+const dbOps: { op: string; key?: string }[] = [];
+
+vi.mock("@/integrations/supabase/client", () => {
+  // Chainable stand-in for the PostgREST builder. `.eq()` has to be both
+  // chainable (after .select()) and awaitable (after .delete()), which
+  // is how the hook actually calls it.
+  const makeQuery = () => {
+    let deleting = false;
+    const q: Record<string, unknown> = {
+      select: () => q,
+      maybeSingle: async () => ({ data: null }),
+      insert: async () => { dbOps.push({ op: "insert" }); return { error: null }; },
+      delete: () => { deleting = true; return q; },
+      eq: (_col: string, val: string) => {
+        if (deleting) {
+          dbOps.push({ op: "delete", key: val });
+          return Promise.resolve({ error: null });
+        }
+        return q;
+      },
+    };
+    return q;
+  };
+  return {
+    supabase: {
+      auth: { getSession: vi.fn(async () => ({ data: { session: null } })) },
+      from: vi.fn(() => makeQuery()),
+      functions: { invoke: vi.fn(async () => ({ data: null, error: null })) },
+    },
+    SUPABASE_URL: "https://example.supabase.co",
+    SUPABASE_ANON_KEY: "anon",
+  };
+});
+
+import { useAINuggets } from "@/hooks/useAINuggets";
+
+const TRACK = "real::Turnover::Humming";
+
+function renderHookForTrack() {
+  return renderHook(() => useAINuggets(
+    TRACK, "Turnover", "Humming", undefined, 200, 0,
+    "https://example.com/art.jpg", "", "curious", ["Turnover"], ["Humming"],
+  ));
+}
+
+/** Resolves once generation has reached the streaming request. */
+let reachedSse: Promise<void>;
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  dbOps.length = 0;
+  getNuggetCache.mockReturnValue(null);
+
+  let arrived: () => void;
+  reachedSse = new Promise<void>((res) => { arrived = res; });
+
+  // Hangs until aborted — the shape of a real generation the user
+  // walks away from mid-stream.
+  global.fetch = vi.fn((_url: string, opts: { signal: AbortSignal }) => {
+    arrived();
+    return new Promise((_resolve, reject) => {
+      opts.signal.addEventListener("abort", () => {
+        reject(new DOMException("The operation was aborted.", "AbortError"));
+      });
+    });
+  }) as unknown as typeof global.fetch;
+});
+
+afterEach(() => { global.fetch = realFetch; });
+
+const claimed = () => dbOps.some((o) => o.op === "insert");
+const released = () => dbOps.some((o) => o.op === "delete");
+
+describe("generation claims are released when the run does not finish", () => {
+  it("claims the track before generating", async () => {
+    renderHookForTrack();
+    await reachedSse;
+    expect(claimed()).toBe(true);
+  });
+
+  // THE REGRESSION. Unmounting mid-generation is the common case — a
+  // track skip — and it took the AbortError exit, which never reached
+  // the old cleanup.
+  it("releases the claim when unmounted mid-generation", async () => {
+    const { unmount } = renderHookForTrack();
+    await reachedSse;
+    expect(released()).toBe(false);
+
+    unmount();
+
+    await waitFor(() => expect(released()).toBe(true));
+  });
+
+  it("releases the claim for the track it claimed", async () => {
+    const { unmount } = renderHookForTrack();
+    await reachedSse;
+    unmount();
+
+    await waitFor(() => {
+      const del = dbOps.find((o) => o.op === "delete");
+      expect(del?.key).toContain("Turnover");
+    });
+  });
+
+  // Releasing twice would be a different bug: the second delete could
+  // land after another client had re-claimed the track.
+  it("releases exactly once", async () => {
+    const { unmount } = renderHookForTrack();
+    await reachedSse;
+    unmount();
+
+    await waitFor(() => expect(released()).toBe(true));
+    expect(dbOps.filter((o) => o.op === "delete")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
The second of the two known issues left open. #126 cleared the backlog of stuck claims; **this stops it refilling.**

## Why claims leaked

A `status='generating'` row is a lock — other clients poll it instead of starting their own generation. Releasing it lived at the **bottom of the try block**:

```js
      // Remove the 'generating' sentinel so waiting clients don't poll indefinitely.
      if (sentinelClaimed) { await supabase.from("nugget_cache").delete()... }
    } finally {
      if (!cancelledRef.current) setLoading(false);   // ← cleanup was NOT here
    }
```

So only the two paths that reached the end ever cleaned up. **Thirteen earlier exits did not**, including:

| Line | Exit | When |
|---|---|---|
| 826, 852, 958, 1101 | `if (cancelledRef.current) return` | user skipped the track |
| 1162 | `AbortError` catch | **the hook's own effect cleanup on unmount** |
| 1023 | SSE complete | repeat listens — see below |

`sentinelClaimed` is only cleared inside `if (currentListenCount <= 1)` (line 1008), so a repeat listen leaked on the *success* path too.

Line 1162 is the common one. The effect cleanup does `cancelledRef.current = true; abortRef.current?.abort()`, the in-flight fetch rejects with `AbortError`, and the handler returns — past the claim, never near the release.

**Nothing else could clear those rows.** The claiming client was the only party able to, and it had already walked away. The affected track then showed "researching" and no facts to every later listener, permanently. Twelve accumulated since May 2026 — including `Turnover — Humming`, claimed 2026-07-30, which Pete reported twice as never resolving.

## The fix

Move the release into `finally`, so every exit covers it. Two properties make that safe rather than merely broader:

- **No-op on success** — the success paths set `sentinelClaimed = false` once the row holds real content.
- **Cannot destroy a good row** — a release racing a server write matches nothing, because the RLS scoping from #125 only permits deleting a row that is still `'generating'`. Once the server has written `'ready'`, the delete finds nothing. Worth noting: before #125 this same change would have been risky, since the client could delete a `ready` row outright.

## Tests

New `nuggetClaimRelease.test.tsx` drives the real path rather than a stand-in: a `fetch` that hangs until aborted, then unmount, which is precisely a track skip mid-generation.

- claims the track before generating
- **releases the claim when unmounted mid-generation** ← the regression
- releases the claim for the track it claimed
- releases exactly once (a double release could land after another client re-claimed)

**Mutation-verified:** moving the release back out of `finally` fails three of the four; the survivor is the one asserting the claim was taken at all — which is the correct split, since that test is not about release.

## Verification

- `npm test` — 599 passing (was 595)
- `npm run build` — clean
- `npx tsc -b` — 7-error pre-existing baseline
- `eslint` — one pre-existing `no-explicit-any` at `useAINuggets.ts:864`, identical on `staging`, untouched by this change

## Still open

The other known issue, the wave-cache regression (#125 review), is unfixable from the client — it needs `generate-nuggets` to merge rather than overwrite, and that function is deploy-guarded. Tracked separately.